### PR TITLE
feat(install): launch directory is the workspace, and say so on re-runs

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -11,10 +11,10 @@ Open <http://localhost:5003/space/>.
 Docker is not required. The command:
 
 1. installs [uv](https://docs.astral.sh/uv/) if it is missing;
-2. clones Quirq into `./quirq`;
-3. creates `./quirq/venv` with Python 3.12, downloading an interpreter if the
-   host has none, and installs `requirements.txt`;
-4. creates `./xo-projects` and `./.quirq`;
+2. clones Quirq into `./xo-space`, named after the repository;
+3. creates `./xo-space/venv` with Python 3.12, downloading an interpreter if
+   the host has none, and installs `requirements.txt`;
+4. creates `./.quirq`, and treats the current directory as your projects root;
 5. reports which optional tools are present; and
 6. starts the server in the foreground and prints the URL.
 
@@ -62,9 +62,9 @@ self-contained and you can move or delete it as one folder.
 
 | Path | Purpose |
 |---|---|
-| `./quirq` | The Quirq source checkout |
-| `./quirq/venv` | Python environment |
-| `./xo-projects` | XO projects and their `.xo` project metadata |
+| `.` | Your projects root — each project is a subdirectory with its own `.xo` |
+| `./xo-space` | The Quirq source checkout |
+| `./xo-space/venv` | Python environment |
 | `./.quirq` | Runtime configuration, saved credentials, watcher activity, cursors, locks, and other machine-local state |
 
 Open the **Setup** tab after installation. It shows the paths in use, CLI
@@ -88,8 +88,8 @@ cd xo-space
 
 It detects the checkout, uses that working tree in place, and never runs a git
 command against it — your local edits are left alone. In this mode
-`./xo-projects` and `./.quirq` are created inside the repository, so add them
-to `.gitignore` if you want a clean `git status`.
+the repository itself becomes the projects root and `./.quirq` is created
+inside it. Both are already in `.gitignore`.
 
 ## Configuration
 
@@ -99,9 +99,9 @@ Every value is overridable from the environment:
 |---|---|
 | `PORT` | `5003` |
 | `HOST` | `127.0.0.1` |
-| `XO_PROJECTS_ROOT` | `./xo-projects` |
+| `XO_PROJECTS_ROOT` | the launch directory |
 | `QUIRQ_STATE_ROOT` | `./.quirq` |
-| `QUIRQ_APP_DIR` | `./quirq` |
+| `QUIRQ_APP_DIR` | `./xo-space` |
 | `QUIRQ_SOURCE_REF` | `main` |
 | `AGENT_NAME` | `claude_code` |
 | `QUIRQ_SKIP_BOOT_INSTALL` | `1` |
@@ -133,6 +133,12 @@ Quirq refuses to start if the projects root and state root are nested inside
 one another, or if the checkout sits inside the state root — relocating the
 state root copies it wholesale, and it must not drag a checkout or your
 projects along.
+
+The one exception is the default layout: the state root may be a *hidden*
+directory directly inside the projects root, as `./.quirq` is. Project
+enumeration skips dot-prefixed entries, so it can never be mistaken for a
+project. A visible `./quirq` state root, or one nested deeper, is still
+rejected.
 
 ## Windows
 

--- a/install.sh
+++ b/install.sh
@@ -15,19 +15,20 @@
 #       git clone https://github.com/quirq-ai/xo-space
 #       cd xo-space && ./install.sh
 #
-#   Standalone — clones into ./quirq and runs from there. Re-running
-#   fast-forwards that checkout, so this doubles as the update path:
+#   Standalone — clones into ./<repo-name> and runs from there.
+#   Re-running fast-forwards that checkout, so this doubles as the
+#   update path:
 #       curl -fsSL <raw-url>/install.sh | bash
 #
-# Everything is created under the directory you launch from, so a run
-# is self-contained:  ./quirq (source), ./xo-projects, ./.quirq (state)
+# The directory you launch from becomes the workspace: the checkout
+# lands beside your projects, and machine state goes in ./.quirq
 #
 # Ctrl-C stops the server. Re-run to update and restart.
 #
 # Root directory precedence:
 #     XO_PROJECTS_ROOT / QUIRQ_STATE_ROOT env vars
 #         → roots.env saved by the Setup tab
-#         → ./xo-projects and ./.quirq
+#         → the launch directory, and ./.quirq inside it
 #
 # Every environment value below is overridable from the caller's
 # environment, e.g.  PORT=8080 ./install.sh
@@ -45,7 +46,11 @@ SOURCE_REF="${QUIRQ_SOURCE_REF:-main}"
 # Captured before anything cd's. Everything Quirq creates hangs off this, so
 # a run is self-contained in the directory you launched it from.
 LAUNCH_DIR="$PWD"
-APP_DIR="${QUIRQ_APP_DIR:-${LAUNCH_DIR}/quirq}"
+# Named after the repository, the way a plain `git clone` would name it, so
+# the directory follows QUIRQ_SOURCE_REPO instead of hardcoding one name.
+REPO_NAME="${SOURCE_REPO##*/}"
+REPO_NAME="${REPO_NAME%.git}"
+APP_DIR="${QUIRQ_APP_DIR:-${LAUNCH_DIR}/${REPO_NAME}}"
 PYTHON_VERSION="${QUIRQ_PYTHON_VERSION:-3.12}"
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
 
@@ -105,11 +110,12 @@ resolve_repo_dir() {
 # than one that is a version behind.
 fetch_repo() {
     if [ -d "${REPO_DIR}/.git" ]; then
+        printf 'Quirq is already installed here: %s\n' "$REPO_DIR"
         if [ -n "$(git -C "$REPO_DIR" status --porcelain)" ]; then
-            printf 'Local changes in %s — keeping them, skipping the update.\n' "$REPO_DIR"
+            printf 'It has local changes — keeping them, skipping the update.\n'
             return
         fi
-        printf 'Updating Quirq in %s...\n' "$REPO_DIR"
+        printf 'Updating it to the latest %s...\n' "$SOURCE_REF"
         git -C "$REPO_DIR" fetch --quiet --depth 1 origin "$SOURCE_REF" ||
             fail "Could not fetch ${SOURCE_REF} from ${SOURCE_REPO}."
         git -C "$REPO_DIR" reset --hard --quiet FETCH_HEAD ||
@@ -239,9 +245,23 @@ validate_host_root() {
 validate_separate_roots() {
     local projects_root="$1"
     local state_root="$2"
+    local relative
 
     case "${state_root}/" in
-        "${projects_root}/"*) fail "Quirq root cannot be inside XO root." ;;
+        "${projects_root}/"*)
+            # One nesting is allowed: the state root as a hidden directory
+            # directly inside the projects root, which is the default layout
+            # (./ and ./.quirq). quirq_catalog skips dot-prefixed entries when
+            # it enumerates projects, so ".quirq" there can never be mistaken
+            # for one. Anything deeper, or not hidden, would be — and equal
+            # roots fall through to the failure too.
+            relative="${state_root#"${projects_root}/"}"
+            case "$relative" in
+                */*) fail "Quirq root cannot be nested inside XO root." ;;
+                .?*) ;;
+                *) fail "Quirq root cannot be inside XO root." ;;
+            esac
+            ;;
     esac
     case "${projects_root}/" in
         "${state_root}/"*) fail "XO root cannot be inside Quirq root." ;;
@@ -291,7 +311,7 @@ PY
 
     case "$status" in
         0) return 0 ;;
-        1) fail "Port ${port} is already in use. Stop what is using it, or set PORT=<port> and run this script again." ;;
+        1) fail "Port ${port} is already in use — Quirq may already be running here. Stop it with Ctrl-C in the terminal running it, or set PORT=<port> to start a second one." ;;
         *) printf 'Could not verify that port %s is free; starting anyway.\n' "$port" ;;
     esac
 }
@@ -506,7 +526,7 @@ main() {
     anchor_dir="${QUIRQ_STATE_ROOT:-${LAUNCH_DIR}/.quirq}"
     saved_projects_root="$(saved_root_from_file "$anchor_dir" "XO_PROJECTS_ROOT")"
     saved_state_root="$(saved_root_from_file "$anchor_dir" "QUIRQ_STATE_ROOT")"
-    projects_root="${XO_PROJECTS_ROOT:-${saved_projects_root:-${LAUNCH_DIR}/xo-projects}}"
+    projects_root="${XO_PROJECTS_ROOT:-${saved_projects_root:-${LAUNCH_DIR}}}"
     state_root="${QUIRQ_STATE_ROOT:-${saved_state_root:-${LAUNCH_DIR}/.quirq}}"
     validate_host_root "XO root" "$projects_root"
     validate_host_root "Quirq root" "$state_root"


### PR DESCRIPTION
Three changes to how an install lays itself out and reports itself.

- Clone into a directory named after the repository rather than a hardcoded "quirq". Derived from QUIRQ_SOURCE_REPO, so a fork clones into its own name the way a plain `git clone` would.

- Treat the launch directory itself as the projects root, instead of creating an xo-projects subdirectory inside it. The directory you run the installer from is the workspace: your projects sit beside the checkout.

  This needed validate_separate_roots relaxed, because the default state root (./.quirq) is now inside the projects root and the old check rejected any nesting outright. The guard exists so the state root cannot be mistaken for a project, and quirq_catalog skips dot-prefixed entries when enumerating (quirq_catalog.py:324), so a hidden direct child is safe. Narrowed rather than removed: a visible child, anything nested deeper, identical roots, and projects-inside-state are all still rejected.

- Re-running now reports that an install already exists, with its path, rather than only printing "Updating Quirq in ...". Re-running remains the update path, so it still fast-forwards and restarts; a dirty checkout still keeps its changes and skips the update.

  The port-in-use message now names the likely cause too: re-running while the server is still up is the common way to hit it, and "port already in use" alone does not point at your own terminal.