### PR TITLE
fix(setup): make the storage-roots flow work end to end

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,8 +30,9 @@
 # Re-run to update and restart.
 #
 # Root directory precedence:
-#     XO_PROJECTS_ROOT / QUIRQ_STATE_ROOT env vars
+#     XO_PROJECTS_ROOT / QUIRQ_STATE_ROOT exported in the caller's shell
 #         → roots.env saved by the Setup tab
+#         → the checkout's .env from the first install
 #         → the launch directory, and ./.quirq inside it
 #
 # Every environment value below is overridable from the caller's
@@ -50,6 +51,12 @@ SOURCE_REF="${QUIRQ_SOURCE_REF:-main}"
 # Captured before anything cd's. Everything Quirq creates hangs off this, so
 # a run is self-contained in the directory you launched it from.
 LAUNCH_DIR="$PWD"
+# Captured before .env is loaded into the environment, so the resolution
+# below can tell a root the caller exported (beats everything) apart from
+# one that merely came out of the checkout's .env (loses to roots.env —
+# the Setup tab's saved roots must actually apply on the next run).
+SHELL_XO_PROJECTS_ROOT="${XO_PROJECTS_ROOT:-}"
+SHELL_QUIRQ_STATE_ROOT="${QUIRQ_STATE_ROOT:-}"
 # Named after the repository, the way a plain `git clone` would name it, so
 # the directory follows QUIRQ_SOURCE_REPO instead of hardcoding one name.
 REPO_NAME="${SOURCE_REPO##*/}"
