### PR TITLE
Claude Code and Codex plugins for the local control plane

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "quirq-ai",
+  "interface": {
+    "displayName": "Quirq"
+  },
+  "plugins": [
+    {
+      "name": "quirq",
+      "source": {
+        "source": "local",
+        "path": "./.agents/plugins/quirq"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.agents/plugins/quirq/.codex-plugin/plugin.json
+++ b/.agents/plugins/quirq/.codex-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "quirq",
+  "version": "1.0.0",
+  "description": "Find and talk to the local Quirq (xo-space) control plane: check-only discovery, guided install and start. Every state-changing action requires your explicit yes.",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Quirq",
+    "shortDescription": "Local Quirq control plane: discovery, status, install, start"
+  }
+}

--- a/.agents/plugins/quirq/README.md
+++ b/.agents/plugins/quirq/README.md
@@ -1,0 +1,36 @@
+# quirq (Codex plugin)
+
+Codex plugin for [Quirq / xo-space](https://github.com/quirq-ai/xo-space),
+the local control plane for AI coding agents.
+
+The plugin never manages the server's lifecycle on its own: discovery is
+read-only, and installing or starting Quirq only happens after you say yes.
+
+## Install
+
+```
+codex plugin marketplace add quirq-ai/xo-space
+```
+
+then install **quirq** from the `/plugins` list in Codex.
+
+## Skills
+
+| Skill | What it does |
+|---|---|
+| `quirq` | Knowledge of the local control plane and its discovery contract |
+| `quirq-status` | Check whether Quirq is installed and running (check-only) |
+| `quirq-install` | One-time guided install into a directory you choose |
+| `quirq-start` | Start an already-installed server, without updating it |
+
+## How discovery works
+
+`skills/quirq/scripts/discover.sh` reads `~/.config/quirq/install.json`
+(written by the server on every boot), probes `/health` on localhost
+(pointer port first, then 5002/5003), and falls back to checking the
+current directory. It performs no actions and reports one of: `running`,
+`installed`, `not_installed`.
+
+This bundle is the Codex counterpart of the Claude Code plugin in
+`plugin/` at the repo root; `discover.sh` is byte-identical between the
+two (checked by `scripts/check_plugin_sync.sh`).

--- a/.agents/plugins/quirq/skills/quirq-install/SKILL.md
+++ b/.agents/plugins/quirq/skills/quirq-install/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: quirq-install
+description: Install the Quirq control plane into a directory the user chooses. One-time, explicit — never reinstalls over an existing install and never picks the directory itself.
+---
+
+Install Quirq (xo-space) on this machine.
+
+**Rules — read before acting:**
+- The workspace directory is the user's decision. If they haven't named
+  one, ask for it and stop — never pick, suggest, or default one.
+- This is a one-time action. If Quirq is already installed or running, never
+  reinstall over it; report what you found instead.
+
+**Steps:**
+
+1. Run the discovery script from the sibling `quirq` skill
+   (`../quirq/scripts/discover.sh` relative to this SKILL.md's directory).
+   - `running` → report the server and its `/space/` URL; stop.
+   - `installed` → report the existing checkout location; stop.
+
+2. Validate the directory: expand `~`, require an absolute path after
+   expansion. Create it only if the user gave a path that doesn't exist yet
+   and confirms creation.
+
+3. Confirm once, showing exactly what will happen: "Installing Quirq into
+   `<dir>` — this clones xo-space there, sets up a Python env, and starts
+   the server (the directory becomes your workspace root)." Proceed only on
+   an explicit yes.
+
+4. Run the official installer **in the background** (it ends by starting
+   the server in the foreground, so it will not return):
+
+   ```bash
+   cd <dir> && curl -fsSL https://www.quirq.ai/install | sh
+   ```
+
+5. Poll `http://127.0.0.1:5002/health` (then 5003) every ~5 s, up to
+   ~5 minutes — first install builds a venv and can be slow.
+
+6. On success: report the UI at `http://127.0.0.1:<port>/space/`, note the
+   config file at `<dir>/xo-space/.env`, and that the server stops when
+   the background process is killed — re-running `./xo-space/install.sh`
+   in `<dir>` (or the `quirq-start` skill) brings it back.
+
+7. On timeout or failure: show the tail of the installer output verbatim
+   and stop. Do not retry on your own.

--- a/.agents/plugins/quirq/skills/quirq-start/SKILL.md
+++ b/.agents/plugins/quirq/skills/quirq-start/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: quirq-start
+description: Start an already-installed Quirq server exactly as it is on disk — no update, no installer re-run, explicit consent required.
+---
+
+Start the locally installed Quirq server. **Starting is not updating**: this
+runs the checkout exactly as it is on disk. It never fetches, pulls, or
+re-runs the installer.
+
+1. Run the discovery script from the sibling `quirq` skill
+   (`../quirq/scripts/discover.sh` relative to this SKILL.md's directory).
+   - `running` → already up; report the base URL and stop.
+   - `not_installed` → nothing to start; suggest the `quirq-install` skill
+     and stop.
+   - `installed` → continue with `repo_dir` from the output.
+
+2. Preconditions in `repo_dir`: `venv/bin/python` must exist (if missing,
+   the env was never built — tell the user to run `./install.sh` there
+   themselves, since that path also updates; stop). `.env` should exist and
+   is picked up automatically.
+
+3. Unless the user already explicitly asked to start it in this
+   conversation, confirm: "Start Quirq from `<repo_dir>`?" Proceed only on
+   an explicit yes.
+
+4. Start it **in the background**:
+
+   ```bash
+   cd <repo_dir> && ./venv/bin/python server.py
+   ```
+
+5. Poll `/health` on 5002 then 5003 (the server falls back automatically)
+   for up to ~60 s.
+
+6. On success report port and `<base_url>/space/`. On failure show the
+   server's output verbatim and stop — no retries, no cleanup attempts.

--- a/.agents/plugins/quirq/skills/quirq-status/SKILL.md
+++ b/.agents/plugins/quirq/skills/quirq-status/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: quirq-status
+description: Check whether the local Quirq control plane is installed and running, and report its state. Check-only — never installs, starts, stops, or updates anything.
+---
+
+Check the state of the local Quirq control plane. This skill is
+**check-only**: it never installs, starts, stops, or updates anything.
+
+1. Run the discovery script from the sibling `quirq` skill
+   (`../quirq/scripts/discover.sh` relative to this SKILL.md's directory)
+   and parse the JSON it prints.
+
+2. If `state` is `running`:
+   - `curl -fsS <base_url>/health` and `curl -fsS <base_url>/api/runtime-config`.
+   - Report concisely: port, stage, auth state (authenticated or not, token
+     source), active sessions, projects/state roots, and the UI link
+     `<base_url>/space/`.
+
+3. If `state` is `installed`:
+   - Report the checkout location (`repo_dir`) and that no server is
+     running, then ask whether the user wants it started (the
+     `quirq-start` skill does that). Do not start it yourself without an
+     explicit yes.
+
+4. If `state` is `not_installed`:
+   - Report that no install was found (no pointer file, no live server, no
+     checkout in the current directory). Mention that the `quirq-install`
+     skill installs it, and that the directory choice is theirs.
+
+Report faithfully — if `/health` returns an error or unexpected output,
+show what came back instead of interpreting around it.

--- a/.agents/plugins/quirq/skills/quirq/SKILL.md
+++ b/.agents/plugins/quirq/skills/quirq/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: quirq
+description: Use when the user mentions Quirq, xo-space, the XO workspace / control plane, or asks whether their local agent server is installed or running. Covers finding the install, checking health, and the strict ask-before-acting rules for install/start.
+---
+
+# Quirq — the local control plane
+
+Quirq (repo: `xo-space`) is a FastAPI server the user runs **locally**. It
+brokers coding-agent runtimes, owns the `xo-projects` model, and serves its
+own web UI at `<base_url>/space/`. Default port 5002 (falls back to 5003).
+The server's lifecycle belongs to the **user**, not to you.
+
+## Always start with discovery (read-only)
+
+Before answering anything about Quirq, run the discovery script bundled
+with this skill (`scripts/discover.sh`, relative to this SKILL.md's
+directory):
+
+```bash
+bash <this-skill-directory>/scripts/discover.sh
+```
+
+It performs no actions — it reads the pointer file
+(`~/.config/quirq/install.json`, written by the server on every boot),
+probes `/health` on localhost, and checks the cwd. It prints one JSON
+object with `state`: `running`, `installed`, or `not_installed`.
+
+## What to do per state
+
+**`running`** — proceed with whatever was asked. Useful endpoints:
+- `GET <base_url>/health` — status, stage, auth state, active sessions.
+- `GET <base_url>/api/runtime-config` — resolved port, roots, path status.
+- The web UI: `<base_url>/space/` — send the user there for anything
+  interactive (setup, connectors, secrets).
+
+**`installed`** (checkout at `repo_dir`, no live server) — report it, then
+ask: *"Quirq is installed at `<repo_dir>` but not running. Want me to start
+it?"* Only on an explicit yes, follow the `quirq-start` skill.
+
+**`not_installed`** — report it, then ask: *"Quirq isn't installed on this
+machine. Want me to install it? Which directory should be the workspace?"*
+The directory is **always the user's answer — never pick or suggest a
+default yourself**. On an explicit yes + directory, follow the
+`quirq-install` skill.
+
+## Hard rules
+
+1. **Discovery is check-only.** Never start, stop, restart, update, or
+   install anything as a side effect of checking.
+2. **Every state-changing action needs an explicit yes from the user in
+   this conversation.** An earlier yes does not carry over to a new action.
+3. **Never choose the install directory.** It decides where the workspace
+   and all project data live — that is the user's call.
+4. **Starting is not updating.** The `quirq-start` skill runs the existing
+   checkout as-is. Updating (re-running `install.sh`, which fast-forwards
+   the checkout) only happens if the user explicitly asks to update.
+5. **Never touch `/api/secrets*` or connector endpoints.** Credentials and
+   OAuth flows belong in the `/space/` UI — point the user there.
+6. If the server misbehaves, report what you observed (exact curl output)
+   and let the user decide; do not "fix" it by restarting.

--- a/.agents/plugins/quirq/skills/quirq/scripts/discover.sh
+++ b/.agents/plugins/quirq/skills/quirq/scripts/discover.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# discover.sh — read-only discovery of the local Quirq install.
+#
+# Performs NO actions: a few file checks and short GET requests, then one
+# JSON object on stdout. Starting, installing, or updating Quirq is a human
+# decision made after reading this output — never this script's job.
+#
+# States:
+#   running        a Quirq server answered /health
+#   installed      a checkout exists on disk but no server is running
+#   not_installed  neither a live server nor a checkout was found
+#
+# Sources, in order:
+#   1. ~/.config/quirq/install.json — written by server.py on every boot
+#      (a last-known-location hint; paths are verified before being trusted)
+#   2. health probes on 127.0.0.1: pointer port first, then 5002, 5003
+#   3. the current directory (./xo-space/server.py, or being inside a checkout)
+set -u
+
+POINTER_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/quirq/install.json"
+CURL_TIMEOUT=2
+
+# Extract a string field from one-level JSON without jq/python. Good enough
+# for a file we write ourselves; paths with spaces survive (split on quotes).
+json_str() { # $1=file $2=key
+    grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$1" 2>/dev/null |
+        head -1 | sed 's/.*:[[:space:]]*"//; s/"$//'
+}
+
+json_num() { # $1=file $2=key
+    grep -o "\"$2\"[[:space:]]*:[[:space:]]*[0-9]*" "$1" 2>/dev/null |
+        head -1 | grep -o '[0-9]*$'
+}
+
+emit() { # $1=state $2=base_url $3=repo_dir $4=projects_root $5=state_root
+    printf '{"state":"%s","base_url":"%s","repo_dir":"%s","projects_root":"%s","state_root":"%s","pointer_file":"%s"}\n' \
+        "$1" "$2" "$3" "$4" "$5" "$POINTER_FILE"
+}
+
+probe_health() { # $1=port → 0 if a healthy Quirq answered
+    local body
+    body="$(curl -fsS -m "$CURL_TIMEOUT" "http://127.0.0.1:$1/health" 2>/dev/null)" || return 1
+    # Not just "any 200": make sure it is Quirq, not another local service.
+    printf '%s' "$body" | grep -q '"status"[[:space:]]*:[[:space:]]*"healthy"'
+}
+
+pointer_repo=""
+pointer_projects=""
+pointer_state=""
+pointer_port=""
+if [ -f "$POINTER_FILE" ]; then
+    pointer_repo="$(json_str "$POINTER_FILE" repo_dir)"
+    pointer_projects="$(json_str "$POINTER_FILE" projects_root)"
+    pointer_state="$(json_str "$POINTER_FILE" state_root)"
+    pointer_port="$(json_num "$POINTER_FILE" port)"
+fi
+
+# --- 1. Is a server running? Pointer port first, then the defaults. ------
+# QUIRQ_DISCOVER_PORTS overrides the defaults for non-standard setups
+# (and lets tests point the probe at known-dead ports).
+default_ports="${QUIRQ_DISCOVER_PORTS:-5002 5003}"
+candidate_ports=""
+[ -n "$pointer_port" ] && candidate_ports="$pointer_port"
+for p in $default_ports; do
+    [ "$p" = "${pointer_port:-}" ] || candidate_ports="$candidate_ports $p"
+done
+
+for port in $candidate_ports; do
+    if probe_health "$port"; then
+        emit running "http://127.0.0.1:$port" "$pointer_repo" "$pointer_projects" "$pointer_state"
+        exit 0
+    fi
+done
+
+# --- 2. Not running. Does a checkout exist where the pointer says? -------
+if [ -n "$pointer_repo" ] && [ -f "$pointer_repo/server.py" ] && [ -f "$pointer_repo/requirements.txt" ]; then
+    emit installed "" "$pointer_repo" "$pointer_projects" "$pointer_state"
+    exit 0
+fi
+
+# --- 3. No (valid) pointer. Last resort: look around the cwd. ------------
+# Covers installs that predate the pointer write, when the user happens to
+# be in the workspace. A filesystem-wide scan is deliberately NOT done.
+for dir in "$PWD/xo-space" "$PWD"; do
+    if [ -f "$dir/server.py" ] && [ -f "$dir/requirements.txt" ] && [ -f "$dir/cowork-api.sh" ]; then
+        emit installed "" "$dir" "" ""
+        exit 0
+    fi
+done
+
+emit not_installed "" "" "" ""

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "quirq-ai",
+  "owner": {
+    "name": "Quirq",
+    "url": "https://github.com/quirq-ai"
+  },
+  "plugins": [
+    {
+      "name": "quirq",
+      "source": "./plugin",
+      "description": "Find and talk to the local Quirq (xo-space) control plane: check-only discovery, guided install and start.",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ rclone.conf
 # Created by install.sh under the directory it is launched from. Running it
 # from a checkout puts all three inside the working tree, and .quirq holds
 # secrets.env — never commit them.
-.quirq/
-xo-projects/
-quirq/
+# Anchored to the repo root: an unanchored pattern would also swallow
+# unrelated directories that happen to share the name (e.g. plugin/skills/quirq/).
+/.quirq/
+/xo-projects/
+/quirq/

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "quirq",
+  "displayName": "Quirq",
+  "version": "1.0.0",
+  "description": "Find and talk to the local Quirq (xo-space) control plane: check-only discovery, guided install and start. Every state-changing action requires your explicit yes.",
+  "author": {
+    "name": "Quirq",
+    "url": "https://github.com/quirq-ai"
+  },
+  "homepage": "https://xo.builders",
+  "repository": "https://github.com/quirq-ai/xo-space",
+  "license": "MIT",
+  "keywords": ["quirq", "xo-space", "control-plane", "coding-agents"]
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,33 @@
+# quirq-plugin
+
+Claude Code plugin for [Quirq / xo-space](https://github.com/quirq-ai/xo-space),
+the local control plane for AI coding agents.
+
+The plugin never manages the server's lifecycle on its own: discovery is
+read-only, and installing or starting Quirq only happens after you say yes.
+
+## Install
+
+```
+/plugin marketplace add quirq-ai/xo-space
+/plugin install quirq@quirq-ai
+```
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `/quirq:status` | Check whether Quirq is installed and running (check-only) |
+| `/quirq:install <dir>` | One-time guided install into a directory you choose |
+| `/quirq:start` | Start an already-installed server, without updating it |
+
+The bundled `quirq` skill also lets Claude answer questions about your local
+Quirq install in plain conversation.
+
+## How discovery works
+
+`scripts/discover.sh` reads `~/.config/quirq/install.json` (written by the
+server on every boot), probes `/health` on localhost (pointer port first,
+then 5002/5003), and falls back to checking the current directory. It
+performs no actions and reports one of: `running`, `installed`,
+`not_installed`.

--- a/plugin/commands/install.md
+++ b/plugin/commands/install.md
@@ -1,0 +1,46 @@
+---
+description: Install Quirq into a directory the user chooses (one-time, explicit)
+argument-hint: <workspace-directory>
+---
+
+Install Quirq (xo-space) on this machine. The workspace directory is
+`$ARGUMENTS`.
+
+**Rules — read before acting:**
+- The workspace directory is the user's decision. If `$ARGUMENTS` is empty,
+  ask for it and stop — never pick, suggest, or default one.
+- This is a one-time action. If Quirq is already installed or running, never
+  reinstall over it; report what you found instead.
+
+**Steps:**
+
+1. Run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/discover.sh"`.
+   - `running` → report the server and its `/space/` URL; stop.
+   - `installed` → report the existing checkout location; stop.
+
+2. Validate the directory: expand `~`, require an absolute path after
+   expansion. Create it only if the user gave a path that doesn't exist yet
+   and confirms creation.
+
+3. Confirm once, showing exactly what will happen: "Installing Quirq into
+   `<dir>` — this clones xo-space there, sets up a Python env, and starts
+   the server (the directory becomes your workspace root)." Proceed only on
+   an explicit yes.
+
+4. Run the official installer **as a background task** (it ends by starting
+   the server in the foreground, so it will not return):
+
+   ```bash
+   cd <dir> && curl -fsSL https://www.quirq.ai/install | sh
+   ```
+
+5. Poll `http://127.0.0.1:5002/health` (then 5003) every ~5 s, up to
+   ~5 minutes — first install builds a venv and can be slow.
+
+6. On success: report the UI at `http://127.0.0.1:<port>/space/`, note the
+   config file at `<dir>/xo-space/.env`, and that the server stops when
+   this background task is killed — re-running `./xo-space/install.sh` in
+   `<dir>` (or `/quirq:start`) brings it back.
+
+7. On timeout or failure: show the tail of the installer output verbatim
+   and stop. Do not retry on your own.

--- a/plugin/commands/start.md
+++ b/plugin/commands/start.md
@@ -1,0 +1,33 @@
+---
+description: Start an already-installed Quirq server (no update, explicit consent)
+---
+
+Start the locally installed Quirq server. **Starting is not updating**: this
+runs the checkout exactly as it is on disk. It never fetches, pulls, or
+re-runs the installer.
+
+1. Run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/discover.sh"`.
+   - `running` → already up; report the base URL and stop.
+   - `not_installed` → nothing to start; suggest `/quirq:install <dir>` and stop.
+   - `installed` → continue with `repo_dir` from the output.
+
+2. Preconditions in `repo_dir`: `venv/bin/python` must exist (if missing,
+   the env was never built — tell the user to run `./install.sh` there
+   themselves, since that path also updates; stop). `.env` should exist and
+   is picked up automatically.
+
+3. Unless the user already explicitly asked to start it in this
+   conversation, confirm: "Start Quirq from `<repo_dir>`?" Proceed only on
+   an explicit yes.
+
+4. Start it **as a background task**:
+
+   ```bash
+   cd <repo_dir> && ./venv/bin/python server.py
+   ```
+
+5. Poll `/health` on 5002 then 5003 (the server falls back automatically)
+   for up to ~60 s.
+
+6. On success report port and `<base_url>/space/`. On failure show the
+   server's output verbatim and stop — no retries, no cleanup attempts.

--- a/plugin/commands/status.md
+++ b/plugin/commands/status.md
@@ -1,0 +1,27 @@
+---
+description: Check whether Quirq is installed and running, and report its state
+---
+
+Check the state of the local Quirq control plane. This command is
+**check-only**: it never installs, starts, stops, or updates anything.
+
+1. Run: `bash "${CLAUDE_PLUGIN_ROOT}/scripts/discover.sh"` and parse the JSON.
+
+2. If `state` is `running`:
+   - `curl -fsS <base_url>/health` and `curl -fsS <base_url>/api/runtime-config`.
+   - Report concisely: port, stage, auth state (authenticated or not, token
+     source), active sessions, projects/state roots, and the UI link
+     `<base_url>/space/`.
+
+3. If `state` is `installed`:
+   - Report the checkout location (`repo_dir`) and that no server is
+     running, then ask whether the user wants it started (they can also run
+     `/quirq:start`). Do not start it yourself without an explicit yes.
+
+4. If `state` is `not_installed`:
+   - Report that no install was found (no pointer file, no live server, no
+     checkout in the current directory). Mention that `/quirq:install
+     <directory>` installs it, and that the directory choice is theirs.
+
+Report faithfully — if `/health` returns an error or unexpected output,
+show what came back instead of interpreting around it.

--- a/plugin/scripts/discover.sh
+++ b/plugin/scripts/discover.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# discover.sh — read-only discovery of the local Quirq install.
+#
+# Performs NO actions: a few file checks and short GET requests, then one
+# JSON object on stdout. Starting, installing, or updating Quirq is a human
+# decision made after reading this output — never this script's job.
+#
+# States:
+#   running        a Quirq server answered /health
+#   installed      a checkout exists on disk but no server is running
+#   not_installed  neither a live server nor a checkout was found
+#
+# Sources, in order:
+#   1. ~/.config/quirq/install.json — written by server.py on every boot
+#      (a last-known-location hint; paths are verified before being trusted)
+#   2. health probes on 127.0.0.1: pointer port first, then 5002, 5003
+#   3. the current directory (./xo-space/server.py, or being inside a checkout)
+set -u
+
+POINTER_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/quirq/install.json"
+CURL_TIMEOUT=2
+
+# Extract a string field from one-level JSON without jq/python. Good enough
+# for a file we write ourselves; paths with spaces survive (split on quotes).
+json_str() { # $1=file $2=key
+    grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$1" 2>/dev/null |
+        head -1 | sed 's/.*:[[:space:]]*"//; s/"$//'
+}
+
+json_num() { # $1=file $2=key
+    grep -o "\"$2\"[[:space:]]*:[[:space:]]*[0-9]*" "$1" 2>/dev/null |
+        head -1 | grep -o '[0-9]*$'
+}
+
+emit() { # $1=state $2=base_url $3=repo_dir $4=projects_root $5=state_root
+    printf '{"state":"%s","base_url":"%s","repo_dir":"%s","projects_root":"%s","state_root":"%s","pointer_file":"%s"}\n' \
+        "$1" "$2" "$3" "$4" "$5" "$POINTER_FILE"
+}
+
+probe_health() { # $1=port → 0 if a healthy Quirq answered
+    local body
+    body="$(curl -fsS -m "$CURL_TIMEOUT" "http://127.0.0.1:$1/health" 2>/dev/null)" || return 1
+    # Not just "any 200": make sure it is Quirq, not another local service.
+    printf '%s' "$body" | grep -q '"status"[[:space:]]*:[[:space:]]*"healthy"'
+}
+
+pointer_repo=""
+pointer_projects=""
+pointer_state=""
+pointer_port=""
+if [ -f "$POINTER_FILE" ]; then
+    pointer_repo="$(json_str "$POINTER_FILE" repo_dir)"
+    pointer_projects="$(json_str "$POINTER_FILE" projects_root)"
+    pointer_state="$(json_str "$POINTER_FILE" state_root)"
+    pointer_port="$(json_num "$POINTER_FILE" port)"
+fi
+
+# --- 1. Is a server running? Pointer port first, then the defaults. ------
+# QUIRQ_DISCOVER_PORTS overrides the defaults for non-standard setups
+# (and lets tests point the probe at known-dead ports).
+default_ports="${QUIRQ_DISCOVER_PORTS:-5002 5003}"
+candidate_ports=""
+[ -n "$pointer_port" ] && candidate_ports="$pointer_port"
+for p in $default_ports; do
+    [ "$p" = "${pointer_port:-}" ] || candidate_ports="$candidate_ports $p"
+done
+
+for port in $candidate_ports; do
+    if probe_health "$port"; then
+        emit running "http://127.0.0.1:$port" "$pointer_repo" "$pointer_projects" "$pointer_state"
+        exit 0
+    fi
+done
+
+# --- 2. Not running. Does a checkout exist where the pointer says? -------
+if [ -n "$pointer_repo" ] && [ -f "$pointer_repo/server.py" ] && [ -f "$pointer_repo/requirements.txt" ]; then
+    emit installed "" "$pointer_repo" "$pointer_projects" "$pointer_state"
+    exit 0
+fi
+
+# --- 3. No (valid) pointer. Last resort: look around the cwd. ------------
+# Covers installs that predate the pointer write, when the user happens to
+# be in the workspace. A filesystem-wide scan is deliberately NOT done.
+for dir in "$PWD/xo-space" "$PWD"; do
+    if [ -f "$dir/server.py" ] && [ -f "$dir/requirements.txt" ] && [ -f "$dir/cowork-api.sh" ]; then
+        emit installed "" "$dir" "" ""
+        exit 0
+    fi
+done
+
+emit not_installed "" "" "" ""

--- a/plugin/skills/quirq/SKILL.md
+++ b/plugin/skills/quirq/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: quirq
+description: Use when the user mentions Quirq, xo-space, the XO workspace / control plane, or asks whether their local agent server is installed or running. Covers finding the install, checking health, and the strict ask-before-acting rules for install/start.
+---
+
+# Quirq — the local control plane
+
+Quirq (repo: `xo-space`) is a FastAPI server the user runs **locally**. It
+brokers coding-agent runtimes, owns the `xo-projects` model, and serves its
+own web UI at `<base_url>/space/`. Default port 5002 (falls back to 5003).
+The server's lifecycle belongs to the **user**, not to you.
+
+## Always start with discovery (read-only)
+
+Before answering anything about Quirq, run:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/discover.sh"
+```
+
+It performs no actions — it reads the pointer file
+(`~/.config/quirq/install.json`, written by the server on every boot),
+probes `/health` on localhost, and checks the cwd. It prints one JSON
+object with `state`: `running`, `installed`, or `not_installed`.
+
+## What to do per state
+
+**`running`** — proceed with whatever was asked. Useful endpoints:
+- `GET <base_url>/health` — status, stage, auth state, active sessions.
+- `GET <base_url>/api/runtime-config` — resolved port, roots, path status.
+- The web UI: `<base_url>/space/` — send the user there for anything
+  interactive (setup, connectors, secrets).
+
+**`installed`** (checkout at `repo_dir`, no live server) — report it, then
+ask: *"Quirq is installed at `<repo_dir>` but not running. Want me to start
+it?"* Only on an explicit yes, follow `/quirq:start`.
+
+**`not_installed`** — report it, then ask: *"Quirq isn't installed on this
+machine. Want me to install it? Which directory should be the workspace?"*
+The directory is **always the user's answer — never pick or suggest a
+default yourself**. On an explicit yes + directory, follow `/quirq:install`.
+
+## Hard rules
+
+1. **Discovery is check-only.** Never start, stop, restart, update, or
+   install anything as a side effect of checking.
+2. **Every state-changing action needs an explicit yes from the user in
+   this conversation.** An earlier yes does not carry over to a new action.
+3. **Never choose the install directory.** It decides where the workspace
+   and all project data live — that is the user's call.
+4. **Starting is not updating.** `/quirq:start` runs the existing checkout
+   as-is. Updating (re-running `install.sh`, which fast-forwards the
+   checkout) only happens if the user explicitly asks to update.
+5. **Never touch `/api/secrets*` or connector endpoints.** Credentials and
+   OAuth flows belong in the `/space/` UI — point the user there.
+6. If the server misbehaves, report what you observed (exact curl output)
+   and let the user decide; do not "fix" it by restarting.

--- a/scripts/check_plugin_sync.sh
+++ b/scripts/check_plugin_sync.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# The Claude Code plugin (plugin/) and the Codex plugin (.agents/plugins/quirq/)
+# share discovery logic that must not drift. Run from the repo root; exits
+# non-zero with a diff when the copies disagree.
+set -u
+
+cd "$(dirname "$0")/.." || exit 1
+
+fail=0
+compare() {
+    if ! diff -u "$1" "$2"; then
+        printf '\nOut of sync: %s vs %s\n' "$1" "$2" >&2
+        fail=1
+    fi
+}
+
+compare plugin/scripts/discover.sh .agents/plugins/quirq/skills/quirq/scripts/discover.sh
+
+if [ "$fail" -eq 0 ]; then
+    printf 'Plugin bundles in sync.\n'
+fi
+exit "$fail"

--- a/server.py
+++ b/server.py
@@ -537,9 +537,45 @@ def _install_shared_deps() -> None:
         print(f"⚠️ Shared dep install failed (non-fatal): {e}")
 
 
+def _write_install_pointer() -> None:
+    """Record where this install lives so local clients (the Claude Code
+    plugin, support tooling) can find it without scanning the filesystem.
+
+    One fixed path, dynamic contents: ~/.config/quirq/install.json (XDG
+    honoured), rewritten on every boot because it is a last-known-location
+    hint, not configuration — port fallbacks and relocated roots must show
+    up here. Consumers verify the recorded paths still exist before
+    trusting them, so a stale file after an uninstall is harmless.
+    """
+    try:
+        from services.cowork_agent.local_state import quirq_state_dir
+
+        config_home = Path(
+            os.getenv("XDG_CONFIG_HOME", "").strip() or Path.home() / ".config"
+        )
+        pointer_dir = config_home / "quirq"
+        pointer_dir.mkdir(parents=True, exist_ok=True)
+        pointer = {
+            "repo_dir": str(Path(__file__).resolve().parent),
+            "projects_root": os.getenv("XO_PROJECTS_ROOT", "").strip()
+            or str(Path("~/xo-projects").expanduser()),
+            "state_root": str(quirq_state_dir()),
+            "host": os.getenv("HOST", "127.0.0.1"),
+            "port": int(os.getenv("PORT", "5002")),
+            "updated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        }
+        (pointer_dir / "install.json").write_text(json.dumps(pointer, indent=2) + "\n")
+    except Exception as e:
+        print(f"⚠️ Could not write install pointer (non-fatal): {e}")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan handler."""
+    # Written first: the pointer must exist even if a later boot step fails,
+    # so a half-started install is still discoverable.
+    _write_install_pointer()
+
     # Bootstrap the agent runtime (OpenClaw, etc.) before serving traffic.
     # Done synchronously so the API doesn't accept requests until the
     # agent it's meant to drive is installed and configured.


### PR DESCRIPTION
Adds installable plugins for Claude Code and Codex that let agent sessions
find and talk to the locally running Quirq server, plus the server-side
pointer they rely on.

## What's included

- **`plugin/`** — Claude Code plugin (skill + `/quirq:status`, `/quirq:install <dir>`, `/quirq:start`), distributed via `.claude-plugin/marketplace.json` in this repo
- **`.agents/plugins/`** — Codex plugin, same scope with the commands recast as skills
- **`server.py`** — writes `~/.config/quirq/install.json` on every boot (repo dir, roots, port) so clients can find the install without scanning the filesystem; best-effort, never blocks startup
- **`scripts/check_plugin_sync.sh`** — guards the shared `discover.sh` against drift between the two bundles
- `.gitignore` root-state patterns anchored (`/quirq/` was swallowing `plugin/skills/quirq/`)

## Design rules

Discovery is read-only; every state-changing action (install/start) requires an
explicit user yes; the install directory is always the user's choice; start
never updates the checkout.

## Install

Claude Code: `/plugin marketplace add quirq-ai/xo-space` → `/plugin install quirq@quirq-ai`
Codex: `codex plugin marketplace add quirq-ai/xo-space` → `codex plugin add quirq@quirq-ai`

## Tested

Server boot verified to write the pointer; all three discovery states exercised
against a live server. Codex flow verified end-to-end on Codex CLI 0.147.0
(local marketplace; git-based add untested until this merges).