@@ -515,9 +522,9 @@ start_server() {
     # during it should be reported here, not discovered later.
     while [ "$waited" -lt 90 ]; do
         if curl -fsS -m 2 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
-            printf '\nQuirq is running: http://localhost:%s/space/\n' "$PORT"
-            printf 'Logs:  %s\n' "$log_file"
-            printf 'Stop:  kill "$(cat %s)"\n' "$pid_file"
+            printf '\n▶️  Quirq is running: http://localhost:%s/space/\n\n' "$PORT"
+            printf '    Logs:  %s\n' "$log_file"
+            printf '    Stop:  kill "$(cat %s)"\n' "$pid_file"
             return 0
         fi
         if ! kill -0 "$server_pid" 2>/dev/null; then
@@ -568,8 +575,8 @@ main() {
     anchor_dir="${QUIRQ_STATE_ROOT:-${LAUNCH_DIR}/.quirq}"
     saved_projects_root="$(saved_root_from_file "$anchor_dir" "XO_PROJECTS_ROOT")"
     saved_state_root="$(saved_root_from_file "$anchor_dir" "QUIRQ_STATE_ROOT")"
-    projects_root="${XO_PROJECTS_ROOT:-${saved_projects_root:-${LAUNCH_DIR}}}"
-    state_root="${QUIRQ_STATE_ROOT:-${saved_state_root:-${LAUNCH_DIR}/.quirq}}"
+    projects_root="${SHELL_XO_PROJECTS_ROOT:-${saved_projects_root:-${XO_PROJECTS_ROOT:-${LAUNCH_DIR}}}}"
+    state_root="${SHELL_QUIRQ_STATE_ROOT:-${saved_state_root:-${QUIRQ_STATE_ROOT:-${LAUNCH_DIR}/.quirq}}}"
     validate_host_root "XO root" "$projects_root"
     validate_host_root "Quirq root" "$state_root"
     validate_separate_roots "$projects_root" "$state_root"

--- a/services/cowork_agent/runtime_config.py
+++ b/services/cowork_agent/runtime_config.py
@@ -34,11 +34,10 @@ RUNTIME_CONFIG_KEYS = frozenset(
     }
 )
 ROOT_CONFIG_KEYS = frozenset({"XO_PROJECTS_ROOT", "QUIRQ_STATE_ROOT"})
-INSTALL_COMMAND = (
-    "curl -fsSL "
-    "https://raw.githubusercontent.com/sharmasuraj0123/"
-    "xo-cowork-api/main/install.sh | bash"
-)
+# The canonical one-liner from the website, not a raw GitHub URL: the site
+# bootstrapper follows repo renames and branch selection, so this string
+# cannot rot the way a hardcoded raw.githubusercontent.com path did.
+INSTALL_COMMAND = "curl -fsSL https://www.quirq.ai/install | sh"
 
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _SESSION_SCAN_CAP = 10_000
@@ -305,10 +304,26 @@ def validate_root_settings(payload: dict[str, Any]) -> dict[str, str]:
         common = os.path.commonpath([projects_root, state_root])
     except ValueError as exc:
         raise ValueError("XO root and Quirq root must be on compatible paths") from exc
-    if common in {projects_root, state_root}:
+    if common == state_root:
         raise ValueError(
             "XO root and Quirq root must be separate, non-nested directories"
         )
+    if common == projects_root:
+        # Mirror install.sh's validate_separate_roots: the one allowed nesting
+        # is the state root as a hidden directory directly inside the projects
+        # root — the default ./ and ./.quirq layout the installer itself
+        # creates. quirq_catalog skips dot-prefixed entries when enumerating
+        # projects, so ".quirq" there can never be mistaken for one. Anything
+        # deeper, not hidden, or equal stays forbidden.
+        relative = os.path.relpath(state_root, projects_root)
+        if (
+            relative == os.curdir
+            or os.sep in relative
+            or not relative.startswith(".")
+        ):
+            raise ValueError(
+                "XO root and Quirq root must be separate, non-nested directories"
+            )
     return {
         "xo_projects_root": projects_root,
         "quirq_state_root": state_root,
@@ -327,13 +342,20 @@ def save_root_settings(payload: dict[str, Any]) -> dict[str, str]:
 
 
 def root_settings() -> dict[str, Any]:
+    # QUIRQ_HOST_* are the Docker installer's container→host translations and
+    # win when set. Native runs never set them, so fall back to the roots the
+    # process is actually using — otherwise Setup shows empty fields and
+    # "not reported" for an install that is running fine.
     current = {
         "xo_projects_root": (
-            os.getenv("QUIRQ_HOST_PROJECTS_ROOT", "") or ""
-        ).strip(),
+            (os.getenv("QUIRQ_HOST_PROJECTS_ROOT", "") or "").strip()
+            or (os.getenv("XO_PROJECTS_ROOT", "") or "").strip()
+            or str(Path("~/xo-projects").expanduser())
+        ),
         "quirq_state_root": (
-            os.getenv("QUIRQ_HOST_STATE_ROOT", "") or ""
-        ).strip(),
+            (os.getenv("QUIRQ_HOST_STATE_ROOT", "") or "").strip()
+            or str(quirq_state_dir())
+        ),
     }
     saved = _parse_env_file(root_config_file(), ROOT_CONFIG_KEYS)
     configured = {

--- a/space_ui/js/views/secrets.js
+++ b/space_ui/js/views/secrets.js
@@ -70,7 +70,7 @@ function renderShell(){
           +'</div>'
           +'<div class="setup-form-error" id="roots-error" role="alert" hidden></div>'
           +'<div class="setup-root-apply" id="roots-apply" hidden>'
-            +'<div><b>Container recreation required</b><p>Docker bind mounts cannot change in place. Run this same one-command installer to apply both roots.</p></div>'
+            +'<div><b>Server restart required</b><p>Storage roots are applied when the server starts. Run this same one-command installer to restart with both roots.</p></div>'
             +'<pre id="roots-command"></pre>'
           +'</div>'
           +'<div class="setup-actions">'
@@ -220,7 +220,7 @@ function renderRuntime(){
   if(rootPending){
     alert.className='setup-alert is-pending';
     alert.innerHTML='<span aria-hidden="true">◆</span><div><b>New storage roots are saved but not mounted yet.</b>'
-      +'<p>Run the installer command shown below. It will recreate the managed container and also apply any pending runtime or credential changes.</p></div>';
+      +'<p>Run the installer command shown below. It restarts the server with the new roots and also applies any pending runtime or credential changes.</p></div>';
   }else if(runtimeData.restart_required){
     const reasons=runtimeData.restart_reasons||[];
     const runtimePending=reasons.includes('runtime');

--- a/space_ui/js/views/wiki.js
+++ b/space_ui/js/views/wiki.js
@@ -471,13 +471,13 @@ const TAB_GUIDES={
       ['POST /api/runtime-config/restart','Restarts only an installer-managed local container.','Managed process control']
     ],
     steps:[
-      ['Confirm paths','Compare host paths with their fixed container mount points.'],
-      ['Save roots','If roots differ, copy and run the one-command installer because Docker bind mounts cannot change in place.'],
+      ['Confirm paths','Compare the configured roots with what the running server reports.'],
+      ['Save roots','If roots differ, copy and run the one-command installer — roots are applied when the server starts.'],
       ['Save runtime','Review the pending-restart banner before applying process-time changes.'],
       ['Add credentials','Choose a manifest-recommended key, save it, then restart when requested.']
     ],
     checks:[
-      ['Root not applied','Saving queues it; rerun the displayed installer to recreate the bind mounts.'],
+      ['Root not applied','Saving queues it; rerun the displayed installer to restart with the new roots.'],
       ['CLI unavailable','A manifest may support bootstrap, but required credentials must be present first.'],
       ['Sessions missing','Confirm the native runtime directory is mounted and watcher coverage includes it.'],
       ['Secret value hidden','That is intentional; replace the value or remove the variable.']
@@ -679,15 +679,17 @@ function installationArticle(){
       <section class="wiki-section">
         <h2>First installation</h2>
         <ol class="wiki-steps">
-          <li><b>Start Docker.</b>
-          <p>No Git clone, Python environment, or repository checkout is
-          required.</p></li>
+          <li><b>Pick a workspace directory.</b>
+          <p>Run the installer from the directory you want as your
+          workspace — the checkout lands beside your projects. Git is the
+          only prerequisite.</p></li>
           <li><b>Run the installer.</b>
-          <code>curl -fsSL https://raw.githubusercontent.com/sharmasuraj0123/xo-cowork-api/main/install.sh | bash</code>
-          <p>The command downloads the published image, starts the container
-          in the background, waits for health, and prints the browser URL.</p></li>
+          <code>curl -fsSL https://www.quirq.ai/install | sh</code>
+          <p>The command clones the server, prepares a Python environment,
+          starts the server in the background, waits for health, and prints
+          the browser URL.</p></li>
           <li><b>Open the workspace.</b>
-          <code>http://localhost:5003/space/</code>
+          <code>http://localhost:5002/space/</code>
           <p>The same address is used every time. Re-run the same installer
           command whenever you want to update or restart.</p></li>
         </ol>
@@ -1100,13 +1102,13 @@ function quirqDataArticle(){
           </article>
 
           <article class="wiki-file">
-            <header><code>roots.env</code><span>installer bind-mount configuration</span></header>
+            <header><code>roots.env</code><span>installer root configuration</span></header>
             <p>Stores the absolute host paths selected for the XO projects
             root and machine-local Quirq state root. These values are
-            intentionally separate from process runtime settings: Docker
-            cannot replace a running container's bind mounts, so Setup marks
-            them pending until the one-command installer recreates the managed
-            container.</p>
+            intentionally separate from process runtime settings: the running
+            server cannot change its own roots, so Setup marks them pending
+            until the one-command installer restarts it with the new
+            values.</p>
             <dl><div><dt>Writer</dt><dd>typed root configuration API</dd></div><div><dt>Migration</dt><dd>empty state targets receive a copy; project roots are selected, never moved</dd></div></dl>
           </article>
 

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -70,11 +70,31 @@ class RuntimeConfigTests(unittest.TestCase):
         invalid = (
             {"xo_projects_root": "relative", "quirq_state_root": "/tmp/state"},
             {"xo_projects_root": "/", "quirq_state_root": "/tmp/state"},
-            {"xo_projects_root": "/tmp/xo", "quirq_state_root": "/tmp/xo/.quirq"},
+            # equal roots
+            {"xo_projects_root": "/tmp/xo", "quirq_state_root": "/tmp/xo"},
+            # nested deeper than one level
+            {"xo_projects_root": "/tmp/xo", "quirq_state_root": "/tmp/xo/deep/.quirq"},
+            # nested one level but not hidden
+            {"xo_projects_root": "/tmp/xo", "quirq_state_root": "/tmp/xo/quirq"},
+            # projects root inside the state root
+            {
+                "xo_projects_root": "/tmp/xo/.quirq/projects",
+                "quirq_state_root": "/tmp/xo/.quirq",
+            },
         )
         for payload in invalid:
             with self.assertRaises(ValueError):
                 runtime_config.validate_root_settings(payload)
+
+    def test_state_root_may_be_hidden_directly_inside_projects_root(self) -> None:
+        # The default layout install.sh itself creates: ./ and ./.quirq. The
+        # API validator must accept what the installer's validator accepts,
+        # or Setup rejects the configuration the server is running with.
+        clean = runtime_config.validate_root_settings(
+            {"xo_projects_root": "/tmp/xo", "quirq_state_root": "/tmp/xo/.quirq"}
+        )
+        self.assertEqual(clean["xo_projects_root"], "/tmp/xo")
+        self.assertEqual(clean["quirq_state_root"], "/tmp/xo/.quirq")
 
     def test_save_is_private_validated_and_restart_aware(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
The Setup page's apply command pointed at the dead pre-rename repo (404); it now serves the canonical curl quirq.ai/install one-liner, which follows repo renames. Docker-era wording (container recreation, bind mounts, port 5003) is rewritten for the native install across the Setup callouts and wiki.

Three roots bugs fixed:
- validate_root_settings now accepts the one nesting install.sh's own validator allows — the state root as a hidden directory directly inside the projects root (the default ./ + ./.quirq layout). Setup previously rejected the exact configuration the server was running.
- Applied roots fall back from the Docker-only QUIRQ_HOST_* vars to the live environment, so Setup prefills current values instead of showing empty fields and 'not reported'.
- install.sh root precedence is now shell env > roots.env > .env > launch dir, so roots saved in Setup actually apply on the next run instead of being shadowed by the first install's .env.

Installer success line made prominent (devrel feedback): '▶️ Quirq is running' with log and stop paths indented beneath.

Tests updated: the old case asserting the hidden-dir rejection encoded the bug; new cases pin the shared validator contract.