### PR TITLE
feat(space): workspace lenses, file preview, and one XO root

### DIFF
--- a/routers/cowork_agent/bff/xo_projects.py
+++ b/routers/cowork_agent/bff/xo_projects.py
@@ -11,7 +11,9 @@ See docs/bff-endpoints-design.md §9.1 for the full contract.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
+from pathlib import PurePosixPath
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException
@@ -28,6 +30,7 @@ from services.cowork_agent.project_layout import (
     list_projects,
     list_unscaffolded_dirs,
     project_dir_exists,
+    read_project_file,
 )
 
 router = APIRouter()
@@ -56,13 +59,75 @@ def _to_iso_utc(ts: Optional[float]) -> Optional[str]:
     )
 
 
+# A project's own docs are the only place a human sentence about it exists —
+# .xo/project.json's description is empty for every project the API did not
+# create. Read the first real line of the usual suspects so the list can say
+# what a project IS, not just when it was created. Bounded: 3 files, 2 KB
+# each, first 40 lines.
+#
+# AGENTS.md is deliberately NOT in this list: it is the scaffold's operating
+# contract, so its opening line is identical in every project and would put
+# the same sentence on every row — the exact failure this replaces.
+_DESC_FILES = ("README.md", "PROJECT.md", "OBJECTIVES.md")
+_DESC_MAX = 160
+
+
+def _described(project_id: str) -> Optional[str]:
+    from services.cowork_agent.project_layout import project_dir
+
+    root = project_dir(project_id)
+    for candidate in _DESC_FILES:
+        path = root / candidate
+        try:
+            if not path.is_file():
+                continue
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                head = fh.read(2048)
+        except OSError:
+            continue
+        # Take the whole first paragraph, not the first line: markdown wraps
+        # at ~80 columns, so one line ends mid-sentence ("…in the tradition
+        # of") and reads like a truncation bug.
+        para: list[str] = []
+        for line in head.splitlines()[:40]:
+            text = line.strip()
+            if not text:
+                if para:
+                    break
+                continue
+            # skip headings, badges, html, front matter, tables, quotes, code
+            if text.startswith(("#", "!", "<", "---", "|", ">", "```")):
+                if para:
+                    break
+                continue
+            if text.startswith(("- ", "* ", "+ ")):
+                if para:
+                    break
+                continue
+            para.append(text)
+        if not para:
+            continue
+        text = " ".join(" ".join(para).split())
+        # The row shows plain text, so strip the markdown that survives a
+        # raw paragraph grab: links, emphasis, code ticks.
+        text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", text)
+        text = text.replace("**", "").replace("`", "").strip("*_ ")
+        if len(text) < 12:
+            continue
+        if len(text) > _DESC_MAX:
+            cut = text[:_DESC_MAX].rsplit(" ", 1)[0].rstrip(" ,;:.")
+            text = cut + "…"
+        return text
+    return None
+
+
 def _shape_scaffolded(entry: dict) -> Project:
     name = str(entry.get("name") or "")
     display = entry.get("display_name") or name
     return Project(
         id=name,
         display_name=str(display),
-        description=(entry.get("description") or None),
+        description=(entry.get("description") or _described(name) or None),
         created_at=(entry.get("created_at") or None),
         unscaffolded=False,
     )
@@ -126,8 +191,19 @@ def list_xo_projects() -> ListProjectsResponse:
 
 
 class TreeEntry(BaseModel):
+    """One row of a project's file explorer.
+
+    ``size_bytes`` is set for files, ``entries`` for directories, and both are
+    optional: a broken symlink or a file deleted mid-listing still gets a row
+    with a name, just without detail.
+    """
+
     name: str
     relative_path: str
+    is_dir: bool = False
+    size_bytes: Optional[int] = None
+    modified_at: Optional[str] = None
+    entries: Optional[int] = None
 
 
 class ProjectTreeResponse(BaseModel):
@@ -138,7 +214,12 @@ class ProjectTreeResponse(BaseModel):
     files: list[TreeEntry]
 
 
-def _filter_tree_entries(entries: list[dict], at_root: bool) -> list[TreeEntry]:
+def _filter_tree_entries(
+    entries: list[dict],
+    at_root: bool,
+    *,
+    is_dir: bool,
+) -> list[TreeEntry]:
     out: list[TreeEntry] = []
     for e in entries:
         name = e.get("name") or ""
@@ -146,7 +227,16 @@ def _filter_tree_entries(entries: list[dict], at_root: bool) -> list[TreeEntry]:
             continue
         if at_root and is_root_only_hidden(name):
             continue
-        out.append(TreeEntry(name=name, relative_path=e.get("relative_path") or ""))
+        out.append(
+            TreeEntry(
+                name=name,
+                relative_path=e.get("relative_path") or "",
+                is_dir=is_dir,
+                size_bytes=e.get("size_bytes"),
+                modified_at=_to_iso_utc(e.get("modified_at")),
+                entries=e.get("entries"),
+            )
+        )
     return out
 
 
@@ -188,6 +278,107 @@ def project_tree(project_id: str, relative_path: str = "") -> ProjectTreeRespons
         project_id=raw["project_id"],
         relative_path=raw["relative_path"],
         parent_relative_path=raw["parent_relative_path"],
-        dirs=_filter_tree_entries(raw["dirs"], at_root),
-        files=_filter_tree_entries(raw["files"], at_root),
+        dirs=_filter_tree_entries(raw["dirs"], at_root, is_dir=True),
+        files=_filter_tree_entries(raw["files"], at_root, is_dir=False),
+    )
+
+
+# ── /api/xo-projects/{id}/file ────────────────────────────────────────────────
+#
+# Preview one text file from inside a project. Deliberately NOT the older
+# POST /api/files/content: that takes an absolute host path, and the Space UI
+# never sees absolute paths (see the module docstring). Here the project id
+# plus a project-relative path is the whole address space, validated by the
+# same helper the tree listing uses.
+
+PREVIEW_MAX_BYTES = 256 * 1024
+# Text this UI can present honestly: rendered markdown, sandboxed HTML, and
+# plain text. Anything else (an image, a 40 MB parquet) gets a "no preview"
+# state from its metadata rather than a wall of replacement characters.
+PREVIEW_SUFFIXES = frozenset(
+    {
+        ".md", ".markdown", ".mdx",
+        ".html", ".htm",
+        ".txt", ".text", ".rst", ".log",
+        ".json", ".yml", ".yaml", ".toml", ".ini", ".cfg", ".env.example",
+        ".py", ".js", ".mjs", ".ts", ".tsx", ".jsx", ".css", ".sh", ".sql",
+        ".go", ".rs", ".java", ".c", ".h", ".cpp",
+    }
+)
+
+
+def _preview_kind(name: str) -> str:
+    lower = name.lower()
+    if lower.endswith((".md", ".markdown", ".mdx")):
+        return "markdown"
+    if lower.endswith((".html", ".htm")):
+        return "html"
+    return "text"
+
+
+class FilePreviewResponse(BaseModel):
+    project_id: str
+    relative_path: str
+    name: str
+    kind: str
+    size_bytes: int
+    modified_at: Optional[str] = None
+    truncated: bool
+    content: str
+
+
+@router.get(
+    "/api/xo-projects/{project_id}/file",
+    response_model=FilePreviewResponse,
+)
+def project_file(project_id: str, relative_path: str) -> FilePreviewResponse:
+    """Return one previewable text file's content."""
+    if not project_dir_exists(project_id):
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "project_not_found", "message": "Project not found."},
+        )
+    suffix = PurePosixPath(relative_path or "").suffix.lower()
+    if suffix not in PREVIEW_SUFFIXES:
+        raise HTTPException(
+            status_code=415,
+            detail={
+                "code": "preview_unsupported",
+                "message": f"No text preview for {suffix or 'this file type'}.",
+            },
+        )
+
+    try:
+        raw = read_project_file(
+            project_id, relative_path, max_bytes=PREVIEW_MAX_BYTES
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_relative_path",
+                "message": "relative_path is malformed or escapes the project root.",
+            },
+        ) from exc
+    except OSError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail={"code": "scope_unavailable", "message": "File is not readable."},
+        ) from exc
+
+    if raw is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "file_not_found", "message": "File not found in project."},
+        )
+
+    return FilePreviewResponse(
+        project_id=raw["project_id"],
+        relative_path=raw["relative_path"],
+        name=raw["name"],
+        kind=_preview_kind(raw["name"]),
+        size_bytes=raw["size_bytes"],
+        modified_at=_to_iso_utc(raw["modified_at"]),
+        truncated=raw["truncated"],
+        content=raw["content"],
     )

--- a/server.py
+++ b/server.py
@@ -19,15 +19,47 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from dotenv import load_dotenv
+from dotenv import dotenv_values, load_dotenv
 import httpx
 import uvicorn
 from config.models.claude_code import ClaudeCodeClient
 from config.models.codex import CodexCodeClient
 from utils.local_port import LocalPortsUnavailableError, resolve_server_port
 
-# Load environment variables
+# Load environment variables. Keys already exported by the shell (or by
+# docker -e / compose) are recorded first: they outrank every file below,
+# exactly as install.sh orders them.
+_shell_env_keys = frozenset(os.environ)
 load_dotenv()
+
+
+def _load_storage_roots() -> None:
+    """Apply ``<state root>/roots.env`` — the storage roots the Setup tab writes.
+
+    Precedence, mirroring install.sh: shell/container env > roots.env >
+    the checkout's .env. Loading it here is what makes the Setup tab's XO
+    root real for every reader (all of which resolve through
+    ``project_layout.xo_projects_root()``) after a restart, instead of only
+    when the Docker installer is re-run.
+
+    The file is anchored to the state root we can see right now; if it
+    relocates the state root, runtime.env and secrets are then read from the
+    new location.
+    """
+    anchor = Path(
+        (os.getenv("QUIRQ_STATE_ROOT", "") or "").strip() or Path.home() / ".quirq"
+    ).expanduser()
+    try:
+        values = dotenv_values(anchor / "roots.env")
+    except OSError:
+        return
+    for key in ("XO_PROJECTS_ROOT", "QUIRQ_STATE_ROOT"):
+        value = (values.get(key) or "").strip()
+        if value and key not in _shell_env_keys:
+            os.environ[key] = value
+
+
+_load_storage_roots()
 _quirq_state_root = Path(
     (os.getenv("QUIRQ_STATE_ROOT", "") or "").strip() or Path.home() / ".quirq"
 ).expanduser()
@@ -549,6 +581,7 @@ def _write_install_pointer() -> None:
     """
     try:
         from services.cowork_agent.local_state import quirq_state_dir
+        from services.cowork_agent.project_layout import xo_projects_root
 
         config_home = Path(
             os.getenv("XDG_CONFIG_HOME", "").strip() or Path.home() / ".config"
@@ -557,8 +590,7 @@ def _write_install_pointer() -> None:
         pointer_dir.mkdir(parents=True, exist_ok=True)
         pointer = {
             "repo_dir": str(Path(__file__).resolve().parent),
-            "projects_root": os.getenv("XO_PROJECTS_ROOT", "").strip()
-            or str(Path("~/xo-projects").expanduser()),
+            "projects_root": str(xo_projects_root()),
             "state_root": str(quirq_state_dir()),
             "host": os.getenv("HOST", "127.0.0.1"),
             "port": int(os.getenv("PORT", "5002")),

--- a/services/cowork_agent/project_layout.py
+++ b/services/cowork_agent/project_layout.py
@@ -255,6 +255,14 @@ def list_projects() -> list[dict]:
     ``.xo/project.json``. Hidden directories are skipped. Missing or
     malformed metadata yields a minimal entry with just ``name`` and
     ``path`` so the UI can still surface the folder.
+
+    **The directory name is the project id.** Every other helper here
+    resolves paths as ``xo_projects_root() / name``, so a stale
+    ``name`` inside ``.xo/project.json`` (left behind when a folder is
+    renamed) must never win: it would point consumers at the wrong
+    folder — or at another project's — and two folders carrying the
+    same stored name would collide into one id. ``project.json`` is
+    therefore read for descriptive fields only.
     """
     root = xo_projects_root()
     out: list[dict] = []
@@ -273,10 +281,14 @@ def list_projects() -> list[dict]:
             meta = {}
         if not isinstance(meta, dict):
             meta = {}
-        if not meta.get("name"):
-            meta["name"] = entry.name
-        if not meta.get("display_name"):
-            meta["display_name"] = meta["name"]
+        stored_name = str(meta.get("name") or "")
+        meta["name"] = entry.name
+        display = str(meta.get("display_name") or "")
+        # A display name that merely echoes a stale stored name is stale
+        # too; only a deliberately different label survives the rename.
+        if not display or (stored_name != entry.name and display == stored_name):
+            display = entry.name
+        meta["display_name"] = display
         meta["path"] = str(entry)
         out.append(meta)
 
@@ -332,10 +344,26 @@ def list_project_tree(name: str, relative_path: str = "") -> dict | None:
     files: list[dict] = []
     for entry in sorted(target.iterdir()):
         entry_rel = str(entry.relative_to(root_resolved)).replace("\\", "/")
-        info = {"name": entry.name, "relative_path": entry_rel}
+        info: dict = {"name": entry.name, "relative_path": entry_rel}
+        # stat() is best-effort: a broken symlink or a race with a delete
+        # must degrade to a listed entry with no detail, never a 500.
+        try:
+            st = entry.stat()
+            info["modified_at"] = st.st_mtime
+        except OSError:
+            st = None
         if entry.is_dir():
+            if st is not None:
+                try:
+                    # Cheap one-level count so the UI can say "12 items"
+                    # without a second request per folder.
+                    info["entries"] = sum(1 for _ in os.scandir(entry))
+                except OSError:
+                    pass
             dirs.append(info)
         else:
+            if st is not None:
+                info["size_bytes"] = st.st_size
             files.append(info)
 
     parent_rel: str | None
@@ -351,6 +379,67 @@ def list_project_tree(name: str, relative_path: str = "") -> dict | None:
         "parent_relative_path": parent_rel,
         "dirs": dirs,
         "files": files,
+    }
+
+
+def read_project_file(name: str, relative_path: str, *, max_bytes: int) -> dict | None:
+    """Read one text file from inside a project, for preview.
+
+    Returns ``None`` when the project or the file does not exist. Raises
+    ``ValueError`` for an unsafe ``relative_path`` — the same rules as
+    :func:`list_project_tree`, which is the only path validation in this
+    module and must stay the only one.
+
+    Reads at most ``max_bytes`` and reports ``truncated`` rather than
+    streaming a 200 MB file into a browser. Decoding is non-strict: a preview
+    of a file with one bad byte is more useful than an error.
+    """
+    project_id = normalize_agent_id(name)
+    root = project_dir(project_id)
+    if not root.is_dir():
+        return None
+    root_resolved = root.resolve()
+
+    rel = (relative_path or "")
+    if not rel:
+        raise ValueError("relative_path is required")
+    if "\x00" in rel:
+        raise ValueError("relative_path must not contain null bytes")
+    if rel.startswith("/") or rel.startswith("\\"):
+        raise ValueError("relative_path must not start with a path separator")
+    rel = rel.replace("\\", "/").strip("/")
+    parts = rel.split("/")
+    if any(p in ("..", ".") or p == "" for p in parts):
+        raise ValueError("relative_path must not contain '..' or '.' segments")
+
+    target = root_resolved / rel
+    try:
+        target = target.resolve()
+        target.relative_to(root_resolved)
+    except ValueError:
+        raise ValueError("relative_path escapes project root") from None
+
+    # is_file() follows symlinks; the relative_to() check above already
+    # rejected a link pointing out of the project, so this only excludes
+    # directories and specials.
+    if not target.is_file():
+        return None
+
+    size = target.stat().st_size
+    with open(target, "rb") as fh:
+        raw = fh.read(max_bytes + 1)
+    truncated = len(raw) > max_bytes
+    if truncated:
+        raw = raw[:max_bytes]
+
+    return {
+        "project_id": project_id,
+        "relative_path": rel,
+        "name": target.name,
+        "size_bytes": size,
+        "modified_at": target.stat().st_mtime,
+        "truncated": truncated,
+        "content": raw.decode("utf-8", errors="replace"),
     }
 
 

--- a/services/cowork_agent/quirq_catalog.py
+++ b/services/cowork_agent/quirq_catalog.py
@@ -1,6 +1,7 @@
 """Read-only, privacy-aware catalog of machine-local Quirq state.
 
-The catalog powers the local Quirq tab. It deliberately reports structure and
+The catalog powers the local Quirq view, opened from the Setup tab's header
+(deep link ``#/quirq``). It deliberately reports structure and
 operational summaries rather than serving arbitrary files: credential values,
 native session contents, cursor paths, and symlink targets never leave the
 machine-local state service.
@@ -15,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from services.cowork_agent.local_state import quirq_state_dir
+from services.cowork_agent.project_layout import xo_projects_root
 from services.cowork_agent.registry.agent_env import load_env_entries
 from services.cowork_agent.runtime_config import (
     configured_settings,
@@ -306,9 +308,8 @@ def _contract_status(
 
 
 def _project_outputs() -> dict[str, Any]:
-    projects_root = Path(
-        (os.getenv("XO_PROJECTS_ROOT", "") or "").strip() or "~/xo-projects"
-    ).expanduser()
+    # Same root helper as every other tab — see project_layout.
+    projects_root = xo_projects_root()
     host_root = (
         os.getenv("QUIRQ_HOST_PROJECTS_ROOT", "") or ""
     ).strip()

--- a/services/cowork_agent/runtime_config.py
+++ b/services/cowork_agent/runtime_config.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from services.cowork_agent.local_state import quirq_state_dir
+from services.cowork_agent.project_layout import xo_projects_root
 from services.cowork_agent.registry.agent_env import load_env_entries
 from services.cowork_agent.registry.agent_registry import all_agents, get_active_agent
 
@@ -190,12 +191,23 @@ def secrets_restart_required() -> bool:
     return _secrets_fingerprint() != _STARTUP_SECRETS_FINGERPRINT
 
 
+def roots_restart_required() -> bool:
+    """Whether saved storage roots differ from the ones now in use.
+
+    Startup reads roots.env, so this is a restart condition like the other
+    two — not an installer-only one.
+    """
+    return bool(root_settings()["change_required"])
+
+
 def restart_reasons() -> list[str]:
     reasons: list[str] = []
     if _runtime_settings_restart_required():
         reasons.append("runtime")
     if secrets_restart_required():
         reasons.append("secrets")
+    if roots_restart_required():
+        reasons.append("roots")
     return reasons
 
 
@@ -333,7 +345,8 @@ def validate_root_settings(payload: dict[str, Any]) -> dict[str, str]:
 def save_root_settings(payload: dict[str, Any]) -> dict[str, str]:
     clean = validate_root_settings(payload)
     text = (
-        "# Managed by Quirq Runtime Setup. Applied by the installer.\n"
+        "# Managed by Quirq Runtime Setup. Read at server startup;\n"
+        "# an exported shell/container value still wins over these.\n"
         f"XO_PROJECTS_ROOT={clean['xo_projects_root']}\n"
         f"QUIRQ_STATE_ROOT={clean['quirq_state_root']}\n"
     )
@@ -341,22 +354,47 @@ def save_root_settings(payload: dict[str, Any]) -> dict[str, str]:
     return clean
 
 
-def root_settings() -> dict[str, Any]:
-    # QUIRQ_HOST_* are the Docker installer's container→host translations and
-    # win when set. Native runs never set them, so fall back to the roots the
-    # process is actually using — otherwise Setup shows empty fields and
-    # "not reported" for an install that is running fine.
-    current = {
+def _same_root(left: str, right: str) -> bool:
+    """Whether two root strings name the same directory.
+
+    ``xo_projects_root()`` resolves symlinks; the Setup tab saves the path
+    the user typed. Comparing the strings alone would leave an install whose
+    home is a symlink permanently stuck on "restart required".
+    """
+    if left == right:
+        return True
+    try:
+        return os.path.realpath(left) == os.path.realpath(right)
+    except OSError:
+        return False
+
+
+def applied_roots() -> dict[str, str]:
+    """The roots this process is actually using.
+
+    Resolved through the same helpers every tab reads from
+    (``xo_projects_root`` / ``quirq_state_dir``) so Setup can never report a
+    root the rest of the app is not using.
+
+    QUIRQ_HOST_* are the Docker installer's container→host translations and
+    win when set. Native runs never set them, so fall back to the real roots
+    — otherwise Setup shows empty fields and "not reported" for an install
+    that is running fine.
+    """
+    return {
         "xo_projects_root": (
             (os.getenv("QUIRQ_HOST_PROJECTS_ROOT", "") or "").strip()
-            or (os.getenv("XO_PROJECTS_ROOT", "") or "").strip()
-            or str(Path("~/xo-projects").expanduser())
+            or str(xo_projects_root())
         ),
         "quirq_state_root": (
             (os.getenv("QUIRQ_HOST_STATE_ROOT", "") or "").strip()
             or str(quirq_state_dir())
         ),
     }
+
+
+def root_settings() -> dict[str, Any]:
+    current = applied_roots()
     saved = _parse_env_file(root_config_file(), ROOT_CONFIG_KEYS)
     configured = {
         "xo_projects_root": saved.get(
@@ -368,10 +406,17 @@ def root_settings() -> dict[str, Any]:
             current["quirq_state_root"],
         ),
     }
+    change_required = not all(
+        _same_root(configured[key], current[key]) for key in current
+    )
     return {
         "applied": current,
         "configured": configured,
-        "change_required": configured != current,
+        "change_required": change_required,
+        # Saved roots are read at startup (server.py), so a plain restart
+        # applies them. The installer command stays for container installs,
+        # where the roots are also bind mounts that only it can remap.
+        "applied_on_restart": True,
         "apply_command": INSTALL_COMMAND,
         "config_file": str(root_config_file()),
     }
@@ -484,9 +529,9 @@ def runtime_sources() -> list[dict[str, Any]]:
 
 
 def runtime_status() -> dict[str, Any]:
-    projects_root = Path(
-        (os.getenv("XO_PROJECTS_ROOT", "") or "").strip() or "~/xo-projects"
-    ).expanduser()
+    # One resolution for the whole app: the same helper the Files, Graph,
+    # Timeline, Chat and Quirq data paths call.
+    projects_root = xo_projects_root()
     state_root = quirq_state_dir()
     configured = configured_settings()
     applied = effective_settings()

--- a/space_ui/README.md
+++ b/space_ui/README.md
@@ -1,8 +1,9 @@
 # Space — the workspace knowledge graph UI
 
-An explorable map of `~/xo-projects`: a force-directed **graph** (click to
-focus, double-click clusters, re-root on any node), a scrubbable **timeline**,
-and **six degrees** pathfinding between any two artifacts.
+An explorable map of `~/xo-projects`. Six top-level tabs — **Dashboard**,
+**Files** (List | Graph | Tree lenses under one tab), **Timeline**,
+**Sessions**, **Wiki**, and **Setup** — plus the **Quirq** state view, which
+has no tab of its own and opens from Setup's header.
 
 This folder is a bundled snapshot of the xo-atlas UI (originally a standalone
 folder with no remote), trimmed to the single endpoint-driven page and served
@@ -24,14 +25,20 @@ directly. Descended from the single-file xo-atlas `v3.html`.
 | `js/core/store.js` | Idempotency helpers: single-flight promises, slotted (non-stacking) intervals. |
 | `js/core/ui.js` | Shared UI helpers (toast). |
 | `js/core/server-widget.js` | Footer server pill (status poll + stop). |
-| `js/views/atlas.js` | Graph + Timeline + Six Degrees — three lenses over one dataset, one shared closure, three exported views. |
+| `js/core/preview.js` | File previewer drawer. Any view opens it with a `space:preview-file` event; markdown renders through `markdown.js`, HTML renders in an empty-`sandbox` iframe, everything else as escaped source. |
+| `js/views/atlas.js` | Dashboard + Graph + Timeline — three lenses over one dataset, one shared closure, three exported views. |
 | `js/views/sessions.js` | The Sessions (Argus telemetry) view. |
-| `js/views/projects.js` | The Projects view: xo-projects observability — project list with per-project drawers for live todos, open sessions, and recent timeline events (read-only v1). |
-| `js/views/chat.js` | The Chat view: Plane-B chat (`/api/chat/prompt` → SSE stream → transcript refetch) with session sidebar, project binding for new sessions, and mini-markdown rendering. Works across claude_code / hermes / openclaw. |
+| `js/views/projects.js` | The Files List lens: project list with per-project drawers (folder browser via `/tree`, todos, open sessions, recent events). Owns the `Files` tab; Graph and Tree are sibling lenses (`nav:false`, `parent:'projects'`). |
+| `js/views/tree.js` | The Files Tree lens: horizontal hierarchy over the same `space.json` dataset as Graph — folders as columns, files stacked beside their parent. Deep-link `#/tree`. |
+| `js/views/chat.js` | The Chat view: Plane-B chat (`/api/chat/prompt` → SSE stream → transcript refetch) with session sidebar, project binding for new sessions, and mini-markdown rendering. Works across claude_code / hermes / openclaw. Deliberately unregistered — no tab. |
 | `js/views/wiki.js` | The Wiki view: bundled, version-matched operating documentation. It includes storage architecture, watcher internals, complete `.xo` / `.quirq` data catalogs, and flow-building recipes. |
+| `js/views/quirq.js` | The Quirq view: machine-local `.quirq` watcher state beside portable project `.xo` output. No tab of its own — `nav:false, parent:'secrets'`, opened from Setup's header button (`#/quirq`). |
+| `js/views/secrets.js` | The Setup view: storage roots, agent runtime, watcher coverage, write-only credentials, git self-update, managed restart. |
 | `js/core/markdown.js` | Escape-first mini-markdown (fences, inline code, bold/italic, links, headings, lists). |
 
-See `AGENTS.md` in this folder for the view contract and working rules.
+The view contract (`id`/`label`/`order`/`nav`/`parent`/`section`, mount/show/hide)
+is documented in the header comment of `js/core/registry.js`; repo-wide working
+rules are in the root `AGENTS.md`.
 
 ## How it's served
 
@@ -57,8 +64,8 @@ spring stiffness makes the original explicit-Euler sim diverge (positions hit
 
 ## Sessions tab
 
-The fourth topbar tab (`Graph | Timeline | Six Degrees | Sessions`) is an
-Argus telemetry dashboard: Claude Code session stats rendered as cards,
+The fourth topbar tab (`Dashboard | Files | Timeline | Sessions | Wiki |
+Setup`) is an Argus telemetry dashboard: Claude Code session stats rendered as cards,
 tables, and hand-drawn canvas charts (no dependencies), re-skinned to the
 Space theme. It lives in its own module (`js/views/sessions.js`), independent
 of the atlas's `boot()` — either can fail without taking the other down, and

--- a/space_ui/css/base.css
+++ b/space_ui/css/base.css
@@ -1,7 +1,7 @@
   :root{
     --bg:#0b0c0f; --bg-2:#101318; --bg-3:#161a20;
     --line:#242832; --line-soft:#1b1f27;
-    --ink:#e9e4d9; --ink-2:#b3ada0; --ink-3:#7d786d; --ink-4:#56534b;
+    --ink:#e9e4d9; --ink-2:#b3ada0; --ink-3:#888276; --ink-4:#6f6b61;
     --eng:#a2b56b; --res:#6f93ad; --ops:#cfc9bb; --mkt:#c8674c;
     --accent:#a8d94f; --accent-deep:#83d63a; --err:#c8674c;
     --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,serif;

--- a/space_ui/css/chrome.css
+++ b/space_ui/css/chrome.css
@@ -42,7 +42,7 @@
     border:1px solid var(--line);border-radius:8px;padding:10px 14px}
   .nodata button{font:600 10.5px var(--mono);letter-spacing:.1em;text-transform:uppercase;
     color:#14100a;background:var(--accent);border-radius:999px;padding:9px 18px}
-  /* the full single-row topbar (brand + 9 tabs + root picker + search) needs
+  /* the full single-row topbar (brand + 6 tabs + root picker + search) needs
      ~1400px; below that, reflow to two rows instead of overflowing the page */
   @media (max-width:1400px){
     .topbar{grid-template-columns:auto 1fr;grid-template-rows:auto auto;height:auto;padding:8px 14px;gap:7px 14px}

--- a/space_ui/css/graph.css
+++ b/space_ui/css/graph.css
@@ -83,6 +83,19 @@
   .conn .cdot{width:6px;height:6px;border-radius:50%;flex:none;align-self:center}
   .conn .rel{font:italic 400 11.5px var(--serif);color:var(--ink-3);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
   .conn .yr{margin-left:auto;font:400 10px var(--mono);color:var(--ink-3);white-space:nowrap}
+  /* Todos section — reuses the Files tab's .prj-todo/.tchip vocabulary
+     (projects.css, loaded globally) so a status reads the same in both places. */
+  .psec h4 .tref{float:right;margin-top:-2px;font-size:12px;line-height:1;color:var(--ink-3);
+    padding:2px 5px;border-radius:5px;transition:all .16s var(--ease)}
+  .psec h4 .tref:hover{color:var(--ink);background:var(--bg-3)}
+  .ptally{font:400 9.5px var(--mono);letter-spacing:.12em;color:var(--ink-3);margin:-3px 0 9px}
+  .psec .prj-todo.ptodo{width:100%;text-align:left;padding:5px 6px;border-radius:7px;
+    transition:background .16s var(--ease)}
+  .psec .prj-todo.ptodo:hover{background:var(--bg-3)}
+  .psec .prj-todo.ptodo .tcontent{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .psec .prj-todo.ptodo .truntime{margin-left:auto}
+  /* the dot on the map was clicked: show which row it is */
+  .psec .prj-todo.is-flash{background:rgba(168,217,79,.16);box-shadow:inset 0 0 0 1px rgba(168,217,79,.4)}
   .pacts{display:flex;flex-wrap:wrap;gap:7px;padding:16px 22px 22px}
   .pacts button{
     font:400 10.5px var(--mono);letter-spacing:.1em;text-transform:uppercase;color:var(--ink-2);

--- a/space_ui/css/preview.css
+++ b/space_ui/css/preview.css
@@ -1,0 +1,71 @@
+/* ============================== FILE PREVIEWER ==============================
+   A right-side drawer, wider than the graph's detail panel because it shows
+   documents rather than metadata. Slides over the stage; the view underneath
+   keeps its state, which is the point — previewing a file must not navigate. */
+  #preview{
+    position:fixed;top:var(--topbar-h);right:0;bottom:var(--footer-h);
+    width:min(620px,52vw);z-index:60;display:flex;flex-direction:column;
+    background:rgba(13,16,20,.975);backdrop-filter:blur(18px);
+    border-left:1px solid var(--line);
+    transform:translateX(102%);transition:transform .30s var(--ease);
+  }
+  #preview.is-open{transform:translateX(0)}
+  @media (max-width:760px){#preview{width:100vw}}
+
+  #preview>header{
+    display:flex;align-items:flex-start;gap:14px;padding:15px 18px 13px;
+    border-bottom:1px solid var(--line-soft);flex:none;
+  }
+  .pv-title{min-width:0;flex:1}
+  .pv-title b{display:block;font:500 15px/1.25 var(--serif);color:var(--ink);
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .pv-title code{display:block;margin-top:3px;font:400 10.5px var(--mono);
+    color:var(--ink-3);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  #preview-meta{display:block;margin-top:5px;font:400 9.5px var(--mono);
+    letter-spacing:.12em;text-transform:uppercase;color:var(--ink-4)}
+  .pv-acts{display:flex;align-items:center;gap:7px;flex:none}
+  .pv-acts button{
+    font:400 10px var(--mono);letter-spacing:.1em;text-transform:uppercase;
+    color:var(--ink-2);border:1px solid var(--line);border-radius:999px;
+    padding:5px 11px;transition:all .16s var(--ease);
+  }
+  .pv-acts button:hover{color:var(--ink);border-color:#39404d;background:var(--bg-3)}
+  #preview-close{border:0;font-size:13px;padding:4px 7px;letter-spacing:0}
+
+  .pv-body{flex:1;min-height:0;overflow:auto;padding:18px 22px 26px}
+  .pv-note{color:var(--ink-3);font-size:12.5px;line-height:1.55;padding:6px 0}
+  .pv-src{
+    font:400 12px/1.65 var(--mono);color:var(--ink-2);white-space:pre-wrap;
+    word-break:break-word;tab-size:2;
+  }
+  /* The sandboxed document paints its own background, so give it a surface
+     that reads as "another document", not as part of this page. */
+  .pv-frame{
+    width:100%;height:calc(100% - 4px);min-height:420px;border:1px solid var(--line-soft);
+    border-radius:9px;background:#fff;
+  }
+
+  /* rendered markdown — same restrained typography as the wiki articles */
+  .pv-md{font-size:13.5px;line-height:1.68;color:var(--ink-2)}
+  .pv-md h1,.pv-md h2,.pv-md h3,.pv-md h4,.pv-md h5,.pv-md h6{
+    font-family:var(--serif);font-weight:500;color:var(--ink);line-height:1.25;
+    margin:22px 0 9px;letter-spacing:-.01em}
+  .pv-md h1{font-size:23px;margin-top:4px}
+  .pv-md h2{font-size:19px}
+  .pv-md h3{font-size:16px}
+  .pv-md h4,.pv-md h5,.pv-md h6{font-size:14px}
+  .pv-md p,.pv-md ul,.pv-md ol,.pv-md blockquote,.pv-md table{margin:0 0 12px}
+  .pv-md ul,.pv-md ol{padding-left:20px}
+  .pv-md li{margin:3px 0}
+  .pv-md a{color:var(--accent);text-decoration:underline;text-underline-offset:2px}
+  .pv-md code{font:400 11.5px var(--mono);color:var(--accent);background:var(--bg-3);
+    border:1px solid var(--line-soft);border-radius:5px;padding:1px 5px}
+  .pv-md pre{background:var(--bg-3);border:1px solid var(--line-soft);border-radius:9px;
+    padding:12px 14px;overflow-x:auto;margin:0 0 13px}
+  .pv-md pre code{border:0;background:none;padding:0;color:var(--ink-2);font-size:11.5px}
+  .pv-md blockquote{border-left:2px solid var(--line);padding-left:13px;color:var(--ink-3)}
+  .pv-md hr{border:0;border-top:1px solid var(--line-soft);margin:18px 0}
+  .pv-md table{border-collapse:collapse;width:100%;font-size:12.5px}
+  .pv-md th,.pv-md td{border:1px solid var(--line-soft);padding:6px 9px;text-align:left}
+  .pv-md th{color:var(--ink);background:var(--bg-3);font-weight:500}
+  .pv-md img{max-width:100%}

--- a/space_ui/css/projects.css
+++ b/space_ui/css/projects.css
@@ -1,29 +1,244 @@
-  /* ---------------- projects tab ---------------- */
+  /* ---------------- projects tab (Files → List lens) ---------------- */
   #view-projects{overflow-y:auto}
   .prj{max-width:1180px;margin:0 auto;padding:26px 26px 60px;font-family:var(--sans)}
-  .prj-head{display:flex;align-items:center;margin-bottom:18px}
-  .prj-head .fileslens-list{margin-right:14px}
-  .prj-map{font:400 9.5px var(--mono);letter-spacing:.08em;text-transform:uppercase;
-    color:var(--ink-2);border:1px solid var(--line);border-radius:999px;padding:4px 10px;margin-left:12px}
-  .prj-map:hover{color:var(--ink);border-color:#39404d}
-  .prj-eyebrow{font:600 10.5px/1 var(--mono);letter-spacing:.14em;color:var(--ink-3)}
+
+  /* header strip: lens pill · summary · filter · sort · refresh */
+  .prj-head{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:16px}
+  .prj-head .fileslens-list{margin-right:2px}
+  .prj-eyebrow{font:600 10.5px/1 var(--mono);letter-spacing:.14em;color:var(--ink-3);
+    text-transform:uppercase}
   .prj-spacer{flex:1}
-  .prj-rows{display:flex;flex-direction:column;gap:10px}
-  .prj-row{background:var(--bg-2);border:1px solid var(--line-soft);border-radius:12px}
-  .prj-row.is-open{border-color:var(--line)}
-  .prj-row-head{display:flex;align-items:center;gap:10px;padding:13px 16px;cursor:pointer;font-size:13.5px;color:var(--ink)}
-  .prj-row-head:hover b{color:var(--accent)}
-  .prj-row-head .caret{color:var(--ink-3);font-size:11px;width:12px;flex:none}
+  .prj-sort{display:flex;gap:2px;background:var(--bg-2);border:1px solid var(--line-soft);
+    border-radius:999px;padding:2px}
+  .prj-sort button{font:500 9.5px var(--mono);letter-spacing:.1em;text-transform:uppercase;
+    color:var(--ink-3);border-radius:999px;padding:5px 10px;transition:all .16s var(--ease)}
+  .prj-sort button:hover{color:var(--ink)}
+  .prj-sort button.is-on{color:var(--bg);background:var(--accent)}
+
+  /* Column headers share the row's grid AND its box model — same tracks,
+     same padding, same trailing Map slot — so labels sit exactly over their
+     values instead of near them. */
+  .prj-cols-inner,.prj-row-head{
+    display:grid;
+    grid-template-columns:14px minmax(0,1fr) 68px 150px 132px;
+    align-items:center;gap:14px;
+  }
+  .prj-cols{display:flex;gap:8px;padding:0 14px 7px 0;font:600 10px var(--mono);
+    letter-spacing:.16em;text-transform:uppercase;color:var(--ink-3)}
+  .prj-cols-inner{flex:1;min-width:0;padding:0 4px 0 17px}
+  .prj-cols-map{flex:none;min-width:62px}
+
+  .prj-rows{display:flex;flex-direction:column;gap:8px}
+  .prj-row{background:var(--bg-2);border:1px solid var(--line-soft);border-radius:12px;
+    transition:border-color .16s var(--ease),background .16s var(--ease)}
+  .prj-row:hover{border-color:var(--line)}
+  .prj-row.is-open{border-color:#2c3240;background:var(--bg-3)}
+  .prj-row.is-empty .prj-name b{color:var(--ink-2)}
+  .prj-line{display:flex;align-items:stretch;gap:8px;padding-right:14px}
+  .prj-row-head{flex:1;min-width:0;text-align:left;padding:12px 4px 12px 17px;
+    border-radius:12px 0 0 12px;color:var(--ink)}
+  .prj-row-head:hover .prj-name b{color:var(--accent)}
+  .prj-row-head:focus-visible{outline:2px solid var(--accent);outline-offset:-2px}
+  .prj-row-head .caret{color:var(--ink-4);font-size:10px;transition:color .16s var(--ease)}
+  .prj-row.is-open .prj-row-head .caret{color:var(--accent)}
+  .prj-cell{min-width:0;display:flex;align-items:baseline;gap:8px}
+  .prj-name{flex-wrap:wrap}
+  .prj-name b{font-size:14px;font-weight:500;color:var(--ink);overflow:hidden;
+    text-overflow:ellipsis;white-space:nowrap}
+  .prj-name em{font:400 10.5px var(--mono);font-style:normal;color:var(--ink-3)}
+  .prj-name small{flex:1 0 100%;font-size:12px;color:var(--ink-3);overflow:hidden;
+    text-overflow:ellipsis;white-space:nowrap}
+  /* live dot: the only saturated thing in a row, because it is the only
+     thing that is happening right now */
+  .prj-live{font:600 9.5px var(--mono);letter-spacing:.12em;text-transform:uppercase;
+    color:var(--accent);align-items:center}
+  .prj-live i{width:6px;height:6px;border-radius:50%;background:var(--accent);
+    box-shadow:0 0 0 3px rgba(168,217,79,.14)}
+  .prj-live.is-idle{min-height:6px}
+  .prj-num{font:400 11px var(--mono);color:var(--ink-2);white-space:nowrap;gap:7px}
+  .prj-num em{font-style:normal;color:var(--ink-3)}
+  .prj-num.is-none{color:var(--ink-3)}
+  .prj-when{font:400 10.5px var(--mono);letter-spacing:.04em;color:var(--ink-3);
+    white-space:nowrap}
+  .prj-when.is-none{color:var(--ink-3)}
+  .prj-map{align-self:center;font:600 9.5px var(--mono);letter-spacing:.1em;
+    text-transform:uppercase;color:var(--ink-3);background:var(--bg-3);
+    border:1px solid var(--line);border-radius:999px;padding:7px 13px;flex:none;
+    min-width:62px;transition:all .16s var(--ease)}
+  .prj-map:hover{color:var(--accent);border-color:var(--accent);background:transparent}
+  .prj-map:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+
+  /* skeletons: a shaped placeholder says "loading" without the word */
+  .prj-skel{height:52px;border-radius:12px;background:linear-gradient(90deg,
+    var(--bg-2) 0%,var(--bg-3) 40%,var(--bg-2) 80%);background-size:280% 100%;
+    animation:prjshimmer 1.5s var(--ease) infinite}
+  .prj-skel.is-sm{height:15px;border-radius:5px;margin:0 0 7px;max-width:min(100%,420px)}
+  @keyframes prjshimmer{from{background-position:120% 0}to{background-position:-60% 0}}
+  @media (prefers-reduced-motion:reduce){.prj-skel{animation:none}}
+
+  .prj-empty{padding:46px 22px;text-align:center;border:1px dashed var(--line);
+    border-radius:12px;background:var(--bg-2)}
+  .prj-empty b{display:block;font:500 15px var(--serif);color:var(--ink);margin-bottom:7px}
+  .prj-empty p{font-size:12.5px;color:var(--ink-3);max-width:52ch;margin:0 auto;line-height:1.6}
+
+  /* drawer */
   .prj-desc{color:var(--ink-2);font-size:12.5px;margin:0 0 12px;max-width:70ch}
-  .prj-drawer{padding:2px 16px 16px 38px;border-top:1px solid var(--line-soft)}
-  .prj-panels{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px;align-items:start}
-  .prj-panel{background:var(--bg-3);border:1px solid var(--line-soft);border-radius:9px;padding:12px 14px}
-  .prj-ptitle{font:600 10px/1 var(--mono);letter-spacing:.14em;text-transform:uppercase;color:var(--ink-3);margin-bottom:9px}
+  .prj-drawer{padding:14px 16px 16px 17px;border-top:1px solid var(--line-soft)}
+  .prj-panels{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
+  .prj-panel{background:var(--bg-2);border:1px solid var(--line-soft);border-radius:10px;
+    padding:12px 14px;min-height:98px;display:flex;flex-direction:column}
+  .prj-row.is-open .prj-panel{background:var(--bg-2)}
+  .prj-ptitle{font:600 9.5px/1 var(--mono);letter-spacing:.16em;text-transform:uppercase;
+    color:var(--ink-3);margin-bottom:10px;flex:none}
+  .prj-pbody{flex:1;min-height:0}
+  /* one-line empty states sit centred so a 1-line and a 2-line note leave the
+     same box height — the ragged bottom edge was the loudest broken thing */
+  .prj-pbody>.prj-note:only-child{display:flex;align-items:center;min-height:44px}
   .prj-note{color:var(--ink-3);font-size:12px;line-height:1.5}
   .prj-todos,.prj-list{display:flex;flex-direction:column;gap:6px}
   .prj-todo,.prj-li{display:flex;align-items:baseline;gap:8px;font-size:12.5px;color:var(--ink-2)}
   .prj-todo .tcontent{min-width:0}
   .prj-todo .tcontent.done{color:var(--ink-3);text-decoration:line-through}
+  @media (max-width:1000px){
+    .prj-cols{display:none}
+    .prj-row-head{grid-template-columns:14px minmax(0,1fr) auto;
+      grid-template-areas:'c n live' '. files when';row-gap:6px;padding:12px 4px 12px 15px}
+    .prj-row-head .caret{grid-area:c}
+    .prj-name{grid-area:n}
+    .prj-live{grid-area:live}
+    .prj-num{grid-area:files}
+    .prj-when{grid-area:when;justify-content:flex-end}
+    .prj-panels{grid-template-columns:minmax(0,1fr)}
+  }
+
+  /* Tree lens — the workspace as a horizontal tree that grows left to right.
+     Root at the left, one column per level of depth, files as a card of
+     leaves hanging off the branch that holds them. Branch thickness carries
+     how much a limb holds, so the shape reads as growth rather than as an
+     indented list turned on its side. */
+  .tv{height:100%;display:flex;flex-direction:column;padding:14px 0 0;min-height:0}
+  .tv-head{display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:0 18px 10px;
+    border-bottom:1px solid var(--line-soft)}
+  .tv-filter{width:190px;background:var(--bg-3);border:1px solid var(--line);border-radius:7px;
+    padding:5px 9px;font-size:12px;color:var(--ink)}
+  .tv-filter:focus{outline:none;border-color:#39404d}
+  .tv-scroll{flex:1;min-height:0;overflow:auto;
+    /* a faint vignette so the canvas reads as a surface you pan around */
+    background:radial-gradient(120% 90% at 8% 40%,rgba(168,217,79,.035),transparent 62%)}
+  .tv-surface{position:relative}
+
+  /* ---- branches ---- */
+  .tv-links{position:absolute;inset:0;pointer-events:none;overflow:visible}
+  .tv-link{fill:none;stroke:#39424f;stroke-linecap:round;opacity:.9}
+  .tv-link.is-leaf{stroke:#2f3742;stroke-dasharray:2.5 3.5}
+  /* new limbs draw themselves in, oldest trick in the book and the clearest
+     way to show that a branch just grew */
+  .tv-surface.is-growing .tv-link{animation:tvdraw .42s var(--ease) both}
+  @keyframes tvdraw{from{stroke-dashoffset:1;opacity:0}to{stroke-dashoffset:0;opacity:.9}}
+  .tv-surface.is-growing .tv-link{stroke-dasharray:1}
+  .tv-surface.is-growing .tv-link.is-leaf{stroke-dasharray:1}
+
+  /* ---- nodes ---- */
+  .tv-node{
+    position:absolute;display:grid;grid-template-columns:var(--bud,8px) minmax(0,1fr) 10px;
+    align-items:center;column-gap:9px;width:188px;height:34px;padding:0 10px 0 9px;
+    text-align:left;border-radius:9px;
+    /* deeper branches sit visually further back */
+    background:color-mix(in srgb,var(--bg-3) calc(100% - var(--depth,0)*9%),var(--bg-2));
+    border:1px solid var(--line-soft);
+    transition:border-color .16s var(--ease),background .16s var(--ease),
+      transform .16s var(--ease);
+  }
+  .tv-node:hover{border-color:#3c4655;transform:translateX(2px)}
+  .tv-node:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .tv-node.is-open{border-color:#39424f}
+  .tv-node.is-root{width:196px;height:38px;background:var(--bg-2);border-color:var(--line)}
+  /* the bud: sized by what the branch holds, filled once it is open */
+  .tv-bud{width:var(--bud,8px);height:var(--bud,8px);border-radius:50%;
+    border:1.5px solid var(--accent);opacity:.55;transition:all .16s var(--ease)}
+  .tv-node.is-open .tv-bud{background:var(--accent);opacity:1;
+    box-shadow:0 0 0 3px rgba(168,217,79,.12)}
+  .tv-node.is-empty .tv-bud{border-color:var(--ink-4);opacity:.4}
+  .tv-node:hover .tv-bud{opacity:1}
+  .tv-label{min-width:0;display:flex;flex-direction:column;gap:1px}
+  .tv-node .tv-name{font-size:12.5px;color:var(--ink);line-height:1.15;
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .tv-node.is-project .tv-name{color:var(--accent);font-weight:500}
+  .tv-node.is-root .tv-name{font:500 13.5px var(--serif);color:var(--ink)}
+  .tv-node .tv-count{font:400 9px var(--mono);letter-spacing:.06em;color:var(--ink-4);
+    line-height:1.15;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .tv-caret{color:var(--ink-4);font-size:8px;justify-self:end}
+  .tv-node.is-open .tv-caret{color:var(--accent)}
+
+  /* ---- leaf cards ---- */
+  .tv-stack{position:absolute;width:196px;padding:7px 0 8px;border-radius:9px;
+    background:rgba(16,19,24,.62);border:1px solid var(--line-soft)}
+  .tv-stack-head{font:600 8.5px var(--mono);letter-spacing:.16em;text-transform:uppercase;
+    color:var(--ink-4);padding:0 10px 5px;margin-bottom:2px;
+    border-bottom:1px solid var(--line-soft)}
+  .tv-leaf{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:8px;align-items:baseline;
+    width:100%;text-align:left;height:20px;padding:0 10px;border-radius:5px}
+  .tv-leaf:hover{background:var(--bg-3)}
+  .tv-leaf:focus-visible{outline:2px solid var(--accent);outline-offset:-2px}
+  .tv-leaf .tv-name{font-size:11.5px;color:var(--ink-2);overflow:hidden;
+    text-overflow:ellipsis;white-space:nowrap}
+  .tv-leaf:hover .tv-name{color:var(--ink)}
+  .tv-leaf .tv-tag{font:400 8.5px var(--mono);letter-spacing:.08em;color:var(--ink-4);
+    text-transform:uppercase}
+  .tv-leaf.is-more{color:var(--accent);font:500 9.5px var(--mono);letter-spacing:.1em;
+    text-transform:uppercase;margin-top:3px}
+
+  /* ---- growth ---- */
+  .tv-node.is-new,.tv-stack.is-new{animation:tvgrow .34s var(--ease) both}
+  @keyframes tvgrow{
+    from{opacity:0;transform:translateX(-16px) scale(.94)}
+    to{opacity:1;transform:none}
+  }
+  @media (prefers-reduced-motion:reduce){
+    .tv-node.is-new,.tv-stack.is-new,.tv-surface.is-growing .tv-link{animation:none}
+    .tv-node:hover{transform:none}
+  }
+
+  /* file explorer (Files panel of a project drawer) */
+  .prj-panel-wide{grid-column:1/-1}
+  .fx-crumbs{display:flex;align-items:baseline;flex-wrap:wrap;gap:4px;margin-bottom:6px;
+    font:500 12px var(--mono)}
+  .fx-crumb{color:var(--ink-3);padding:2px 4px;border-radius:4px}
+  .fx-crumb:hover{color:var(--ink);background:var(--bg-2)}
+  .fx-sep{color:var(--ink-4)}
+  .fx-here{color:var(--ink)}
+  .fx-meta{font:400 10px var(--mono);letter-spacing:.1em;text-transform:uppercase;
+    color:var(--ink-3);margin-bottom:9px}
+  /* folders left, files right; on a narrow drawer they stack */
+  /* stretch, not start: sized to its own content the folders pane rendered
+     its divider as a 63px tick beside a 180px file list */
+  .fx-body{display:grid;grid-template-columns:minmax(190px,270px) minmax(0,1fr);gap:16px;
+    align-items:stretch}
+  .fx-body.is-files-only{grid-template-columns:minmax(0,1fr)}
+  @media (max-width:900px){.fx-body{grid-template-columns:minmax(0,1fr)}}
+  .fx-pane{display:flex;flex-direction:column;max-height:430px;min-height:0;
+    overflow-y:auto;padding-right:4px}
+  .fx-dirs{border-right:1px solid var(--line-soft);padding-right:12px}
+  @media (max-width:900px){.fx-dirs{border-right:0;padding-right:4px;max-height:220px}}
+  .fx-row{display:grid;grid-template-columns:14px minmax(0,1fr) auto auto;gap:10px;
+    align-items:baseline;width:100%;text-align:left;padding:5px 7px;border-radius:7px;
+    font-size:13px;color:var(--ink-2)}
+  /* cap the measure so size and date sit beside the name instead of 540px
+     away at the panel edge, and give the eye a rule to track along */
+  .fx-files .fx-row{grid-template-columns:14px minmax(0,460px) 78px 84px;
+    justify-content:start;column-gap:12px}
+  .fx-files .fx-row+.fx-row{box-shadow:inset 0 1px 0 var(--line-soft)}
+  .fx-files .fx-size{text-align:right}
+  .fx-dirs .fx-row{grid-template-columns:14px minmax(0,1fr) auto}
+  button.fx-row:hover{background:var(--bg-2);color:var(--ink)}
+  .fx-row.is-dir .fx-name{color:var(--ink)}
+  .fx-row.is-up .fx-name{color:var(--ink-3)}
+  .fx-ico{color:var(--ink-4);font-size:9px;line-height:1.5}
+  .fx-row.is-dir .fx-ico{color:var(--accent)}
+  .fx-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  .fx-size,.fx-when{font:400 11px var(--mono);color:var(--ink-3);white-space:nowrap}
+  .fx-when{min-width:70px;text-align:right}
+
   .tchip{font:500 10px/1 var(--mono);color:var(--ink-2);background:var(--bg-2);border:1px solid var(--line);border-radius:5px;padding:3px 6px;flex:none;white-space:nowrap}
   .tchip.st-in_progress{color:var(--accent);border-color:var(--accent)}
   .tchip.st-pending{color:var(--ink-2)}

--- a/space_ui/css/quirq.css
+++ b/space_ui/css/quirq.css
@@ -9,8 +9,9 @@
 .quirq-hero h1{font:500 clamp(34px,4vw,54px)/1 var(--serif);letter-spacing:-.03em}
 .quirq-hero h1 em{color:var(--accent);font-style:normal}
 .quirq-hero p{max-width:700px;margin-top:11px;color:var(--ink-2);font-size:13.5px;line-height:1.55}
-#quirq-refresh{flex:none;border:1px solid var(--line);border-radius:999px;padding:8px 15px;font:600 9px var(--mono);letter-spacing:.1em;text-transform:uppercase;color:var(--ink-2)}
-#quirq-refresh:hover{border-color:#46505e;color:var(--ink)}
+.quirq-hero-actions{display:flex;flex:none;align-items:center;gap:8px}
+#quirq-refresh,#quirq-back{flex:none;border:1px solid var(--line);border-radius:999px;padding:8px 15px;font:600 9px var(--mono);letter-spacing:.1em;text-transform:uppercase;color:var(--ink-2)}
+#quirq-refresh:hover,#quirq-back:hover{border-color:#46505e;color:var(--ink)}
 #quirq-refresh:disabled{opacity:.5;cursor:wait}
 .quirq-path{display:grid;grid-template-columns:minmax(0,1.2fr) minmax(0,1fr) auto;align-items:center;gap:18px;margin-bottom:10px;padding:13px 16px;border:1px solid var(--line);border-radius:12px;background:rgba(16,19,24,.76)}
 .quirq-path>div{min-width:0}

--- a/space_ui/index.html
+++ b/space_ui/index.html
@@ -3,16 +3,17 @@
 <title>XO Space</title>
 <style>html{color-scheme:dark}</style>
 </head><body>
-<link rel="stylesheet" href="css/base.css">
+<link rel="stylesheet" href="css/base.css?v=20260817-a11y1">
 <link rel="stylesheet" href="css/stage.css?v=20260813-wikisetup1">
-<link rel="stylesheet" href="css/graph.css?v=20260813-files2">
+<link rel="stylesheet" href="css/graph.css?v=20260816-todos1">
 <link rel="stylesheet" href="css/sessions.css?v=20260725-sessions2">
 <link rel="stylesheet" href="css/timeline.css?v=20260813-timeline2">
 <link rel="stylesheet" href="css/chrome.css?v=20260813-timeline2">
-<link rel="stylesheet" href="css/projects.css?v=20260813-files2">
+<link rel="stylesheet" href="css/projects.css?v=20260817-a11y1">
 <link rel="stylesheet" href="css/wiki.css?v=20260725-collaboration1">
-<link rel="stylesheet" href="css/quirq.css?v=20260725-quirq2">
+<link rel="stylesheet" href="css/quirq.css?v=20260816-navswap1">
 <link rel="stylesheet" href="css/secrets.css?v=20260813-update1">
+<link rel="stylesheet" href="css/preview.css?v=20260816-preview1">
 
 <div class="topbar">
   <div class="brand">
@@ -52,6 +53,7 @@
     <div class="ov atlas-lens-switch fileslens" id="fileslens-graph" aria-label="Files lens" hidden>
       <button type="button" data-files-lens="projects">List</button>
       <button class="is-on" type="button" data-files-lens="graph">Graph</button>
+      <button type="button" data-files-lens="tree">Tree</button>
     </div>
     <p class="ov" id="hint"><b>Click</b> a node to focus its neighbourhood &middot; <b>Double-click</b> a cluster to open or close it &middot; <b>Drag</b> to reposition &middot; <b>Scroll</b> to zoom</p>
     <div class="ov" id="legend"></div>
@@ -100,6 +102,23 @@
   <div class="scroll" id="panel-scroll"></div>
 </aside>
 
+<!-- file previewer (core/preview.js; any view opens it via space:preview-file) -->
+<aside id="preview">
+  <header>
+    <div class="pv-title">
+      <b id="preview-name"></b>
+      <code id="preview-path"></code>
+      <span id="preview-meta"></span>
+    </div>
+    <div class="pv-acts">
+      <button id="preview-source" type="button" hidden>Source</button>
+      <button id="preview-graph" type="button" title="Focus this file on the graph">Graph</button>
+      <button id="preview-close" type="button" title="Close (Esc)">&#10005;</button>
+    </div>
+  </header>
+  <div class="pv-body" id="preview-body"></div>
+</aside>
+
 <!-- hover card -->
 <div id="hc"></div>
 <div id="toast"></div>
@@ -119,6 +138,6 @@
   <div class="meta" id="fmeta"></div>
 </footer>
 
-<script type="module" src="js/app.js?v=20260813-timeline3"></script>
+<script type="module" src="js/app.js?v=20260817-a11y1"></script>
 
 </body></html>

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -3,14 +3,16 @@
    bundler, so no file globbing; this import list is the one manual step. */
 import {registerView,startRegistry} from './core/registry.js?v=20260813-timeline2';
 import {initServerWidget} from './core/server-widget.js';
-import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260813-timeline3';
+import {initPreview} from './core/preview.js?v=20260816-preview1';
+import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260816-preview1';
 import sessionsView from './views/sessions.js?v=20260725-sessions2';
-import projectsView from './views/projects.js?v=20260813-files2';
+import projectsView from './views/projects.js?v=20260817-a11y1';
+import treeView from './views/tree.js?v=20260817-tree3';
 /* Chat is deliberately hidden from the tab bar: re-import ./views/chat.js
    and register it below to bring the tab back. */
-import wikiView from './views/wiki.js?v=20260813-timeline3';
-import quirqView from './views/quirq.js?v=20260725-quirq3';
-import secretsView from './views/secrets.js?v=20260813-update1';
+import wikiView from './views/wiki.js?v=20260817-files3';
+import quirqView from './views/quirq.js?v=20260816-navswap1';
+import secretsView from './views/secrets.js?v=20260816-navswap1';
 
 /* app-shell bulkhead: a fatal script error logs instead of white-screening */
 addEventListener('error',e=>console.error('Space shell error:',e.error||e.message));
@@ -22,6 +24,7 @@ try{
   registerView(timeView);
   registerView(sessionsView);
   registerView(projectsView);
+  registerView(treeView);
   registerView(wikiView);
   registerView(quirqView);
   registerView(secretsView);
@@ -29,3 +32,4 @@ try{
 }catch(err){console.error('Space registry failed to start:',err);}
 
 try{initServerWidget();}catch(err){console.error('Server widget failed to start:',err);}
+try{initPreview();}catch(err){console.error('Previewer failed to start:',err);}

--- a/space_ui/js/core/preview.js
+++ b/space_ui/js/core/preview.js
@@ -1,0 +1,123 @@
+/* File previewer — a side drawer that renders one file from a project.
+
+   Lives in core/, not in a view, because three surfaces open it (the Tree
+   lens, the Files explorer, the graph's detail panel) and views never import
+   each other. They dispatch `space:preview-file` with {project, path, name}
+   and this module owns everything after that.
+
+   Rendering rules, in order of how much they matter:
+     - markdown goes through core/markdown.js, which escapes before it
+       transforms and emits only fixed attribute-free tags;
+     - HTML from disk is NEVER injected into this document. It renders in an
+       iframe with an empty sandbox: no scripts, no same-origin, no forms, no
+       top-level navigation. A file in the workspace is not trusted content —
+       an agent wrote it — and the app it would otherwise be running inside
+       holds the user's session;
+     - anything else renders as escaped source text.
+   The Source toggle shows raw text for every kind, which is also the escape
+   hatch when a render looks wrong. */
+import {API_BASE,apiFetch} from './api.js';
+import {mdToHtml} from './markdown.js';
+
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const bytes=n=>n==null?'':n<1024?n+' B'
+  :n<1048576?(n/1024).toFixed(n<10240?1:0)+' KB':(n/1048576).toFixed(1)+' MB';
+function rel(iso){
+  if(!iso)return'';
+  const s=(Date.now()-new Date(iso).getTime())/1000;
+  if(!isFinite(s))return'';
+  if(s<60)return'just now';
+  if(s<3600)return Math.floor(s/60)+'m ago';
+  if(s<86400)return Math.floor(s/3600)+'h ago';
+  return Math.floor(s/86400)+'d ago';
+}
+
+let el=null,body=null;
+let current=null;   /* {project,path,name} */
+let data=null;      /* the loaded payload */
+let source=false;   /* Source toggle */
+let token=0;        /* race guard: only the newest request may paint */
+
+export function initPreview(){
+  el=document.getElementById('preview');
+  if(!el)return;
+  body=el.querySelector('#preview-body');
+  el.addEventListener('click',onClick);
+  addEventListener('space:preview-file',e=>open(e.detail||{}));
+  addEventListener('keydown',e=>{
+    /* Escape closes the preview first; the graph's own Escape handling only
+       gets it once nothing is being previewed. */
+    if(e.key==='Escape'&&el.classList.contains('is-open')){e.stopPropagation();close();}
+  },true);
+}
+
+async function open({project,path,name}){
+  if(!el||!project||!path)return;
+  current={project,path,name:name||path.split('/').pop()};
+  data=null;source=false;
+  const mine=++token;
+  el.classList.add('is-open');
+  render('<div class="pv-note">loading…</div>');
+  const res=await apiFetch(API_BASE+'/api/xo-projects/'+encodeURIComponent(project)
+    +'/file?relative_path='+encodeURIComponent(path));
+  if(mine!==token)return; /* a newer file is on screen */
+  if(!res.ok){
+    render('<div class="pv-note">'+esc(
+      res.offline?'xo-cowork-api is unreachable'
+      :res.status===415?'No text preview for this file type.'
+      :res.error||'Could not read this file.')+'</div>');
+    return;
+  }
+  data=res.data;
+  render();
+}
+function close(){
+  el.classList.remove('is-open');
+  current=null;data=null;token++;
+  if(body)body.innerHTML='';
+}
+
+function render(placeholder){
+  el.querySelector('#preview-name').textContent=current?current.name:'';
+  el.querySelector('#preview-path').textContent=current
+    ?current.project+'/'+current.path:'';
+  const meta=el.querySelector('#preview-meta');
+  const toggle=el.querySelector('#preview-source');
+  if(placeholder||!data){
+    meta.textContent='';
+    toggle.hidden=true;
+    body.innerHTML=placeholder||'';
+    return;
+  }
+  meta.textContent=[data.kind,bytes(data.size_bytes),rel(data.modified_at),
+    data.truncated?'truncated':''].filter(Boolean).join(' · ');
+  toggle.hidden=false;
+  toggle.textContent=source?'Rendered':'Source';
+  body.innerHTML=source?sourceHTML(data)
+    :data.kind==='markdown'?'<div class="pv-md">'+mdToHtml(data.content)+'</div>'
+    :data.kind==='html'?frameHTML(data)
+    :sourceHTML(data);
+  if(data.truncated)body.insertAdjacentHTML('beforeend',
+    '<div class="pv-note">Showing the first 256 KB of this file.</div>');
+}
+const sourceHTML=d=>'<pre class="pv-src">'+esc(d.content)+'</pre>';
+/* sandbox="" is the whole point: an empty allow-list means no scripts and a
+   unique opaque origin, so the document cannot reach this page, its storage,
+   or the API it is served from. srcdoc keeps it out of the network entirely. */
+const frameHTML=d=>'<iframe class="pv-frame" sandbox="" referrerpolicy="no-referrer" '
+  +'title="'+esc(d.name)+' preview" srcdoc="'+esc(d.content)+'"></iframe>';
+
+function onClick(e){
+  if(e.target.closest('#preview-close')){close();return;}
+  if(e.target.closest('#preview-source')){source=!source;render();return;}
+  if(e.target.closest('#preview-graph')&&current){
+    /* Explicit, never automatic: the point of the previewer is that opening a
+       file does NOT move you somewhere else. Leaf ids in space.json are
+       '<project>:<relative path>'; atlas parks the request if the graph has
+       not booted yet, so dispatch before the route change. */
+    dispatchEvent(new CustomEvent('space:focus-project',
+      {detail:current.project+':'+current.path}));
+    location.hash='#/graph';
+    close();
+  }
+}

--- a/space_ui/js/core/workspace.js
+++ b/space_ui/js/core/workspace.js
@@ -1,0 +1,49 @@
+/* Workspace-wide rollups, in one request.
+
+   The Files List needs a file and folder count per project. Asking each
+   project for its tree would be one request per row; `data/space.json` — the
+   same bounded, server-cached payload the Graph and Tree lenses read — already
+   carries every mapped file as "<project>/<relative path>", so the whole
+   column costs one fetch no matter how many projects there are.
+
+   Lives in core/ because two views need it and views never import each other.
+   Counts are of MAPPED files: space_index caps its scan at 400 leaves per
+   project and 1500 workspace-wide, so a big project reports its capped
+   number. The cap is reported PER PROJECT (`p.capped`) and separately for
+   the workspace total (`totalsCapped`) — a single workspace-wide flag would
+   put a "+" on an 18-file project the moment some other project filled the
+   graph, which is worse than showing no number at all. */
+import {apiFetch} from './api.js';
+
+export async function workspaceCounts(){
+  const res=await apiFetch('data/space.json');
+  if(!res.ok)return{ok:false,error:res.error,offline:res.offline,byProject:new Map(),
+    totals:{projects:0,files:0,folders:0}};
+
+  const byProject=new Map();
+  const ensure=id=>{
+    if(!byProject.has(id))byProject.set(id,{files:0,folders:0,dirs:new Set()});
+    return byProject.get(id);
+  };
+  for(const hub of res.data.hubs||[])ensure(hub.id.replace(/^p_/,''));
+  for(const leaf of res.data.leaves||[]){
+    const parts=String(leaf.path||'').split('/').filter(Boolean);
+    if(parts.length<2)continue;
+    const p=ensure(parts[0]);
+    p.files++;
+    /* every ancestor directory of this file, deduped */
+    for(let i=1;i<parts.length-1;i++)p.dirs.add(parts.slice(1,i+1).join('/'));
+  }
+  let files=0,folders=0;
+  for(const p of byProject.values()){
+    p.folders=p.dirs.size;
+    delete p.dirs;
+    /* MAX_LEAVES_PER_PROJECT in space_index.py */
+    p.capped=p.files>=400;
+    files+=p.files;folders+=p.folders;
+  }
+  return{ok:true,byProject,
+    totals:{projects:byProject.size,files,folders},
+    /* MAX_TOTAL_LEAVES in space_index.py */
+    totalsCapped:(res.data.leaves||[]).length>=1500};
+}

--- a/space_ui/js/views/atlas.js
+++ b/space_ui/js/views/atlas.js
@@ -6,7 +6,7 @@
    forbids). Cross-view jumps go through ctx.switchTo (`go`). All graph
    content comes from ./data/space.json; nothing is embedded here; the data
    lives on disk, next to this page. */
-import {apiFetch} from '../core/api.js';
+import {API_BASE,apiFetch} from '../core/api.js';
 import {toast} from '../core/ui.js';
 
 let go=()=>{};   /* ctx.switchTo, captured on first mount */
@@ -421,6 +421,7 @@ function drawGraph(now){
   const k=cam.k;
   gc.setTransform(dpr*k,0,0,dpr*k,dpr*(GW/2-cam.x*k),dpr*(GH/2-cam.y*k));
   const es=shownEdges(),vs=shownNodes();
+  layoutSats(now);
   const inFocus=id=>!focusSet||focusSet.has(id);
   if(DATA.meta.enclose)drawEnclosures(k);
   /* path reveal progress */
@@ -457,6 +458,7 @@ function drawGraph(now){
     }else{gc.moveTo(a.x,a.y);gc.lineTo(b.x,b.y);}
     gc.strokeStyle=hexA(color,alpha);gc.lineWidth=width;gc.lineCap='round';gc.stroke();
   }
+  drawSatOrbits(k);
   /* ---- nodes ---- */
   const drawOrder=pathIds?[...vs].sort((a,b)=>(pathIds.includes(a.id)?1:0)-(pathIds.includes(b.id)?1:0)):vs;
   for(const n of drawOrder){
@@ -523,6 +525,7 @@ function drawGraph(now){
     }
     gc.globalAlpha=1;
   }
+  drawSatDots(now,k);
   /* ---- labels (screen space) ---- */
   gc.setTransform(dpr,0,0,dpr,0,0);
   gc.textAlign='center';
@@ -555,6 +558,7 @@ function drawGraph(now){
       halo(n.label,sx,sy-n.r*k-7,on?`rgba(233,228,217,${.94*a})`:`rgba(179,173,160,${.62*a})`);
     }
   }
+  drawSatLabels(k);
   gc.globalAlpha=1;
   /* pulse ring */
   if(pulseN){
@@ -602,6 +606,7 @@ function pick(mx,my){
 gcv.addEventListener('pointerdown',e=>{
   gcv.setPointerCapture(e.pointerId);
   downX=lastX=e.clientX;downY=lastY=e.clientY;moved=false;
+  if(pickSat(...evXY(e))){camAnim=null;return;} /* satellites are not bodies */
   const n=pick(...evXY(e));
   if(n&&n.type!=='root'){drag=n;n.fx=n.x;n.fy=n.y;}
   else pan=true;
@@ -619,6 +624,14 @@ gcv.addEventListener('pointermove',e=>{
     lastX=e.clientX;lastY=e.clientY;
     hideHC();
   }else{
+    const s=pickSat(...evXY(e));
+    if(s){
+      if(satHover!==s.key)satHover=s.key;
+      hoverId=null;gcv.style.cursor='pointer';
+      showSatHC(s,e.clientX,e.clientY);
+      return;
+    }
+    satHover=null;
     const n=pick(...evXY(e));
     hoverId=n?n.id:null;
     gcv.style.cursor=n?'pointer':'default';
@@ -634,6 +647,8 @@ gcv.addEventListener('pointerup',e=>{
   }
   pan=false;
   if(moved)return;
+  const sat=pickSat(...evXY(e));
+  if(sat){revealTodoRow(sat);return;}
   const n=pick(...evXY(e));
   const now=performance.now();
   if(now-lastUp<300){
@@ -670,6 +685,7 @@ function select(id,depth,fly=true){
   document.getElementById('crumb-depth').textContent=`${depth} hop${depth>1?'s':''} · ${focusSet.size} nodes`;
   document.getElementById('crumb').classList.add('is-on');
   openPanel(n);
+  syncSats(n);
   if(fly){
     const kT=Math.max(cam.k,1.6);
     const off=GW>760?PANEL_W/2/kT:0;
@@ -680,6 +696,7 @@ function clearFocus(){
   selId=null;focusSet=null;focusDepth=0;
   document.getElementById('crumb').classList.remove('is-on');
   closePanel();
+  clearSats();
 }
 function clearPath(){pathIds=null;pathEdges=null;}
 function setExp(g,v){
@@ -827,7 +844,7 @@ function placeHC(mx,my){
   if(y+r.height>innerHeight-8)y=my-r.height-18;
   hc.style.left=Math.max(8,x)+'px';hc.style.top=Math.max(64,y)+'px';
 }
-function hideHC(){hc.classList.remove('is-on');hoverId=null;}
+function hideHC(){hc.classList.remove('is-on');hoverId=null;satHover=null;}
 
 /* ============================== DETAIL PANEL ============================== */
 const panel=document.getElementById('panel');
@@ -861,13 +878,18 @@ function openPanel(n){
       ${n.path?`<div class="path">${esc(n.path)}</div>`:''}
     </div>
     <div class="psec"><h4>About</h4><p>${esc(n.blurb||'')}</p></div>
+    ${todoSectionHTML(n)}
     ${conns?`<div class="psec"><h4>Connections</h4>${conns}</div>`:''}
     <div class="pacts">
       ${n.type==='leaf'||n.type==='group'?`<button data-act="timeline">Show on timeline</button>`:''}
+      ${previewable(n)?`<button data-act="preview">Preview file</button>`:''}
     </div>`;
   panel.classList.add('is-open');
   panel.dataset.id=n.id;
 }
+/* Only in the graph dataset: there a leaf is a file with a
+   "<project>/<relative path>" path. A dashboard leaf is a whole project. */
+const previewable=n=>bootDataset==='graph'&&n.type==='leaf'&&!!n.path&&n.path.includes('/');
 function closePanel(){panel.classList.remove('is-open');}
 document.getElementById('panel-close').addEventListener('click',()=>{clearFocus();clearPath();});
 panel.addEventListener('click',e=>{
@@ -880,15 +902,288 @@ panel.addEventListener('click',e=>{
     pulseN={id:n.id,t0:performance.now()};
     return;
   }
+  const row=e.target.closest('.ptodo');
+  if(row){
+    satPulse={key:row.dataset.todo,t0:performance.now()};
+    return;
+  }
   const a=e.target.closest('[data-act]');
   if(!a)return;
   const n=byId.get(panel.dataset.id);
-  if(a.dataset.act==='timeline'){traceOnTimeline(n);}
+  if(a.dataset.act==='timeline'){traceOnTimeline(n);return;}
+  if(a.dataset.act==='preview'){
+    const cut=n.path.indexOf('/');
+    dispatchEvent(new CustomEvent('space:preview-file',{detail:{
+      project:n.path.slice(0,cut),path:n.path.slice(cut+1),name:n.label}}));
+    return;
+  }
+  if(a.dataset.act==='todos'){
+    const pid=satHost;
+    if(!pid)return;
+    satCache.delete(pid);
+    satHost=null;            /* defeat syncSats' same-project early return */
+    syncSats(byId.get(pid));
+  }
 });
 function ensureShown(n){
   if(n.type==='leaf'){
     if(!expanded.get(n.group)){setExp(byId.get(n.group),true);reheat(.4);}
   }
+}
+
+/* ============================== TODO SATELLITES ==============================
+   Dashboard only: there a leaf IS an xo-project (leaf id == project id), so
+   selecting one can show its live todos. In the Graph dataset leaves are files
+   and the whole feature stays switched off.
+
+   Satellites are UI state, never graph data: nothing is pushed into NODES /
+   EDGES / byId / LEAVES. The model is built once from the dataset (:136-161)
+   and half a dozen subsystems read it as a snapshot — LEAVES-derived counts,
+   the timeline's lanes and axis, search, the re-root walk. A todo injected
+   there would invent a timeline lane and inflate "N projects"; keeping them
+   out of the model means none of those need to know this feature exists.
+   The cost is that they get no adjacency, so hover/click/label are handled
+   explicitly below. Positions are recomputed from the host each frame, so the
+   constellation follows drags and settling for free without any force. */
+const SAT_DOTS=28;    /* dots drawn — beyond this the orbit reads as noise */
+const SAT_ROWS=40;    /* rows listed in the panel */
+const SAT_TTL=20000;  /* ms a fetched list stays fresh (re-click is instant) */
+const SAT_MIN_K=.55;  /* below this zoom, dots would collide with sibling nodes */
+/* Same order the Files tab lists todos in (projects.js:28). Duplicated rather
+   than imported: views never import each other (see the registry contract). */
+const ST_ORDER={in_progress:0,pending:1,blocked:2,completed:3,cancelled:4};
+const ST_DONE=new Set(['completed','cancelled']);
+const ST_COLOR={in_progress:ACCENT,blocked:'#e0b04c',pending:'#b3ada0',
+  completed:'#7d786d',cancelled:'#7d786d'};
+let satHost=null;    /* project id the constellation belongs to, or null */
+let satRows=[];      /* every todo, ST_ORDER-sorted — the panel's source */
+let satDots=[];      /* satRows.slice(0,SAT_DOTS) — the canvas's source */
+let satState='idle'; /* idle | loading | ready | error */
+let satNote='';      /* one-line reason when state is error */
+let satToken=0;      /* race guard: bumped whenever the selection changes */
+let satT0=0;         /* grow-in start */
+let satHover=null;   /* key of the hovered dot */
+let satPulse=null;   /* {key,t0} — panel row clicked, flash its dot */
+const satCache=new Map();
+
+/* The one gate. Everything else early-returns on a null host. */
+const todoProjectId=n=>bootDataset==='dashboard'&&n&&n.type==='leaf'?n.id:null;
+
+function shapeTodos(res){
+  if(!res.ok){
+    return{rows:[],state:'error',
+      note:res.notImplemented?'todos are not available for the active agent'
+        :res.offline?'xo-cowork-api is unreachable':String(res.error||'could not read todos')};
+  }
+  const rows=[];
+  for(const [sid,sess] of Object.entries(res.data.sessions||{})){
+    for(const t of sess.todos||[]){
+      rows.push({key:sid+'/'+t.id,sid,runtime:sess.runtime||'',
+        status:t.status||'pending',content:t.content||'',
+        st:ST_ORDER[t.status]??9});
+    }
+  }
+  rows.sort((a,b)=>a.st-b.st||a.content.localeCompare(b.content));
+  rows.forEach((r,i)=>{r.i=i;});
+  return{rows,state:'ready',note:'',updated:res.data.updated_at||null};
+}
+function tallyText(){
+  const by=new Map();
+  for(const r of satRows)by.set(r.status,(by.get(r.status)||0)+1);
+  return Object.keys(ST_ORDER)
+    .filter(s=>by.get(s))
+    .map(s=>`${by.get(s)} ${s.replace('_',' ')}`)
+    .join(' · ').toUpperCase();
+}
+
+function syncSats(n){
+  const pid=todoProjectId(n);
+  if(pid&&pid===satHost)return; /* same project re-selected: keep what we have */
+  clearSats();
+  if(!pid)return;
+  satHost=pid;satT0=performance.now();
+  const hit=satCache.get(pid);
+  if(hit&&performance.now()-hit.t<SAT_TTL){applySats(pid,hit,satToken);return;}
+  satState='loading';renderTodoSection();
+  loadSats(pid,satToken);
+}
+async function loadSats(pid,tok){
+  const res=await apiFetch(API_BASE+'/api/xo-projects/'+encodeURIComponent(pid)+'/todos');
+  if(tok!==satToken)return; /* a newer selection owns the screen */
+  const shaped=shapeTodos(res);
+  if(shaped.state==='ready'){
+    if(satCache.size>40)satCache.clear();
+    satCache.set(pid,{t:performance.now(),...shaped});
+  }
+  applySats(pid,shaped,tok);
+}
+function applySats(pid,shaped,tok){
+  /* Two guards, not one: the token catches an A→B→A sequence where the host
+     id alone would let A's older response paint over A's newer one. */
+  if(tok!==satToken||satHost!==pid)return;
+  satRows=shaped.rows;satDots=satRows.slice(0,SAT_DOTS);
+  satState=shaped.state;satNote=shaped.note;
+  renderTodoSection();
+  reheat(.12); /* nudge the loop so the grow-in animates from a settled layout */
+}
+function clearSats(){
+  satToken++;satHost=null;satRows=[];satDots=[];
+  satState='idle';satNote='';satHover=null;satPulse=null;
+}
+
+/* Concentric shells at roughly constant arc spacing: 10, 16, 22, … */
+function satSlot(i){
+  let shell=0,base=0;
+  for(;;){const cap=10+shell*6;if(i<base+cap)return{shell,slot:i-base,cap};base+=cap;shell++;}
+}
+/* The host must exist, be selected, and be on screen. A group can be collapsed
+   out from under a live selection (double-clicking its hub, :654) — without
+   this the constellation would hang in empty space. */
+function satAnchor(){
+  if(!satHost||!satDots.length)return null;
+  const host=byId.get(satHost);
+  return host&&isShown(host)?host:null;
+}
+function layoutSats(now){
+  const host=satAnchor();
+  if(!host)return;
+  const grow=REDUCED?1:easeCubicInOut(Math.min(1,(now-satT0)/380));
+  for(const s of satDots){
+    const{shell,slot,cap}=satSlot(s.i);
+    const a=slot/cap*Math.PI*2+shell*.31; /* fixed angle: hit-testing stays exact */
+    const rr=(host.r+26+shell*19)*grow;
+    s.x=host.x+Math.cos(a)*rr;s.y=host.y+Math.sin(a)*rr;
+    s.r=s.status==='in_progress'?4.2:s.status==='blocked'?3.6:ST_DONE.has(s.status)?2.4:3.2;
+  }
+}
+function drawSatOrbits(k){
+  const host=satAnchor();
+  if(!host||k<SAT_MIN_K)return;
+  const col=CAT[host.cat]?.color||'#b3ada0';
+  const shells=new Set(satDots.map(s=>satSlot(s.i).shell));
+  for(const shell of shells){
+    gc.beginPath();gc.arc(host.x,host.y,host.r+26+shell*19,0,Math.PI*2);
+    gc.strokeStyle=hexA(col,.10);gc.lineWidth=.7/k;gc.stroke();
+  }
+  /* One spoke per in-progress todo only: 28 spokes is a starburst, but the
+     handful of things actually in flight deserve a line back to the project. */
+  for(const s of satDots){
+    if(s.status!=='in_progress')continue;
+    const dx=s.x-host.x,dy=s.y-host.y,d=Math.hypot(dx,dy)||1;
+    gc.beginPath();
+    gc.moveTo(host.x+dx/d*(host.r+5),host.y+dy/d*(host.r+5));
+    gc.lineTo(s.x,s.y);
+    gc.strokeStyle=hexA(ACCENT,.34);gc.lineWidth=.9/k;gc.stroke();
+  }
+}
+function drawSatDots(now,k){
+  const host=satAnchor();
+  if(!host||k<SAT_MIN_K)return;
+  for(const s of satDots){
+    const col=ST_COLOR[s.status]||'#b3ada0';
+    const done=ST_DONE.has(s.status);
+    const on=s.key===satHover;
+    if(s.status==='in_progress'&&!REDUCED){
+      const b=.5+.5*Math.sin(now/520);
+      gc.beginPath();gc.arc(s.x,s.y,s.r+2.6+b*1.4,0,Math.PI*2);
+      gc.fillStyle=hexA(ACCENT,.10+b*.08);gc.fill();
+    }
+    gc.beginPath();gc.arc(s.x,s.y,s.r+(on?1.2:0),0,Math.PI*2);
+    if(s.status==='pending'){
+      gc.strokeStyle=hexA(col,on?.95:.6);gc.lineWidth=1.2/Math.sqrt(k);gc.stroke();
+    }else{
+      gc.fillStyle=hexA(col,done?.34:on?1:.88);gc.fill();
+    }
+    if(satPulse&&satPulse.key===s.key){
+      const t=(now-satPulse.t0)/900;
+      if(t>1)satPulse=null;
+      else{
+        gc.beginPath();gc.arc(s.x,s.y,s.r+2+t*16,0,Math.PI*2);
+        gc.strokeStyle=hexA(ACCENT,(1-t)*.8);gc.lineWidth=1.6/Math.sqrt(k);gc.stroke();
+      }
+    }
+  }
+}
+/* Screen space — called with the label transform already set. */
+function drawSatLabels(k){
+  const host=satAnchor();
+  if(!host)return;
+  const sx=(host.x-cam.x)*k+GW/2,sy=(host.y-cam.y)*k+GH/2;
+  gc.font='400 8.5px '+MONO;
+  const total=satRows.length;
+  /* Clear of the outermost shell, not of the node: the caption sitting inside
+     the orbit collides with the dots at the bottom of the constellation. */
+  const shells=Math.max(...satDots.map(s=>satSlot(s.i).shell))+1;
+  const out=(host.r+26+(shells-1)*19)*k+15;
+  halo(`${total} TODO${total===1?'':'S'}`,sx,sy+out,'rgba(168,217,79,.9)',.14);
+  const s=satDots.find(d=>d.key===satHover);
+  if(!s||k<SAT_MIN_K)return;
+  gc.font='400 10.5px '+SANS;
+  const t=s.content.length>44?s.content.slice(0,43)+'…':s.content;
+  halo(t,(s.x-cam.x)*k+GW/2,(s.y-cam.y)*k+GH/2-s.r*k-7,'rgba(233,228,217,.95)');
+}
+function pickSat(mx,my){
+  const host=satAnchor();
+  if(!host||cam.k<SAT_MIN_K)return null;
+  const w=toWorld(mx,my);
+  let best=null,bd=1e9;
+  for(const s of satDots){
+    const d=Math.hypot(s.x-w.x,s.y-w.y);
+    /* Deliberately tighter than pick()'s 12/k floor: a generous satellite
+       radius would swallow clicks meant for a neighbouring project. */
+    const hit=Math.max(s.r+2.5/cam.k,7/cam.k);
+    if(d<hit&&d<bd){bd=d;best=s;}
+  }
+  return best;
+}
+function showSatHC(s,mx,my){
+  const col=ST_COLOR[s.status]||'#b3ada0';
+  hc.innerHTML=`
+    <div class="art" style="background:linear-gradient(155deg, ${hexA(col,.24)}, ${hexA(col,.03)} 68%)">
+      <div class="kicker">Todo · ${esc(s.status.replace('_',' '))}</div>
+      <h5>${esc(s.content)}</h5>
+    </div>
+    <dl><dt>Project</dt><dd>${esc(satHost||'')}</dd>
+      ${s.runtime?`<dt>Runtime</dt><dd>${esc(s.runtime)}</dd>`:''}</dl>
+    <div class="foot">Click to find it in the list</div>`;
+  placeHC(mx,my);
+}
+/* Canvas → panel. The list is where the full text lives, so a dot click
+   scrolls to its row and flashes it rather than opening anything new. */
+function revealTodoRow(s){
+  const row=panel.querySelector(`[data-todo="${CSS.escape(s.key)}"]`);
+  if(!row)return;
+  row.scrollIntoView({block:'nearest'});
+  row.classList.add('is-flash');
+  setTimeout(()=>row.classList.remove('is-flash'),900);
+}
+
+function todoSectionHTML(n){
+  return todoProjectId(n)?`<div class="psec" id="panel-todos">${todoBodyHTML()}</div>`:'';
+}
+function todoBodyHTML(){
+  const head=`<h4>Todos<button class="tref" data-act="todos" title="Re-fetch todos">&#8635;</button></h4>`;
+  if(satState==='loading')return head+`<div class="prj-note">loading…</div>`;
+  if(satState==='error')return head+`<div class="prj-note">${esc(satNote)}</div>`;
+  if(!satRows.length)return head+`<div class="prj-note">no todos recorded yet</div>`;
+  const shown=satRows.slice(0,SAT_ROWS);
+  return head
+    +`<div class="ptally">${esc(tallyText())}</div>`
+    +`<div class="prj-todos">`+shown.map(t=>
+      `<button class="prj-todo ptodo" data-todo="${esc(t.key)}">
+        <span class="tchip st-${esc(t.status)}">${esc(t.status.replace('_',' '))}</span>
+        <span class="tcontent${ST_DONE.has(t.status)?' done':''}">${esc(t.content)}</span>
+        ${t.runtime?`<span class="truntime">${esc(t.runtime)}</span>`:''}
+      </button>`).join('')+`</div>`
+    +(satRows.length>shown.length?`<div class="prj-note">+${satRows.length-shown.length} more</div>`:'')
+    +(satRows.length>SAT_DOTS?`<div class="prj-note">${SAT_DOTS} of ${satRows.length} shown on the map</div>`:'');
+}
+/* Patch only this subtree: re-rendering the whole panel would reset its
+   scroll position and give the section two sources of truth. */
+function renderTodoSection(){
+  const el=document.getElementById('panel-todos');
+  if(!el||panel.dataset.id!==satHost)return;
+  el.innerHTML=todoBodyHTML();
 }
 
 /* ============================== SEARCH ============================== */
@@ -978,6 +1273,7 @@ hooks.focusProject=()=>{
   const n=byId.get('p_'+pendingFocus)||byId.get(pendingFocus);
   pendingFocus=null;
   if(!n)return;
+  ensureShown(n); /* a leaf handed over from the Tree lens may sit in a closed group */
   clearPath();
   select(n.id,1);
   pulseN={id:n.id,t0:performance.now()};
@@ -1015,6 +1311,18 @@ const MILES=DATA.milestones;
 const GITHIST=DATA.gitHistory||{};
 const histLanes=Object.keys(CAT).filter(cat=>(GITHIST[cat]||[]).length);
 const hasHist=histLanes.length>0;
+/* Both modes plot git dates only, so a project with no repository has no
+   lane at all. Files counts every project; without this note the Timeline
+   silently shows fewer and reads as broken data rather than as the absence
+   of git history it actually is. */
+const fileLanes=()=>Object.keys(CAT).filter(cat=>LEAVES.some(n=>n.cat===cat&&n.date));
+function coverageNote(){
+  const total=Object.keys(CAT).length;
+  const shown=(tMode==='project'?histLanes:fileLanes()).length;
+  const missing=total-shown;
+  if(!total||missing<=0)return'';
+  return ` Showing ${shown} of ${total} project${total===1?'':'s'}: ${missing} ${missing===1?'has':'have'} no git history to date (dates come from commits only).`;
+}
 const TMODE_KEY='space.timelineMode';
 let tMode='file';
 try{if(localStorage.getItem(TMODE_KEY)==='project'&&hasHist)tMode='project';}catch(_err){}
@@ -1027,9 +1335,13 @@ document.querySelectorAll('#tmode [data-tmode]').forEach(button=>{
   button.addEventListener('click',()=>setTMode(button.dataset.tmode));
 });
 function defaultSub(){
-  if(tMode==='project')return'Every project’s git history in parallel · newest at the top · dot size = commits that day.';
-  return DATA.meta.timelineSub||
-    'Scrub through the workspace as it grew, newest at the top. Open any cluster from the graph to watch its run unfold here.';
+  if(tMode==='project'){
+    return'Every project’s git history in parallel · newest at the top · dot size = commits that day.'
+      +coverageNote();
+  }
+  return(DATA.meta.timelineSub||
+    'Scrub through the workspace as it grew, newest at the top. Open any cluster from the graph to watch its run unfold here.')
+    +coverageNote();
 }
 function syncTModeUI(){
   document.querySelectorAll('#tmode [data-tmode]').forEach(button=>{

--- a/space_ui/js/views/projects.js
+++ b/space_ui/js/views/projects.js
@@ -5,6 +5,7 @@
    one dead source degrades one panel. Writes (todos CRUD, backup/restore)
    are deliberately not wired yet; the sync-vs-git decision is open. */
 import {API_BASE,apiFetch} from '../core/api.js';
+import {workspaceCounts} from '../core/workspace.js';
 
 const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
 const dtfmt=iso=>iso?new Date(iso).toLocaleString(undefined,{dateStyle:'medium',timeStyle:'short'}):'—';
@@ -61,7 +62,80 @@ function rTimeline(d){
     +'</div>').join('')+'</div>';
 }
 
+/* ── file explorer ──────────────────────────────────────────────────────────
+   One folder at a time from GET /api/xo-projects/{id}/tree?relative_path=…,
+   which is bounded and path-safe server-side. Browsing state is per project
+   (cwd) so reopening a drawer returns you to the folder you were in. */
+const cwd=new Map(); /* projectId -> relative path, '' = project root */
+const bytes=n=>{
+  if(n==null)return'';
+  if(n<1024)return n+' B';
+  if(n<1024*1024)return (n/1024).toFixed(n<10240?1:0)+' KB';
+  if(n<1024*1024*1024)return (n/1048576).toFixed(1)+' MB';
+  return (n/1073741824).toFixed(1)+' GB';
+};
+function crumbs(id,rel){
+  const parts=rel?rel.split('/'):[];
+  const out=['<button class="fx-crumb" data-cd="" data-id="'+esc(id)+'">'+esc(id)+'</button>'];
+  let acc='';
+  parts.forEach((p,i)=>{
+    acc=acc?acc+'/'+p:p;
+    out.push('<span class="fx-sep">/</span>');
+    out.push(i===parts.length-1
+      ?'<b class="fx-here">'+esc(p)+'</b>'
+      :'<button class="fx-crumb" data-cd="'+esc(acc)+'" data-id="'+esc(id)+'">'+esc(p)+'</button>');
+  });
+  return'<div class="fx-crumbs">'+out.join('')+'</div>';
+}
+/* Two panes: folders on the left (the thing you navigate with), files on the
+   right (the thing you read). One list mixing both makes you hunt for the
+   folder rows among fifty files every time you go a level deeper. */
+function dirRow(id,e,up){
+  return'<button class="fx-row is-dir'+(up?' is-up':'')+'" '
+    +'data-cd="'+esc(e.relative_path)+'" data-id="'+esc(id)+'">'
+    +'<span class="fx-ico">'+(up?'&#8629;':'&#9654;')+'</span>'
+    +'<span class="fx-name">'+esc(e.name)+'</span>'
+    +'<span class="fx-size">'+(up||e.entries==null?''
+        :e.entries+' item'+(e.entries===1?'':'s'))+'</span>'
+  +'</button>';
+}
+function fileRow(e,id){
+  return'<button class="fx-row is-file" data-file="'+esc(e.relative_path)+'" '
+    +'data-project="'+esc(id)+'">'
+    +'<span class="fx-ico">&#183;</span>'
+    +'<span class="fx-name" title="'+esc(e.name)+'">'+esc(e.name)+'</span>'
+    +'<span class="fx-size">'+bytes(e.size_bytes)+'</span>'
+    +'<span class="fx-when">'+rel2(e.modified_at)+'</span>'
+  +'</button>';
+}
+function rTree(d){
+  const id=d.project_id,rel=d.relative_path||'';
+  cwd.set(id,rel); /* trust the server's answer over our optimistic guess */
+  const dirs=[
+    ...(rel?[{up:true,name:'..',relative_path:d.parent_relative_path||''}]:[]),
+    ...d.dirs,
+  ];
+  if(!d.dirs.length&&!d.files.length&&!rel)
+    return crumbs(id,rel)+'<div class="prj-note">this project has no files yet</div>';
+  return crumbs(id,rel)
+    +'<div class="fx-meta">'+d.dirs.length+' folder'+(d.dirs.length===1?'':'s')
+      +' · '+d.files.length+' file'+(d.files.length===1?'':'s')+'</div>'
+    +'<div class="fx-body'+(dirs.length?'':' is-files-only')+'">'
+      +(dirs.length
+        ?'<div class="fx-pane fx-dirs">'+dirs.map(e=>dirRow(id,e,e.up)).join('')+'</div>'
+        :'')
+      +'<div class="fx-pane fx-files">'
+        +(d.files.length?d.files.map(f=>fileRow(f,id)).join('')
+          :'<div class="prj-note">no files in this folder</div>')
+      +'</div>'
+    +'</div>';
+}
+const rel2=iso=>iso?rel(iso):'';
+
 const PANELS=[
+  {key:'files',   title:'Files',        path:id=>'/api/xo-projects/'+encodeURIComponent(id)+'/tree'
+                                              +(cwd.get(id)?'?relative_path='+encodeURIComponent(cwd.get(id)):''),
+                                                                                                 render:rTree},
   {key:'todos',   title:'Todos',        path:id=>'/api/xo-projects/'+encodeURIComponent(id)+'/todos',            render:rTodos},
   {key:'activity',title:'Open sessions',path:id=>'/api/xo-projects/'+encodeURIComponent(id)+'/activity',         render:rActivity},
   {key:'timeline',title:'Recent events',path:id=>'/api/xo-projects/'+encodeURIComponent(id)+'/timeline?limit=20',render:rTimeline},
@@ -69,85 +143,287 @@ const PANELS=[
 
 let root=null,items=null,expanded=null;
 let switchTo=()=>{}; /* ctx.switchTo, captured on mount */
+/* Workspace-wide rollups: four requests total, whatever the project count.
+   Each degrades on its own — a dead timeline costs the "last active" column,
+   not the list. */
+let counts=new Map();      /* id -> {files,folders} from space.json */
+let live=new Map();        /* id -> {agents:[…], since} from the workspace activity */
+let lastEvent=new Map();   /* id -> ISO of the newest workspace event */
+let capped=false;
+let filter='',sortK='activity';
+const SORTS=[['activity','Activity'],['name','Name'],['files','Files'],['created','Created']];
 
 export default {
-  /* The Files tab lands here, on the List lens; the Graph lens (atlas) is
-     nav:false with parent:'projects' so this tab stays lit for both. */
+  /* The Files tab lands here, on the List lens; the Graph and Tree lenses are
+     nav:false with parent:'projects' so this tab stays lit for all three. */
   id:'projects',label:'Files',order:1,
   async mount(el,ctx){
     root=el;
     switchTo=ctx.switchTo;
-    el.innerHTML='<div class="prj"><div class="prj-note">loading projects…</div></div>';
+    el.innerHTML='<div class="prj">'+skeleton()+'</div>';
     await loadList();
   },
   show(){/* keep whatever the user had open; Refresh re-fetches */}
 };
 
+const skeleton=()=>'<div class="prj-head"></div><div class="prj-rows">'
+  +'<div class="prj-skel"></div>'.repeat(4)+'</div>';
+
 async function loadList(){
-  const res=await apiFetch(API_BASE+'/api/xo-projects');
   const box=root.querySelector('.prj');
-  if(!res.ok){box.innerHTML='<div class="prj-head"><span class="prj-eyebrow">PROJECTS</span></div>'+panelFail(res);return;}
-  items=res.data.items||[];
-  expanded=null;
+  const btn=root.querySelector('#prj-refresh');
+  if(btn){btn.disabled=true;btn.classList.add('is-busy');}
+  /* One barrier, deliberately: the row grid is a table and a table with
+     columns arriving one by one reads as broken. Four requests, not 4×N. */
+  const [list,ws,act,tl]=await Promise.all([
+    apiFetch(API_BASE+'/api/xo-projects'),
+    workspaceCounts(),
+    apiFetch(API_BASE+'/api/xo-projects/activity'),
+    apiFetch(API_BASE+'/api/xo-projects/timeline?limit=200'),
+  ]);
+  if(!list.ok){
+    box.innerHTML=head(0)+panelFail(list);
+    bindHead();
+    return;
+  }
+  items=list.data.items||[];
+  counts=ws.byProject||new Map();
+  capped=!!ws.totalsCapped;
+  live=new Map();
+  if(act.ok)for(const s of act.data.open_sessions||[]){
+    const id=s.project_id||s.agent;
+    if(!id)continue;
+    const e=live.get(id)||{agents:new Set(),since:null};
+    e.agents.add(s.runtime||s.agent||'agent');
+    const t=s.last_activity_at||s.opened_at;
+    if(t&&(!e.since||t>e.since))e.since=t;
+    live.set(id,e);
+  }
+  lastEvent=new Map();
+  if(tl.ok)for(const ev of tl.data.events||[]){
+    const id=ev.project_id;
+    if(!id||!ev.ts)continue;
+    if(!lastEvent.has(id)||ev.ts>lastEvent.get(id))lastEvent.set(id,ev.ts);
+  }
+  /* Refresh must not close what you were reading. */
+  if(expanded&&!items.some(p=>p.id===expanded))expanded=null;
   render();
 }
-function render(){
-  const un=items.filter(p=>p.unscaffolded).length;
-  root.querySelector('.prj').innerHTML=
-    '<div class="prj-head">'
+
+const filesOf=id=>counts.get(id)?.files??null;
+const activityOf=p=>live.has(p.id)?'9999':(lastEvent.get(p.id)||p.created_at||'');
+function visible(){
+  const q=filter.trim().toLowerCase();
+  const rows=items.filter(p=>!q
+    ||p.id.toLowerCase().includes(q)
+    ||String(p.display_name||'').toLowerCase().includes(q));
+  const by={
+    name:(a,b)=>String(a.display_name||a.id).localeCompare(String(b.display_name||b.id)),
+    files:(a,b)=>(filesOf(b.id)??-1)-(filesOf(a.id)??-1),
+    created:(a,b)=>String(b.created_at||'').localeCompare(String(a.created_at||'')),
+    activity:(a,b)=>String(activityOf(b)).localeCompare(String(activityOf(a))),
+  };
+  return rows.sort(by[sortK]||by.activity);
+}
+
+function summary(shown){
+  const t={projects:items?items.length:0,
+    files:[...counts.values()].reduce((s,c)=>s+c.files,0),
+    folders:[...counts.values()].reduce((s,c)=>s+c.folders,0)};
+  const un=(items||[]).filter(p=>p.unscaffolded).length;
+  return t.projects+' projects'
+    +(t.files?' · '+t.files.toLocaleString()+(capped?'+':'')+' files · '
+      +t.folders.toLocaleString()+' folders':'')
+    +(un?' · '+un+' unscaffolded':'')
+    +(shown!==undefined&&shown!==t.projects?' · '+shown+' shown':'');
+}
+function head(n){
+  return'<div class="prj-head">'
     +'<div class="atlas-lens-switch fileslens-list" aria-label="Files lens">'
       +'<button class="is-on" type="button" data-files-lens="projects">List</button>'
       +'<button type="button" data-files-lens="graph">Graph</button>'
+      +'<button type="button" data-files-lens="tree">Tree</button>'
     +'</div>'
-    +'<span class="prj-eyebrow">PROJECTS · '+items.length
-      +(un?' · '+un+' unscaffolded':'')+'</span>'
+    +'<span class="prj-eyebrow" id="prj-count">'+esc(summary(n))+'</span>'
     +'<span class="prj-spacer"></span>'
-    +'<button class="sess-refresh" id="prj-refresh" title="Re-fetch the project list">&#8635; Refresh</button></div>'
-    +(items.length?'<div class="prj-rows">'+items.map(rowHTML).join('')+'</div>'
-      :'<div class="prj-note">no projects in the workspace yet</div>');
-  document.getElementById('prj-refresh').addEventListener('click',loadList);
-  root.querySelectorAll('[data-files-lens]').forEach(b=>
-    b.addEventListener('click',()=>switchTo(b.dataset.filesLens)));
-  root.querySelectorAll('.prj-row-head').forEach(h=>h.addEventListener('click',()=>toggle(h.dataset.id)));
-  root.querySelectorAll('.prj-map').forEach(b=>b.addEventListener('click',e=>{
-    e.stopPropagation();
+    +'<input class="tv-filter" id="prj-filter" placeholder="Filter projects…" '
+      +'autocomplete="off" spellcheck="false" aria-label="Filter projects" '
+      +'value="'+esc(filter)+'">'
+    +'<div class="prj-sort" role="group" aria-label="Sort projects">'
+      +SORTS.map(([k,label])=>'<button type="button" data-sort="'+k+'"'
+        +(sortK===k?' class="is-on" aria-pressed="true"':' aria-pressed="false"')
+        +'>'+label+'</button>').join('')
+    +'</div>'
+    +'<button class="sess-refresh" id="prj-refresh" title="Re-fetch the project list">'
+      +'&#8635; Refresh</button>'
+  +'</div>';
+}
+
+function render(){
+  const rows=visible();
+  root.querySelector('.prj').innerHTML=
+    head(rows.length)
+    +'<div class="prj-body">'+rowsHTML(rows)+'</div>';
+  bindHead();
+  bindRows();
+  if(expanded)fillDrawer(expanded);
+}
+/* Repaint the rows only. Rebuilding the head would destroy the filter input
+   mid-keystroke and throw the caret to the end — which is what the old
+   focus/setSelectionRange hack was papering over. */
+function renderRows(){
+  const rows=visible();
+  const box=root.querySelector('.prj-body');
+  if(!box){render();return;}
+  box.innerHTML=rowsHTML(rows);
+  bindRows();
+  const count=root.querySelector('#prj-count');
+  if(count)count.textContent=summary(rows.length);
+  if(expanded)fillDrawer(expanded);
+}
+function rowsHTML(rows){
+  return(rows.length
+      ?'<div class="prj-cols" aria-hidden="true">'
+        +'<div class="prj-cols-inner"><span></span><span>Project</span><span></span>'
+          +'<span>Files</span><span>Last active</span></div>'
+        +'<span class="prj-cols-map"></span>'
+      +'</div><div class="prj-rows">'+rows.map(rowHTML).join('')+'</div>'
+      :'<div class="prj-empty">'
+        +(items.length?'<b>No project matches “'+esc(filter)+'”</b>'
+            +'<p>Clear the filter to see all '+items.length+'.</p>'
+          :'<b>No projects in this workspace yet</b>'
+            +'<p>Create one through the xo-cowork-api; it appears here as soon as the '
+            +'folder exists under the XO root.</p>')
+      +'</div>');
+}
+function bindRows(){
+  root.querySelectorAll('.prj-row-head').forEach(h=>
+    h.addEventListener('click',()=>toggle(h.dataset.id)));
+  root.querySelectorAll('.prj-map').forEach(b=>b.addEventListener('click',()=>{
     switchTo('graph');
     dispatchEvent(new CustomEvent('space:focus-project',{detail:b.dataset.map}));
   }));
-  if(expanded)fillDrawer(expanded);
 }
+function syncSortUI(){
+  root.querySelectorAll('[data-sort]').forEach(b=>{
+    const on=b.dataset.sort===sortK;
+    b.classList.toggle('is-on',on);
+    b.setAttribute('aria-pressed',on?'true':'false');
+  });
+}
+let fdeb=null;
+function bindHead(){
+  const r=root.querySelector('#prj-refresh');
+  if(r)r.addEventListener('click',loadList);
+  root.querySelectorAll('[data-files-lens]').forEach(b=>
+    b.addEventListener('click',()=>switchTo(b.dataset.filesLens)));
+  root.querySelectorAll('[data-sort]').forEach(b=>
+    b.addEventListener('click',()=>{sortK=b.dataset.sort;syncSortUI();renderRows();}));
+  const f=root.querySelector('#prj-filter');
+  if(f)f.addEventListener('input',e=>{
+    filter=e.target.value;
+    clearTimeout(fdeb);
+    fdeb=setTimeout(renderRows,140);
+  });
+}
+
+function liveCell(p){
+  const l=live.get(p.id);
+  if(!l)return'<span class="prj-cell prj-live is-idle"></span>';
+  const agents=[...l.agents].join(', ');
+  return'<span class="prj-cell prj-live" title="'+esc(agents)+' · active '+esc(rel(l.since))+'">'
+    +'<i></i>live</span>';
+}
+function filesCell(p){
+  const c=counts.get(p.id);
+  if(!c)return'<span class="prj-cell prj-num is-none">—</span>';
+  if(!c.files)return'<span class="prj-cell prj-num is-none">no files yet</span>';
+  return'<span class="prj-cell prj-num">'+c.files.toLocaleString()+(c.capped?'+':'')+' files'
+    +(c.folders?'<em>'+c.folders.toLocaleString()+' folders</em>':'')+'</span>';
+}
+function whenCell(p){
+  const l=live.get(p.id);
+  const ts=l?l.since:lastEvent.get(p.id);
+  if(ts)return'<span class="prj-cell prj-when" title="'+esc(dtfmt(ts))+'">'+esc(rel(ts))+'</span>';
+  return'<span class="prj-cell prj-when is-none" title="'+esc(dtfmt(p.created_at))+'">created '
+    +esc(rel(p.created_at))+'</span>';
+}
+
 function rowHTML(p){
   const open=expanded===p.id;
-  return'<div class="prj-row'+(open?' is-open':'')+'" id="prj-row-'+esc(p.id)+'">'
-    +'<div class="prj-row-head" data-id="'+esc(p.id)+'">'
-    +'<span class="caret">'+(open?'&#9662;':'&#9656;')+'</span>'
-    +'<b>'+esc(p.display_name)+'</b>'
-    +(p.id!==p.display_name?'<span class="truntime">'+esc(p.id)+'</span>':'')
-    +(p.unscaffolded?'<span class="tchip st-blocked">unscaffolded</span>':'')
-    +'<span class="prj-spacer"></span>'
-    +'<span class="tmuted">'+(p.created_at?'created '+rel(p.created_at):'')+'</span>'
-    +'<button class="prj-map" type="button" data-map="'+esc(p.id)+'" title="Focus this project on the graph">Map</button>'
+  const empty=counts.get(p.id)&&!counts.get(p.id).files;
+  return'<div class="prj-row'+(open?' is-open':'')+(empty?' is-empty':'')+'" '
+      +'id="prj-row-'+esc(p.id)+'">'
+    +'<div class="prj-line">'
+      /* a real button: keyboard-reachable, and it says what it does to a
+         screen reader. Map sits OUTSIDE it — a button inside a button is
+         invalid markup and is why this used to need stopPropagation. */
+      +'<button class="prj-row-head" type="button" data-id="'+esc(p.id)+'" '
+        +'aria-expanded="'+(open?'true':'false')+'" '
+        +'aria-controls="prj-drawer-'+esc(p.id)+'">'
+        +'<span class="caret" aria-hidden="true">'+(open?'&#9662;':'&#9656;')+'</span>'
+        +'<span class="prj-cell prj-name"><b>'+esc(p.display_name||p.id)+'</b>'
+          +(p.id!==p.display_name?'<em>'+esc(p.id)+'</em>':'')
+          +(p.unscaffolded?'<span class="tchip st-blocked">unscaffolded</span>':'')
+          +(p.description?'<small>'+esc(p.description)+'</small>':'')
+        +'</span>'
+        +liveCell(p)
+        +filesCell(p)
+        +whenCell(p)
+      +'</button>'
+      +'<button class="prj-map" type="button" data-map="'+esc(p.id)+'" '
+        +'title="Focus '+esc(p.display_name||p.id)+' on the graph">Map</button>'
     +'</div>'
-    +(open?'<div class="prj-drawer">'
-      +(p.description?'<p class="prj-desc">'+esc(p.description)+'</p>':'')
+    +(open?'<div class="prj-drawer" id="prj-drawer-'+esc(p.id)+'">'
       +'<div class="prj-panels">'+PANELS.map(pn=>
-        '<div class="prj-panel"><div class="prj-ptitle">'+pn.title+'</div>'
-        +'<div class="prj-pbody" id="prjp-'+pn.key+'"><div class="prj-note">loading…</div></div></div>').join('')
+        '<div class="prj-panel'+(pn.key==='files'?' prj-panel-wide':'')+'">'
+        +'<div class="prj-ptitle">'+pn.title+'</div>'
+        +'<div class="prj-pbody" id="prjp-'+pn.key+'">'
+        +(pn.key==='files'?'<div class="prj-skel is-sm"></div>'.repeat(3)
+          :'<div class="prj-skel is-sm"></div>')
+        +'</div></div>').join('')
       +'</div></div>':'')
     +'</div>';
 }
 function toggle(id){
   expanded=expanded===id?null:id;
   render();
+  if(expanded){
+    const row=document.getElementById('prj-row-'+expanded);
+    if(row)row.querySelector('.prj-row-head').focus({preventScroll:true});
+  }
 }
 /* three independent fetches per drawer — no barrier, no shared failure */
 function fillDrawer(id){
   for(const pn of PANELS)fillPanel(id,pn);
 }
 async function fillPanel(id,pn){
-  const res=await apiFetch(API_BASE+pn.path(id));
+  let res=await apiFetch(API_BASE+pn.path(id));
+  /* An agent can delete the folder you are standing in. cwd outlives the
+     drawer, so without this the panel renders one grey sentence with no
+     crumb and no "..", and reopening the row reproduces it forever. */
+  if(!res.ok&&pn.key==='files'&&res.status===404&&cwd.get(id)){
+    cwd.set(id,'');
+    res=await apiFetch(API_BASE+pn.path(id));
+  }
   if(expanded!==id)return; /* drawer changed while in flight */
   const el=document.getElementById('prjp-'+pn.key);
   if(!el)return;
-  el.innerHTML=res.ok?pn.render(res.data):panelFail(res);
+  el.innerHTML=res.ok?pn.render(res.data)
+    /* keep the breadcrumb outside the response so a failed fetch cannot
+       take the way back with it */
+    :(pn.key==='files'?crumbs(id,cwd.get(id)||''):'')+panelFail(res);
+  if(pn.key!=='files')return;
+  el.querySelectorAll('[data-cd]').forEach(b=>
+    b.addEventListener('click',()=>{
+      cwd.set(b.dataset.id,b.dataset.cd);
+      el.innerHTML='<div class="prj-note">loading…</div>';
+      fillPanel(b.dataset.id,pn);
+    }));
+  /* Opening a file previews it beside the list — the drawer stays open and
+     the list keeps its position. */
+  el.querySelectorAll('[data-file]').forEach(b=>
+    b.addEventListener('click',()=>dispatchEvent(new CustomEvent('space:preview-file',{
+      detail:{project:b.dataset.project,path:b.dataset.file,
+        name:b.querySelector('.fx-name').textContent}}))));
 }

--- a/space_ui/js/views/quirq.js
+++ b/space_ui/js/views/quirq.js
@@ -16,10 +16,14 @@ let timer=null;
 let loading=false;
 let go=()=>{};
 
+/* No top-level tab: Quirq opens from the button in Setup's header (and stays
+   deep-linkable at #/quirq); Setup's tab lights up while it is open. It stays
+   its own view rather than a card inside Setup so its 10s refresh and full
+   state tree keep a page to themselves. */
 export default {
   id:'quirq',
   label:'Quirq',
-  order:8,
+  order:8,nav:false,parent:'secrets',
   async mount(el,ctx){
     root=el;
     go=ctx.switchTo;
@@ -51,7 +55,12 @@ function renderShell(){
           +'<h1>Inside <em>.quirq</em></h1>'
           +'<p>A live, privacy-aware map of installation state, watcher cursors, runtime configuration, credentials, and ephemeral activity.</p>'
         +'</div>'
-        +'<button id="quirq-refresh" type="button">Refresh data</button>'
+        /* This view has no tab of its own — every other control on the page
+           leads further away, so the way home belongs in the hero. */
+        +'<div class="quirq-hero-actions">'
+          +'<button id="quirq-back" type="button" data-go-view="secrets">&#8592; Setup</button>'
+          +'<button id="quirq-refresh" type="button">Refresh data</button>'
+        +'</div>'
       +'</header>'
       +'<section class="quirq-path" id="quirq-path"><div class="quirq-skeleton"></div></section>'
       +'<section class="quirq-metrics" id="quirq-metrics" aria-label="Quirq state metrics"></section>'

--- a/space_ui/js/views/secrets.js
+++ b/space_ui/js/views/secrets.js
@@ -36,7 +36,7 @@ export default {
   show(){/* Preserve an in-progress credential while switching tabs. */}
 };
 
-let switchTo=()=>{}; /* ctx.switchTo, captured on mount (opens the wiki) */
+let switchTo=()=>{}; /* ctx.switchTo, captured on mount (opens the Quirq view) */
 
 function renderShell(){
   root.innerHTML=
@@ -48,7 +48,7 @@ function renderShell(){
           +'<p>Choose the active agent, connect its native session store, tune the watcher, and provide credentials from one place.</p>'
         +'</div>'
         +'<div class="setup-hero-actions">'
-          +'<button class="setup-refresh" id="setup-wiki" type="button">Open the wiki</button>'
+          +'<button class="setup-refresh" id="setup-quirq" type="button">Open Quirq state</button>'
           +'<button class="setup-refresh" id="setup-refresh" type="button">Refresh status</button>'
         +'</div>'
       +'</header>'
@@ -64,7 +64,7 @@ function renderShell(){
             +'<div>'
               +'<label for="xo-root-input">XO root</label>'
               +'<input id="xo-root-input" type="text" autocomplete="off" spellcheck="false" placeholder="/Users/you/xo-projects">'
-              +'<small>Host folder containing project directories. Selecting a new root does not move project files.</small>'
+              +'<small>Host folder containing project directories — the one root the whole app reads. Selecting a new root does not move project files.</small>'
               +'<code id="xo-root-applied">Mounted now: checking…</code>'
             +'</div>'
             +'<div>'
@@ -76,7 +76,7 @@ function renderShell(){
           +'</div>'
           +'<div class="setup-form-error" id="roots-error" role="alert" hidden></div>'
           +'<div class="setup-root-apply" id="roots-apply" hidden>'
-            +'<div><b>Server restart required</b><p>Storage roots are applied when the server starts. Run this same one-command installer to restart with both roots.</p></div>'
+            +'<div><b>Server restart required</b><p>Saved roots are read at startup: restart the server and every tab reads the new XO root. On installer-managed containers, run the one-command installer instead — it also remaps the bind mounts.</p></div>'
             +'<pre id="roots-command"></pre>'
           +'</div>'
           +'<div class="setup-actions">'
@@ -171,7 +171,7 @@ function renderShell(){
 }
 
 function bindEvents(){
-  root.querySelector('#setup-wiki').addEventListener('click',()=>switchTo('wiki'));
+  root.querySelector('#setup-quirq').addEventListener('click',()=>switchTo('quirq'));
   root.querySelector('#setup-refresh').addEventListener('click',loadAll);
   runtimeForm.addEventListener('submit',saveRuntime);
   root.querySelector('#roots-form').addEventListener('submit',saveRoots);
@@ -318,8 +318,8 @@ function renderRuntime(){
   const rootPending=Boolean(runtimeData.roots?.change_required);
   if(rootPending){
     alert.className='setup-alert is-pending';
-    alert.innerHTML='<span aria-hidden="true">◆</span><div><b>New storage roots are saved but not mounted yet.</b>'
-      +'<p>Run the installer command shown below. It restarts the server with the new roots and also applies any pending runtime or credential changes.</p></div>';
+    alert.innerHTML='<span aria-hidden="true">◆</span><div><b>New storage roots are saved but not in use yet.</b>'
+      +'<p>Restart the server to load them — every tab then reads the new XO root. On an installer-managed container, run the command below instead; it also remaps the bind mounts and applies any pending runtime or credential changes.</p></div>';
   }else if(runtimeData.restart_required){
     const reasons=runtimeData.restart_reasons||[];
     const runtimePending=reasons.includes('runtime');
@@ -376,7 +376,7 @@ function renderRoots(){
   root.querySelector('#xo-root-applied').textContent='Mounted now: '+(applied.xo_projects_root||'not reported');
   root.querySelector('#quirq-root-applied').textContent='Mounted now: '+(applied.quirq_state_root||'not reported');
   const badge=root.querySelector('#roots-badge');
-  badge.textContent=roots.change_required?'Pending installer':'Mounted';
+  badge.textContent=roots.change_required?'Pending restart':'In use';
   badge.className=roots.change_required?'is-pending':'is-good';
   const apply=root.querySelector('#roots-apply');
   const copy=root.querySelector('#roots-copy');
@@ -507,7 +507,7 @@ async function saveRoots(event){
   }
   runtimeData=res.data.status;
   renderRuntime();
-  toast(runtimeData.roots?.change_required?'Roots saved — run the installer to apply':'Roots already match the mounted folders');
+  toast(runtimeData.roots?.change_required?'Roots saved — restart to apply':'Roots already match the folders in use');
 }
 
 async function copyRootCommand(){

--- a/space_ui/js/views/tree.js
+++ b/space_ui/js/views/tree.js
@@ -1,0 +1,363 @@
+/* Tree — the third Files lens, beside List and Graph.
+
+   Same data as the Graph (data/space.json: every project, every mapped
+   folder, every mapped file), read as a hierarchy instead of as a force
+   layout. The graph answers "what is near what"; this answers "what is
+   in there", which is the question a file tree is actually good at.
+
+   Shape: a horizontal tree. The workspace root sits on the left, each level
+   of containers opens one column to the right, and the connectors are drawn
+   as curves in an SVG layer under the node chips. Files do NOT get their own
+   column — they stack vertically in one block beside the folder that holds
+   them. A folder with 300 files would otherwise be 300 columns wide, and the
+   sideways scroll would make the tree unreadable; stacking the leaves keeps
+   horizontal distance meaning depth and nothing else.
+
+   It reads the dataset directly rather than borrowing atlas.js's model:
+   views never import each other (see the registry contract), the payload
+   is cached server-side for 30s, and apiFetch single-flights concurrent
+   GETs — so the second reader costs nothing. */
+import {apiFetch} from '../core/api.js';
+
+const esc=s=>String(s??'').replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+
+/* Layout constants, all in px of the (unscaled) tree surface. */
+const COL_W=212;   /* one level of depth */
+const ROW_H=34;    /* a container chip */
+const FILE_H=20;   /* a row in a leaf stack */
+const STACK_PAD=13;/* the leaf card's own padding */
+const GAP=7;       /* between sibling blocks */
+const PAD_X=24,PAD_Y=24;
+/* A folder's files show a dozen at a time. The old cap of 40 made one folder
+   800px tall, which is what pushed its siblings into the far distance and
+   left the big vertical voids. */
+const FILES_SHOWN=12;
+
+let root=null;
+let go=()=>{};
+let model=null;      /* the tree, or null before the first load */
+let open=new Set();  /* expanded keys */
+let filter='';
+let loading=false;
+const expandedStacks=new Set(); /* leaf cards showing all of their files */
+let seen=new Set();             /* keys on screen last render — the rest are new */
+let growing=false;              /* this render came from an expand: draw branches in */
+let scrollLeft=0,scrollTop=0;   /* the surface is re-created each render */
+let anchor=null;                /* {key,offset} — keep this node where it was */
+
+export default {
+  /* No tab of its own: the Files tab owns the nav slot and this is its third
+     lens, reached from the List | Graph | Tree pill (or #/tree). */
+  id:'tree',label:'Tree',order:3,nav:false,parent:'projects',
+  async mount(el,ctx){
+    root=el;
+    go=ctx.switchTo;
+    root.innerHTML='<div class="tv"><div class="prj-note">loading the workspace…</div></div>';
+    root.addEventListener('click',onClick);
+    root.addEventListener('input',onInput);
+    await load();
+  },
+  show(){if(model===null&&!loading)load();}
+};
+
+/* ── model ────────────────────────────────────────────────────────────────
+   space.json is flat: hubs (projects), groups (a project's mapped folders,
+   already split by depth with '__' separators) and leaves (files, carrying
+   `path` = "<project>/<relative path>"). The real folder nesting is in the
+   leaf paths, so the tree is rebuilt from those and the groups are ignored —
+   using them would reproduce the graph's split-for-layout buckets, which are
+   a rendering decision, not a directory structure. */
+function build(data){
+  const mk=(name,kind)=>({name,kind,dirs:new Map(),files:[],nFiles:0,nDirs:0});
+  const workspace=mk(data.root?.label||'xo-projects','root');
+  /* Seed from hubs, not from leaf paths: a project the scan found no mapped
+     files in still exists, and silently dropping it would make the tree
+     disagree with the List and the Graph about how many projects there are. */
+  for(const hub of data.hubs||[]){
+    const id=hub.id.replace(/^p_/,'');
+    const node=mk(id,'project');
+    node.label=hub.label||id;
+    workspace.dirs.set(id,node);
+  }
+
+  for(const leaf of data.leaves||[]){
+    const parts=String(leaf.path||'').split('/').filter(Boolean);
+    if(parts.length<2)continue;
+    let node=workspace;
+    for(let i=0;i<parts.length-1;i++){
+      const seg=parts[i];
+      if(!node.dirs.has(seg))node.dirs.set(seg,mk(seg,i===0?'project':'dir'));
+      node=node.dirs.get(seg);
+    }
+    /* project + project-relative path address the previewer's endpoint; the
+       graph leaf id is kept for the "Graph" hand-off inside the previewer. */
+    node.files.push({name:parts.at(-1),tag:leaf.tag||'',id:leaf.id,date:leaf.date||null,
+      project:parts[0],path:parts.slice(1).join('/')});
+  }
+  /* Roll counts up so a collapsed branch can still say what it holds. */
+  const roll=n=>{
+    let f=n.files.length,d=n.dirs.size;
+    for(const c of n.dirs.values()){const r=roll(c);f+=r.f;d+=r.d;}
+    n.nFiles=f;n.nDirs=d;
+    n.files.sort((a,b)=>a.name.localeCompare(b.name));
+    return{f,d};
+  };
+  roll(workspace);
+  return workspace;
+}
+
+async function load(){
+  loading=true;
+  const res=await apiFetch('data/space.json');
+  loading=false;
+  if(!res.ok){
+    root.querySelector('.tv').innerHTML=
+      '<div class="prj-note">'+esc(res.offline?'xo-cowork-api is unreachable':res.error)+'</div>';
+    return;
+  }
+  model=build(res.data);
+  /* Start from the root: the workspace open, its projects closed. The first
+     screen is an index of the workspace, not 1500 rows. */
+  open=new Set(['']);
+  render();
+}
+
+/* ── layout ───────────────────────────────────────────────────────────────
+   One recursive pass. Each visible node reports the vertical band it needs;
+   a parent centres itself on the span of its children, so the tree reads as
+   a proper dendrogram rather than an indented list rotated 90°. */
+function matches(n,q){
+  if(!q)return true;
+  if((n.label||n.name).toLowerCase().includes(q))return true;
+  for(const f of n.files)if(f.name.toLowerCase().includes(q))return true;
+  for(const c of n.dirs.values())if(matches(c,q))return true;
+  return false;
+}
+/* 1 file ≈ hairline, 300 files ≈ 4px. log2 so a big project does not swamp
+   everything else the way a linear scale would. */
+const weight=n=>Math.max(1.1,Math.min(4.4,Math.log2(1+(n||0))*.62));
+function layout(n,key,depth,top,q,out){
+  const x=PAD_X+depth*COL_W;
+  const isOpen=q?true:open.has(key);
+  const kids=[...n.dirs.values()]
+    .filter(c=>matches(c,q))
+    .sort((a,b)=>(a.label||a.name).localeCompare(b.label||b.name));
+  const files=q?n.files.filter(f=>f.name.toLowerCase().includes(q)):n.files;
+
+  if(!isOpen||(!kids.length&&!files.length)){
+    const node={key,x,y:top,n,depth,kind:n.kind,open:isOpen&&(kids.length||files.length)>0,
+      hasKids:(n.dirs.size+n.files.length)>0};
+    out.nodes.push(node);
+    return{height:ROW_H,centre:top+ROW_H/2,node};
+  }
+  let cursor=top,first=null,last=null;
+  const childCentres=[];
+  for(const c of kids){
+    const r=layout(c,key+'/'+c.name,depth+1,cursor,q,out);
+    cursor+=r.height+GAP;
+    childCentres.push(r.centre);
+    if(first===null)first=r.centre;
+    last=r.centre;
+  }
+  let stack=null;
+  if(files.length){
+    const all=expandedStacks.has(key);
+    const shown=all?files:files.slice(0,FILES_SHOWN);
+    const rows=shown.length+(files.length>shown.length?1:0);
+    const h=rows*FILE_H+STACK_PAD*2+FILE_H; /* +1 row for the card's header */
+    stack={x:x+COL_W,y:cursor,h,files:shown,extra:files.length-shown.length,
+      total:files.length,centre:cursor+h/2,key};
+    out.stacks.push(stack);
+    childCentres.push(stack.centre);
+    if(first===null)first=stack.centre;
+    last=stack.centre;
+    cursor+=h+GAP;
+  }
+  const height=Math.max(ROW_H,cursor-GAP-top);
+  const centre=childCentres.length?(first+last)/2:top+ROW_H/2;
+  const node={key,x,y:centre-ROW_H/2,n,depth,kind:n.kind,open:true,hasKids:true};
+  out.nodes.push(node);
+  /* One link per child, its weight set by how much that child holds: the
+     trunk is thick, the twigs are thin. This is the whole "growth" read — a
+     uniform 1px hairline makes a 300-file branch look like an empty one. */
+  kids.forEach((c,i)=>out.links.push({
+    x1:x+COL_W-24,y1:centre,x2:x+COL_W,y2:childCentres[i],w:weight(c.nFiles),
+  }));
+  if(stack)out.links.push({x1:x+COL_W-24,y1:centre,x2:x+COL_W,y2:stack.centre,
+    w:weight(files.length),leaf:true});
+  if(stack)stack.parent=node;
+  return{height,centre,node};
+}
+
+/* ── render ─────────────────────────────────────────────────────────────── */
+function render(){
+  const q=filter.trim().toLowerCase();
+  const out={nodes:[],links:[],stacks:[]};
+  const r=layout(model,'',0,PAD_Y,q,out);
+  const width=Math.max(...out.nodes.map(n=>n.x+COL_W),
+    ...out.stacks.map(s=>s.x+COL_W-24),900)+PAD_X;
+  const height=Math.max(r.height+PAD_Y*2,
+    ...out.stacks.map(s=>s.y+s.h+PAD_Y),320);
+
+  const grew=growing;growing=false;
+  root.querySelector('.tv').innerHTML=
+    head()
+    +'<div class="tv-scroll"><div class="tv-surface'+(grew?' is-growing':'')
+      +'" style="width:'+Math.round(width)
+      +'px;height:'+Math.round(height)+'px">'
+      +'<svg class="tv-links" width="'+Math.round(width)+'" height="'+Math.round(height)+'">'
+        +out.links.map(l=>'<path pathLength="1" class="tv-link'+(l.leaf?' is-leaf':'')
+          +'" style="stroke-width:'+l.w.toFixed(2)+'px" d="'+curve(l)+'"/>').join('')
+      +'</svg>'
+      +out.nodes.map(n=>nodeChip(n,!seen.has(n.key))).join('')
+      +out.stacks.map(s=>stackBlock(s,!seen.has('stack:'+s.key))).join('')
+    +'</div></div>';
+  /* Anything that was not on screen last time animates in, so expanding a
+     folder reads as that branch growing rather than as a repaint. */
+  seen=new Set([...out.nodes.map(n=>n.key),...out.stacks.map(s=>'stack:'+s.key)]);
+  /* drop the class once the draw-in has played, so a later re-render (filter,
+     refresh) does not replay every branch */
+  if(grew){
+    const surface=root.querySelector('.tv-surface');
+    setTimeout(()=>surface&&surface.classList.remove('is-growing'),480);
+  }
+  restoreScroll();
+  const input=root.querySelector('#tv-filter');
+  if(input&&filter){input.focus();input.setSelectionRange(filter.length,filter.length);}
+}
+function head(){
+  return'<div class="tv-head">'
+    +'<div class="atlas-lens-switch fileslens-list" aria-label="Files lens">'
+      +'<button type="button" data-files-lens="projects">List</button>'
+      +'<button type="button" data-files-lens="graph">Graph</button>'
+      +'<button class="is-on" type="button" data-files-lens="tree">Tree</button>'
+    +'</div>'
+    +'<span class="prj-eyebrow">'+model.dirs.size+' projects · '
+      +model.nDirs+' folders · '+model.nFiles+' files</span>'
+    +'<span class="prj-spacer"></span>'
+    +'<input class="tv-filter" id="tv-filter" placeholder="Filter by name…" '
+      +'autocomplete="off" spellcheck="false" value="'+esc(filter)+'">'
+    +'<button class="sess-refresh" data-tv="projects">Projects only</button>'
+    +'<button class="sess-refresh" data-tv="reload">&#8635; Refresh</button>'
+  +'</div>';
+}
+/* An S-curve, not an elbow: at 228px of column width a bezier reads the
+   parent→child direction at a glance without a corner every level. */
+function curve(l){
+  const mx=(l.x1+l.x2)/2;
+  return`M${l.x1} ${l.y1} C${mx} ${l.y1} ${mx} ${l.y2} ${l.x2} ${l.y2}`;
+}
+function nodeChip(n,fresh){
+  const label=n.n.label||n.n.name;
+  const sub=n.n.nFiles+' file'+(n.n.nFiles===1?'':'s')
+    +(n.n.nDirs?' · '+n.n.nDirs+' folder'+(n.n.nDirs===1?'':'s'):'');
+  /* the bud grows with what the branch holds — the same signal as the link
+     weight, readable when a chip sits alone on screen */
+  const bud=Math.max(4,Math.min(11,3+Math.log2(1+n.n.nFiles)*1.5)).toFixed(1);
+  return'<button class="tv-node is-'+n.kind+(n.open?' is-open':'')
+      +(n.hasKids?'':' is-empty')+(fresh?' is-new':'')
+      +'" style="left:'+Math.round(n.x)+'px;top:'+Math.round(n.y)+'px'
+      +';--bud:'+bud+'px;--depth:'+Math.min(n.depth,5)+'" '
+      +'data-key="'+esc(n.key)+'" title="'+esc(label)+'" '
+      +'aria-expanded="'+(n.hasKids?(n.open?'true':'false'):'false')+'">'
+    +'<span class="tv-bud" aria-hidden="true"></span>'
+    +'<span class="tv-label"><span class="tv-name">'+esc(label)+'</span>'
+      +'<span class="tv-count">'+esc(sub)+'</span></span>'
+    +(n.hasKids?'<span class="tv-caret" aria-hidden="true">'
+      +(n.open?'&#9662;':'&#9656;')+'</span>':'')
+  +'</button>';
+}
+/* Leaves expand vertically: one card per folder, not one column per file.
+   The card is what makes them read as fruit on that branch instead of loose
+   text floating in the gutter. */
+function stackBlock(s,fresh){
+  return'<div class="tv-stack'+(fresh?' is-new':'')+'" style="left:'+Math.round(s.x)
+      +'px;top:'+Math.round(s.y)+'px;min-height:'+Math.round(s.h)+'px">'
+    +'<div class="tv-stack-head">'+s.total+' file'+(s.total===1?'':'s')+'</div>'
+    +s.files.map(f=>'<button class="tv-leaf" data-file="'+esc(f.path||'')+'" '
+      +'data-project="'+esc(f.project||'')+'" title="'+esc(f.name)+'">'
+      +'<span class="tv-name">'+esc(f.name)+'</span>'
+      +'<span class="tv-tag">'+esc(f.tag||'')+'</span>'
+    +'</button>').join('')
+    +(s.extra
+      ?'<button class="tv-leaf is-more" data-stack="'+esc(s.key)+'">+'+s.extra
+        +' more</button>'
+      :(expandedStacks.has(s.key)&&s.total>FILES_SHOWN
+        ?'<button class="tv-leaf is-more" data-stack="'+esc(s.key)+'">show fewer</button>'
+        :''))
+  +'</div>';
+}
+
+/* ── interaction ──────────────────────────────────────────────────────────
+   Clicking a file opens the previewer; it does not move you. The Graph
+   hand-off lives inside the previewer, so browsing the tree never costs you
+   your place in it. */
+function onClick(e){
+  const lens=e.target.closest('[data-files-lens]');
+  if(lens){go(lens.dataset.filesLens);return;}
+  const act=e.target.closest('[data-tv]');
+  if(act){
+    if(act.dataset.tv==='projects'){open=new Set(['']);expandedStacks.clear();render();}
+    else{model=null;root.querySelector('.tv').innerHTML='<div class="prj-note">loading…</div>';load();}
+    return;
+  }
+  const node=e.target.closest('[data-key]');
+  if(node){
+    const k=node.dataset.key;
+    keepScroll(k);
+    if(open.has(k)){open.delete(k);}
+    else{open.add(k);growing=true;}
+    render();
+    return;
+  }
+  const more=e.target.closest('[data-stack]');
+  if(more){
+    const k=more.dataset.stack;
+    keepScroll(k);growing=true;
+    if(expandedStacks.has(k))expandedStacks.delete(k);else expandedStacks.add(k);
+    render();
+    return;
+  }
+  const file=e.target.closest('[data-file]');
+  if(file&&file.dataset.file){
+    /* Preview in the side drawer; the tree keeps its scroll, its expansion
+       state and its place. Jumping to the Graph is the Graph button inside
+       the previewer — an explicit choice, not the cost of opening a file. */
+    dispatchEvent(new CustomEvent('space:preview-file',{detail:{
+      project:file.dataset.project,path:file.dataset.file,
+      name:file.querySelector('.tv-name').textContent}}));
+  }
+}
+/* The surface is rebuilt on every render AND the layout reflows around the
+   node you just opened — a parent re-centres over its taller subtree, which
+   can shove the whole tree (root included) off screen. Restoring the raw
+   scroll offset is not enough; the fix is to pin the clicked node to the
+   screen position it already had and let the tree grow around it. */
+function keepScroll(key){
+  const sc=root.querySelector('.tv-scroll');
+  if(!sc)return;
+  scrollLeft=sc.scrollLeft;scrollTop=sc.scrollTop;
+  anchor=null;
+  if(!key)return;
+  const el=root.querySelector('[data-key="'+CSS.escape(key)+'"]');
+  if(el)anchor={key,offset:el.getBoundingClientRect().top-sc.getBoundingClientRect().top};
+}
+function restoreScroll(){
+  const sc=root.querySelector('.tv-scroll');
+  if(!sc)return;
+  sc.scrollLeft=scrollLeft;sc.scrollTop=scrollTop;
+  if(!anchor)return;
+  const el=root.querySelector('[data-key="'+CSS.escape(anchor.key)+'"]');
+  if(el){
+    const now=el.getBoundingClientRect().top-sc.getBoundingClientRect().top;
+    sc.scrollTop+=now-anchor.offset;
+  }
+  anchor=null;
+}
+let debounce=null;
+function onInput(e){
+  if(e.target.id!=='tv-filter')return;
+  filter=e.target.value;
+  clearTimeout(debounce);
+  debounce=setTimeout(render,140);
+}

--- a/space_ui/js/views/wiki.js
+++ b/space_ui/js/views/wiki.js
@@ -48,6 +48,12 @@ const PAGES=[
     summary:'Google Docs-style live editing, durable versions, restore, audit, permissions, and safe data boundaries.'
   },
   {
+    id:'spacewalk',
+    section:'Design guide',
+    title:'Space Walk session replay',
+    summary:'Session traces, the repository citymap, the two 3D scenes, the optional judge, and quirq recipes.'
+  },
+  {
     id:'tab-dashboard',
     section:'Tab guides',
     title:'Dashboard tab',
@@ -57,7 +63,7 @@ const PAGES=[
     id:'tab-files',
     section:'Tab guides',
     title:'Files tab',
-    summary:'One home for the workspace: the operational project List first, the relationship Graph a lens switch away.'
+    summary:'One home for the workspace: List for ops and browsing, Graph for relationships, Tree for hierarchy — three lenses, one tab.'
   },
   {
     id:'tab-timeline',
@@ -80,8 +86,8 @@ const PAGES=[
   {
     id:'tab-quirq',
     section:'Tab guides',
-    title:'Quirq tab',
-    summary:'Compare machine-local watcher state with portable project .xo outputs.'
+    title:'Quirq state view',
+    summary:'Opened from Setup: compare machine-local watcher state with portable project .xo outputs.'
   },
   {
     id:'tab-setup',
@@ -99,6 +105,7 @@ const ARTICLES={
   'quirq-data':quirqDataArticle,
   flows:flowsArticle,
   collaboration:collaborationArticle,
+  spacewalk:spaceWalkArticle,
   'tab-dashboard':()=>tabGuideArticle('dashboard'),
   'tab-files':()=>tabGuideArticle('files'),
   'tab-timeline':()=>tabGuideArticle('timeline'),
@@ -117,10 +124,10 @@ let activePage='storage';
 let go=()=>{};
 
 export default {
-  /* No top-level tab: the wiki opens from the button in Setup's header
-     (and stays deep-linkable at #/wiki); Setup's tab lights up while the
-     wiki is open. */
-  id:'wiki',label:'Wiki',order:7,nav:false,parent:'secrets',
+  /* Top-level tab, and still deep-linkable at #/wiki. Order 7 keeps it
+     between Sessions and Setup — the nav slot (and number hotkey) Quirq
+     used to hold. */
+  id:'wiki',label:'Wiki',order:7,
   async mount(el,ctx){
     root=el;
     go=ctx.switchTo;
@@ -219,37 +226,43 @@ const TAB_GUIDES={
     tab:'projects',
     name:'Files',
     kicker:'Tab guide · Workspace map and project state',
-    title:'Files: one home, two lenses',
-    intro:'Files combines the former Projects and Graph tabs behind one List | Graph switch. It lands on the List lens: every project operationally, with per-project todos, open sessions, and recent events. The Graph lens maps the same workspace as projects, clusters, artifacts, and cross-links. Both lenses are read-only.',
-    facts:['lands on List','List | Graph lens switch','live generated map','portable .xo history','live .quirq presence','read-only'],
+    title:'Files: one home, three lenses',
+    intro:'Files is one top-level tab with three lenses behind a List | Graph | Tree pill. It lands on List: every project operationally, with a per-project drawer that browses the filesystem folder-by-folder and shows todos, open sessions, and recent events. Graph maps the same workspace as projects, clusters, artifacts, and cross-links. Tree reads the same space.json dataset as a horizontal hierarchy — folders as columns, files stacked beside their parent. All three lenses are read-only.',
+    facts:['lands on List','List | Graph | Tree lens switch','live generated map','drawer file explorer','portable .xo history','live .quirq presence','read-only'],
     jobs:[
-      ['Find an artifact','In the Graph lens, search by title, tag, project, or cluster and fly directly to the matching node.'],
-      ['Understand relationships','Select a node to inspect its neighborhood and follow parent, cluster, and cross-project ties.'],
+      ['Find an artifact','In Graph, search by title, tag, project, or cluster and fly to the matching node. In Tree, expand folders and filter by name; click a file to hand off to Graph focused on that leaf.'],
+      ['Understand relationships','Select a Graph node to inspect its neighborhood and follow parent, cluster, and cross-project ties.'],
+      ['Read the hierarchy','Use Tree when the question is “what is in there”: workspace root on the left, one column per depth, files stacked beside their folder (not one column per file).'],
       ['Change perspective','Use Graph root to temporarily reorganize the layout around any node without changing the XO filesystem.'],
-      ['Review active work','In the List lens, open a project drawer to inspect todos, current sessions, and the latest normalized timeline events.'],
-      ['Jump between lenses','Use a List row’s Map action to focus that project on the Graph; use “Show on timeline” from the Graph to carry a run into Timeline.']
+      ['Browse project files','In List, open a project drawer: the Files panel lists one folder at a time via GET /api/xo-projects/{id}/tree, with breadcrumbs and separate folder/file panes.'],
+      ['Review active work','In the same drawer, inspect todos, current sessions, and the latest normalized timeline events.'],
+      ['Jump between lenses','Use a List row’s Map action (or a Tree file row) to focus that project or file on Graph; use “Show on timeline” from Graph to carry a run into Timeline.']
     ],
     sources:[
-      ['GET /space/data/space.json','Generated by build_space_data() from the XO projects root and portable project metadata; feeds the Graph lens.','Live primary source'],
-      ['<XO root>/<project>/.xo/project.json','Gates project discovery and supplies each project’s display name and description; dates, git history, and cross-ties come from the project’s git log, not from .xo session data.','Portable project identity'],
-      ['GET /api/xo-projects (+ /todos, /timeline, /activity per project)','Feeds the List lens: identity, portable todos and history, and machine-local live presence. Each drawer panel fetches independently.','List lens data'],
+      ['GET /space/data/space.json','Generated by build_space_data() from the XO projects root and portable project metadata; feeds Graph and Tree.','Live primary source'],
+      ['<XO root>/<project>/.xo/project.json','Gates project discovery and supplies each project’s display name and description. The folder name under the XO root is the project id — a stale name inside this file never overrides it. Dates, git history, and cross-ties come from the project’s git log, not from .xo session data.','Portable project identity'],
+      ['GET /api/xo-projects','Feeds the List lens identity row for every direct child of the XO root.','List lens catalog'],
+      ['GET /api/xo-projects/{id}/tree?relative_path=…','Bounded, path-safe folder listing for the List drawer’s Files panel (dirs, files, sizes, mtimes).','List drawer explorer'],
+      ['GET /api/xo-projects/{id}/todos|activity|timeline','Portable todos, machine-local live presence, and recent normalized events. Each drawer panel fetches independently.','List drawer panels'],
       ['<SPACE_DIR>/data/space.json','Optional static fallback consulted only when live generation fails; no file is bundled, so a builder failure normally returns 503 and the no-data card.','Optional fallback']
     ],
     steps:[
-      ['Pick a lens','Files opens in the List; switch with the List | Graph pill at the top left. #/projects and #/graph deep-link each lens directly.'],
-      ['Search','Press / or use the top-right search field (Graph lens).'],
-      ['Focus','Click a node; double-click clusters to expand or collapse them.'],
-      ['Expand one row','In the List lens each drawer loads independently, so one failed data source does not hide the others.'],
+      ['Pick a lens','Files opens in List; switch with the List | Graph | Tree pill. #/projects, #/graph, and #/tree deep-link each lens.'],
+      ['Search','Press / or use Graph’s top-right search; Tree has its own name filter in the header.'],
+      ['Focus','Click a Graph node; double-click clusters to expand or collapse. In Tree, click folders to expand columns; click a file to jump to Graph.'],
+      ['Expand one row','In List each drawer panel loads independently, so one failed data source does not hide the others.'],
+      ['Browse files','In the Files panel, use breadcrumbs and folder rows to change cwd; browsing state is remembered per project for the session.'],
       ['Follow time','Choose “Show on timeline” to carry the selected run into Timeline.']
     ],
     checks:[
-      ['Empty graph','Confirm the XO root in Setup and verify GET /space/data/space.json.'],
+      ['Empty graph or tree','Confirm the XO root in Setup and verify GET /space/data/space.json.'],
       ['Project missing from the List','Verify the XO root and ensure the folder is a direct child of it.'],
       ['Unscaffolded badge','The folder exists but lacks canonical project metadata.'],
       ['No open sessions','This is a valid live-presence zero, not proof that no historical work exists.'],
       ['Unexpected root label','Graph root is an in-view lens, not the host XO directory configured in Setup.'],
-      ['Stale result','The generated graph payload is cached for up to 30 seconds; the List refetches on Refresh.'],
-      ['No List | Graph pill on Dashboard','Intentional: Dashboard shares the canvas but is its own tab, not a Files lens.']
+      ['Stale result','The generated graph/tree payload is cached for up to 30 seconds; List Refresh re-fetches the project catalog and open drawers.'],
+      ['Tree shows fewer columns than expected','Intentional: files stack beside their folder so horizontal distance means depth only.'],
+      ['No List | Graph | Tree pill on Dashboard','Intentional: Dashboard shares the canvas but is its own tab, not a Files lens.']
     ],
     note:'Files reads derived metadata and project structure. It never writes project files, .xo, or .quirq; the watcher owns .xo writes.'
   },
@@ -277,6 +290,7 @@ const TAB_GUIDES={
     ],
     checks:[
       ['No dots','Dates come from git only: a dot is a file’s first-commit day. Files never committed, and projects without a repo, sit out the By file plot.'],
+      ['Fewer projects than Files lists','Expected, and stated in the subtitle: Files lists every folder under the XO root, while both Timeline modes can only plot projects that have their own git repository. A project whose repo sits in a subfolder counts as having none.'],
       ['No By project toggle','The current dataset carries no git history; the toggle appears only when at least one project has git commits of its own (a repo with no commits yet does not count, and the Dashboard projection never has history).'],
       ['Trace missing','Open the cluster from Graph first or clear the existing trace and try again.']
     ],
@@ -317,14 +331,14 @@ const TAB_GUIDES={
       ['Prompts unavailable','That runtime may not support prompt details, or its native transcript may have been cleaned up.'],
       ['New session missing','Wait for ingestion and the short server cache, then refresh.']
     ],
-    note:'Sessions reads native runtime stores without modifying them. Projects remains the better tab for todos, live presence, and normalized .xo/.quirq history.'
+    note:'Sessions reads native runtime stores without modifying them. Files remains the better tab for todos, live presence, and normalized .xo/.quirq history.'
   },
   wiki:{
     tab:'wiki',
     name:'Wiki',
     kicker:'Tab guide · Local documentation',
     title:'Wiki: the operating manual',
-    intro:'Wiki ships with the application and documents the exact storage, watcher, installation, flow, and tab contracts for this version. It works offline and requires no external documentation service. It is not a top-level tab: open it with the Open the wiki button in Setup’s header, or deep-link to #/wiki; the Setup tab stays highlighted while it is open.',
+    intro:'Wiki ships with the application and documents the exact storage, watcher, installation, flow, and tab contracts for this version. It works offline and requires no external documentation service. It is a top-level tab, between Sessions and Setup, and stays deep-linkable at #/wiki.',
     facts:['versioned with code','offline','architecture + operations','one page per tab'],
     jobs:[
       ['Learn the boundaries','Start with Storage & data map before designing a new flow.'],
@@ -353,9 +367,9 @@ const TAB_GUIDES={
   quirq:{
     tab:'quirq',
     name:'Quirq',
-    kicker:'Tab guide · Watcher storage',
+    kicker:'View guide · Watcher storage',
     title:'Quirq: see both watcher destinations',
-    intro:'Quirq is a privacy-aware operational map. It explicitly separates machine-local watcher state under .quirq from portable derived metadata under each XO project’s .xo directory.',
+    intro:'Quirq is a privacy-aware operational map. It explicitly separates machine-local watcher state under .quirq from portable derived metadata under each XO project’s .xo directory. It is not a top-level tab: open it with the Open Quirq state button in Setup’s header, or deep-link to #/quirq; the Setup tab stays highlighted while it is open.',
     facts:['two storage destinations','live refresh','values masked','filesystem structure only'],
     jobs:[
       ['See local control state','Inspect cursors, locks, and live activity under .quirq/watcher.'],
@@ -369,9 +383,10 @@ const TAB_GUIDES={
       ['<XO root>/.xo/','Workspace aggregates rebuilt from project-level .xo files.','Durable workspace rollup']
     ],
     steps:[
+      ['Open Quirq','Use the Open Quirq state button in Setup’s header, or go straight to #/quirq.'],
       ['Read the split map','Compare the blue machine-local side with the green portable project side.'],
       ['Check freshness','Use updated times and watcher status before treating a snapshot as current.'],
-      ['Open project data','Jump to Projects for API-rendered todos, presence, and recent events.'],
+      ['Open project data','Jump to Files for API-rendered todos, presence, and recent events.'],
       ['Inspect structure','Use State tree for current .quirq files; contents remain protected.']
     ],
     checks:[
@@ -380,7 +395,7 @@ const TAB_GUIDES={
       ['No offsets.json','Some sources use other cursor types, or no supported records have been tailed yet.'],
       ['Credential count only','Values are deliberately write-only and remain masked.']
     ],
-    note:'Use Quirq to understand where data lives. Use Projects to consume project state and Setup to change runtime behavior.'
+    note:'Use Quirq to understand where data lives. Use Files to consume project state and Setup to change runtime behavior.'
   },
   setup:{
     tab:'secrets',
@@ -398,18 +413,19 @@ const TAB_GUIDES={
     sources:[
       ['GET /space/update/status + POST /space/update/apply','Compares HEAD with the checkout’s own remote via git and fast-forwards on request; refuses dirty or diverged checkouts.','Self-update'],
       ['GET/PUT /api/runtime-config','Reads and validates agent and watcher settings in .quirq/runtime.env.','Non-secret configuration'],
-      ['PUT /api/runtime-config/roots','Writes desired host roots to .quirq/roots.env.','Installer configuration'],
+      ['PUT /api/runtime-config/roots','Writes the desired host roots to .quirq/roots.env, which the server reads at startup; an exported shell or container value still outranks it.','Storage root configuration'],
       ['GET/PATCH/DELETE /api/secrets','Returns names/status and writes values to .quirq/secrets.env.','Write-only credentials'],
       ['POST /api/runtime-config/restart','Restarts only an installer-managed local container.','Managed process control']
     ],
     steps:[
       ['Confirm paths','Compare the configured roots with what the running server reports.'],
-      ['Save roots','If roots differ, copy and run the one-command installer — roots are applied when the server starts.'],
+      ['Inspect stored state','The header’s Open Quirq state button opens the machine-local watcher state beside the portable .xo output.'],
+      ['Save roots','Saved roots are applied at startup: restart the server, or run the one-command installer on a managed container, which also remaps its bind mounts.'],
       ['Save runtime','Review the pending-restart banner before applying process-time changes.'],
       ['Add credentials','Choose a manifest-recommended key, save it, then restart when requested.']
     ],
     checks:[
-      ['Root not applied','Saving queues it; rerun the displayed installer to restart with the new roots.'],
+      ['Root not applied','Saving only queues it. Restart the server (or rerun the displayed installer) to boot on the new roots; every tab then reads the same XO root.'],
       ['CLI unavailable','A manifest may support bootstrap, but required credentials must be present first.'],
       ['Sessions missing','Confirm the native runtime directory is mounted and watcher coverage includes it.'],
       ['Secret value hidden','That is intentional; replace the value or remove the variable.']
@@ -1031,7 +1047,7 @@ function quirqDataArticle(){
         <pre class="wiki-tree">~/.quirq/
 ├── state.json
 ├── runtime.env                 # mode 0600; typed restart-time controls
-├── roots.env                   # mode 0600; roots applied by the next installer run
+├── roots.env                   # mode 0600; storage roots, read at server startup
 ├── quirq.log                   # server output appended by the installer's run loop
 ├── secrets.env                 # mode 0600; write-only credentials from Setup
 └── watcher/
@@ -1058,13 +1074,17 @@ function quirqDataArticle(){
           </article>
 
           <article class="wiki-file">
-            <header><code>roots.env</code><span>installer root configuration</span></header>
+            <header><code>roots.env</code><span>storage root configuration</span></header>
             <p>Stores the absolute host paths selected for the XO projects
-            root and machine-local Quirq state root. These values are
-            intentionally separate from process runtime settings: the running
-            server cannot change its own roots, so Setup marks them pending
-            until the one-command installer restarts it with the new
-            values.</p>
+            root and machine-local Quirq state root. The server reads this
+            file at startup, before runtime.env, so the XO root saved in
+            Setup becomes the one root every tab resolves through
+            <code>project_layout.xo_projects_root()</code>. A value exported
+            by the shell or the container still outranks it. Roots are
+            import-time state: the running server cannot change its own, so
+            Setup marks a saved change pending until a restart (on a managed
+            container, the one-command installer, which also remaps the bind
+            mounts).</p>
             <dl><div><dt>Writer</dt><dd>typed root configuration API</dd></div><div><dt>Migration</dt><dd>empty state targets receive a copy; project roots are selected, never moved</dd></div></dl>
           </article>
 
@@ -1766,6 +1786,520 @@ function flowsArticle(){
         update time, confirm runtime coverage, compare project and workspace
         scope, then inspect server watcher logs. Filesystem inspection is a
         diagnostic last step, not an application integration.</p>
+      </aside>
+    </article>`;
+}
+
+function spaceWalkArticle(){
+  return`
+    <article class="wiki-article">
+      <header class="wiki-hero">
+        <div class="wiki-kicker">Design guide · Session replay</div>
+        <h1>Sessions replayed as light</h1>
+        <p>Space Walk is XO Labs’ fork of mindwalk. One Go binary reads
+        Claude Code, Codex, and pi session logs, normalizes each into a
+        replayable trace, and plays it back as light moving over a 3D map of
+        the repository: where the agent searched, read, and edited, the map
+        glows — everything else stays dark. Replay is entirely local: no
+        service, no account, no telemetry. The one exception is the optional
+        judge — when you run it, a summary of that session (task wording, file
+        paths, event digests) goes to the model behind your own
+        <code>claude</code> or <code>codex</code> CLI, and spends real tokens
+        against that provider.</p>
+        <div class="wiki-facts">
+          <span>fork of mindwalk</span>
+          <span>light is data</span>
+          <span>three harness adapters</span>
+          <span>loopback-only server</span>
+        </div>
+      </header>
+
+      <section class="wiki-section">
+        <h2>From session log to moving light</h2>
+        <div class="wiki-flow wiki-flow-five" aria-label="Space Walk data path">
+          <div><small>01</small><b>Session logs</b><span>Native JSONL stays where the runtime wrote it: ~/.claude/projects, ~/.codex/sessions, ~/.pi/agent/sessions.</span></div>
+          <i aria-hidden="true">→</i>
+          <div><small>02</small><b>Harness adapters</b><span>claude-code, codex, and pi adapters are tried in that order and recognize a file by its content, not its name — listing still filters to .jsonl, and claude-code skips agent-*.jsonl sidecars.</span></div>
+          <i aria-hidden="true">→</i>
+          <div><small>03</small><b>Normalized trace</b><span>One schema for every harness: events, targets with touch states, timeline marks, derived stats.</span></div>
+          <i aria-hidden="true">→</i>
+          <div><small>04</small><b>Citymap builder</b><span>A deterministic treemap of the repository, computed server-side as 2D footprints only.</span></div>
+          <i aria-hidden="true">→</i>
+          <div><small>05</small><b>Server + UI</b><span>A 127.0.0.1-only Go server with the React/Three.js frontend embedded in the binary.</span></div>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>One trace, whatever the harness</h2>
+        <p>Every adapter implements the same five-method
+        <code>adapter.Source</code> interface — Harness, SessionDir,
+        ListSessions, Summarize, Parse — and emits the same trace shape:
+        <code>{version, session, events, marks, stats}</code>. An event is one
+        tool call joined with its result: <code>seq</code>, <code>ts</code>,
+        <code>tool</code>, <code>action</code>, <code>targets</code>,
+        <code>resultBytes</code>, <code>isError</code>,
+        <code>outcomeKnown</code>, <code>outside</code>, and
+        <code>summary</code>, where the action is one of
+        <code>search</code>, <code>read</code>,
+        <code>edit</code>, <code>exec</code>, <code>verify</code>, or
+        <code>other</code>. Shell commands classify conservatively: substrings
+        like <code>pytest</code>, <code>go test</code>, and
+        <code>npm run build</code> mean verify; anything unrecognized stays
+        exec.</p>
+        <p>Each target carries a touch state on a strict lattice —
+        <b>edit &gt; read &gt; hit</b> — and a file only ever escalates during
+        playback: a later read never downgrades an earlier edit. Marks record
+        what happened between events: user messages (the note keeps up to
+        2,000 runes of text), context compactions, and subagent launches.</p>
+        <div class="wiki-table-wrap">
+          <table class="wiki-table">
+            <thead><tr><th>Touch</th><th>HUD word</th><th>Rank</th><th>Meaning</th></tr></thead>
+            <tbody>
+              <tr><td><code>hit</code></td><td>seen</td><td>1</td><td>Surfaced by a search, glob, or listing; never opened. Olive.</td></tr>
+              <tr><td><code>read</code></td><td>read</td><td>2</td><td>Opened and read, with line ranges when the tool declared them. Steel.</td></tr>
+              <tr><td><code>edit</code></td><td>edited</td><td>3</td><td>Written, edited, or patched. Lime.</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="wiki-note">The trace grades its own observability per
+        session, not per harness: claude-code and pi carry structural error
+        flags and grade exact, but one event whose outcome the log leaves
+        unknown downgrades that whole session to estimated; codex, whose
+        failures are inferred from output text, is always estimated. The HUD
+        shows a tilde instead of hiding the difference.</p>
+      </section>
+
+      <section class="wiki-section">
+        <h2>The artifacts</h2>
+        <div class="wiki-file-list">
+          <article class="wiki-file">
+            <header><code>trace.json</code><span>normalized session replay</span></header>
+            <p>The portable record of one session: identity with
+            <code>cwd</code> and <code>commit</code>, the event and mark
+            streams, and a derived <code>stats</code> block —
+            fovea/parafovea/edited file counts, regression and error rates,
+            churn, and edits after the last verify. Mirrored by
+            <code>schema/trace.schema.json</code>, version 1.</p>
+            <dl><div><dt>Writer</dt><dd>spacewalk trace &lt;session&gt; [-o out]</dd></div><div><dt>Server route</dt><dd>GET /api/sessions/{selector}/trace</dd></div></dl>
+          </article>
+          <article class="wiki-file">
+            <header><code>citymap.json</code><span>repository ground plan</span></header>
+            <p>A deterministic squarified treemap
+            (<code>squarified-treemap-v1</code>) of up to 10,000 files on a
+            fixed 120×120 plane. Footprint weight is
+            <code>sqrt(max(lines, bytes/4096, 16))</code>; the server ships
+            only 2D rectangles and the browser extrudes all heights. Files a
+            session touched by strong attestation — a tool that named the path,
+            never a path inferred from command text — that are provably gone
+            from the repo become ghosts and keep a tile; a file that is merely
+            unreadable, on a timeout or a permission error, gets no tile at
+            all, because a ghost there would lie.</p>
+            <dl><div><dt>Writer</dt><dd>spacewalk build &lt;repo&gt; [-o out]</dd></div><div><dt>Server routes</dt><dd>GET /api/sessions/{selector}/citymap · GET /api/repomap?repo=PATH</dd></div></dl>
+          </article>
+          <article class="wiki-file">
+            <header><code>~/.spacewalk/reports/&lt;sessionKey&gt;.json</code><span>judge evaluation cache</span></header>
+            <p>An optional LLM evaluation of the trace: a task rubric derived
+            from the user’s own messages plus four fixed dimensions —
+            exploration, scope, wandering, verification. The judge runs a
+            sealed local agent CLI (claude preferred, then codex) with tools
+            disabled; findings must cite event seqs that exist, and verdicts
+            roll up mechanically in Go.</p>
+            <dl><div><dt>Writers</dt><dd>spacewalk analyze &lt;session&gt; · POST /api/sessions/{selector}/analyze</dd></div><div><dt>Freshness</dt><dd>sha256 digest of the exact evidence document, plus pinned prompt versions</dd></div></dl>
+          </article>
+        </div>
+      </section>
+
+      <section class="wiki-section wiki-grid">
+        <div>
+          <h2>Privacy boundary</h2>
+          <p>A trace is not <code>.xo</code>-safe. Marks keep up to 2,000
+          runes of the user’s own message text and event summaries keep up to
+          96 runes of command text, because the walk is unreadable without
+          them. Treat <code>trace.json</code> as transcript-adjacent: share it
+          deliberately, never automatically.</p>
+        </div>
+        <div>
+          <h2>Write boundary</h2>
+          <p>Space Walk reads the runtimes’ session directories and the
+          repository; it writes nothing back to either. Its only writes are
+          the judge report cache under <code>~/.spacewalk/reports</code> and
+          the neutral judge working directory
+          <code>~/.spacewalk/judge</code>, both safe to delete.</p>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Two scenes, one encoding</h2>
+        <p>The V key cycles two views of the same playback state.</p>
+        <div class="wiki-file-list">
+          <article class="wiki-file">
+            <header><code>Firefly tree</code><span>radial layout, browser-computed</span></header>
+            <p>Files hang off the directory tree as a radial diagram, laid out
+            in the browser so switching views costs no server round trip.</p>
+            <dl><div><dt>Layout</dt><dd>Every file gets an identical angular
+            slot, subtrees own contiguous spans, depth grows in equal rings,
+            and the outer radius is
+            max(55, 4·√leaves).</dd></div><div><dt>Ghosts</dt><dd>Deleted-but-touched
+            files render as wireframe orbs — shape separates them where a third
+            grey never could.</dd></div></dl>
+          </article>
+          <article class="wiki-file">
+            <header><code>Attention terrain</code><span>extruded server treemap</span></header>
+            <p>The citymap’s flat rectangles extrude in place, so the skyline
+            is this session’s attention profile over the repository.</p>
+            <dl><div><dt>Height</dt><dd>Touch depth × revisits: base 7.2 for
+            edited, 4.2 for read, 1.6 for seen, times 1 + 0.35·log₂(visits).
+            Height means attention only when a session is loaded — in the
+            session-less map view (<code>spacewalk map</code>,
+            <code>GET /api/repomap</code>) the same tiles extrude by lines of
+            code instead, log-scaled and gamma-exaggerated between 0.3 and 16
+            so the skyline reads as towers and shacks rather than a
+            plateau.</dd></div><div><dt>Ghosts</dt><dd>Strongly attested
+            touches that are provably gone keep a dim grey tile; an unreadable
+            file is left out rather than guessed at.</dd></div></dl>
+          </article>
+        </div>
+        <div class="wiki-decision-list">
+          <div><b>Color says what happened.</b><p>Touch state only. The scenes
+          draw lit emissive tints of the flat HUD swatches (the edit glow is
+          <code>#a8d94f</code>), but hue family and salience order match what
+          the legend promises.</p></div>
+          <div><b>Size says how much.</b><p>Halo radius in the tree and column
+          height in the terrain grow with the logarithm of the visit count —
+          revisits, never touch type.</p></div>
+          <div><b>Brightness says where.</b><p>Branch edges lighten along
+          paths to touched files; the branch guides the eye while the leaf
+          carries the classification.</p></div>
+          <div><b>Selection is a shape.</b><p>A ring and a light beam in the
+          tree — never a recolor that could impersonate a touch state.</p></div>
+        </div>
+        <p>There is no bloom pass and no postprocessing: the glow is faked
+        with unlit materials that skip tone mapping, additive gradient
+        sprites, and vertex shading baked into the column geometry so light
+        pools at the crest. An ember-colored trail of Bézier arcs connects the
+        last twelve fixations, and a firefly — the playhead avatar the tree
+        scene is named for — rides its head.</p>
+      </section>
+
+      <section class="wiki-section">
+        <h2>The playback deck</h2>
+        <div class="wiki-table-wrap">
+          <table class="wiki-table wiki-matrix">
+            <thead><tr><th>Control</th><th>What it shows</th></tr></thead>
+            <tbody>
+              <tr><td>Histogram</td><td>The whole session folded into a 160-bucket histogram. Each bar takes the color of its dominant action, ties broken edit &gt; verify &gt; read &gt; search &gt; exec &gt; other, so rare, load-bearing edits win the bucket.</td></tr>
+              <tr><td>Mark strip</td><td>User turns, context compactions, and subagent launches as distinct glyphs over the same time axis.</td></tr>
+              <tr><td>Agent lenses</td><td>Clicking a subagent mark replays that subagent’s own trace on the root repository’s map, with a remembered per-agent playhead.</td></tr>
+              <tr><td>Transport</td><td>Speeds 1×, 4×, and 16×. The deck opens at the end of the walk so the finished footprint is the first thing you see.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>The HTTP surface</h2>
+        <p>The server binds 127.0.0.1 only and wraps every route in a
+        loopback guard with two halves. The Host check is unconditional: a
+        non-local Host is rejected outright, which is what a rebinding attack
+        would have to forge. The provenance check is conditional: a non-GET
+        request that carries an <code>Origin</code> or
+        <code>Sec-Fetch-Site</code> header must name this exact origin —
+        another loopback port is still cross-site — and gets a 403 otherwise,
+        because POST analyze starts a judge run that costs real tokens.
+        Header-less local clients such as curl pass untouched.</p>
+        <div class="wiki-table-wrap">
+          <table class="wiki-table wiki-matrix">
+            <thead><tr><th>Route</th><th>Returns</th></tr></thead>
+            <tbody>
+              <tr><td><code>GET /api/sessions?fresh=1</code></td><td>Sessions from all three harness directories, newest first, with report badges; fresh=1 bypasses the 5-second list cache.</td></tr>
+              <tr><td><code>GET /api/sessions/{selector}/snapshot</code></td><td>The trace and citymap pair in one call — what the UI loads on selection. The selector is a session key, session id, or file basename.</td></tr>
+              <tr><td><code>GET /api/sessions/{selector}/trace</code></td><td>The normalized trace alone.</td></tr>
+              <tr><td><code>GET /api/sessions/{selector}/citymap</code></td><td>The repository map alone.</td></tr>
+              <tr><td><code>GET /api/sessions/{selector}/report</code></td><td>Judge status and the cached report: state, staleness, available judge CLIs.</td></tr>
+              <tr><td><code>POST /api/sessions/{selector}/analyze</code></td><td>Starts a judge run (optional body with cli, model, rubric); 202 while running, 409 for a conflicting configuration, 429 past two concurrent judges.</td></tr>
+              <tr><td><code>GET /api/sessions/{selector}/agents</code></td><td>The subagent graph behind agent lenses.</td></tr>
+              <tr><td><code>GET /api/sessions/{selector}/agents/{id}/trace</code></td><td>One subagent’s trace, re-projected onto the root session’s map.</td></tr>
+              <tr><td><code>GET /api/repomap?repo=PATH</code></td><td>A session-less citymap of any local repository — the static map view.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>The CLI</h2>
+        <div class="wiki-table-wrap">
+          <table class="wiki-table wiki-matrix">
+            <thead><tr><th>Command</th><th>What it does</th></tr></thead>
+            <tbody>
+              <tr><td><code>spacewalk serve</code></td><td>Scan the session directories and serve the UI; the default when no arguments are given. Flags: --port (default 0, a random local port), --claude-dir, --codex-dir, --pi-dir, --dev, --no-open.</td></tr>
+              <tr><td><code>spacewalk open &lt;session.jsonl&gt;</code></td><td>Serve and open one specific session file.</td></tr>
+              <tr><td><code>spacewalk map &lt;repo&gt;</code></td><td>Open the repository citymap with no session; height reads as lines of code.</td></tr>
+              <tr><td><code>spacewalk build &lt;repo&gt; [-o out]</code></td><td>Write citymap.json offline.</td></tr>
+              <tr><td><code>spacewalk trace &lt;session&gt; [-o out]</code></td><td>Write trace.json offline — the join point for external tooling.</td></tr>
+              <tr><td><code>spacewalk analyze &lt;session&gt;</code></td><td>Run the judge offline. Flags: --judge claude or codex, --model, --no-cache, --no-rubric, --timeout (default 10m).</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="wiki-note"><code>make build</code> embeds the web bundle and
+        produces <code>bin/spacewalk</code>; this machine runs
+        <code>bin/spacewalk serve --port 8765</code> so the UI is always at
+        the same address.</p>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Customizing it</h2>
+        <p>The theme is a token system: the flat data-encoding swatches live
+        in the <code>:root</code> block of <code>web/src/styles.css</code>, the
+        scenes’ emissive touch tints live in
+        <code>web/src/scene/sceneUtils.ts</code>, and the terrain’s structural
+        colors — unvisited, ghost, and the lines-of-code gradient — are still
+        local to <code>web/src/scene/CityScene.tsx</code>. The palette is
+        chosen so the three touch states stay separable without hue alone:
+        olive, steel, and lime differ in lightness as well as hue, and rust is
+        reserved for error so no data state can be mistaken for trouble. These
+        are deliberately <em>not</em> the raw xo-space brand tokens — fed to a
+        six-check validator as a categorical set against the night sky, the
+        brand greens land at ΔE 11.1 for normal vision against a floor of 15,
+        meaning seen and edited blur together even with full color vision. The
+        shipped triad clears that gate at ΔE 17.4 normal and 16.1 under
+        simulated deuteranopia; the run and its thresholds are recorded in the
+        fork at <code>docs/palette-validation.md</code>. Every swatch clears
+        3:1 against the <code>#0b0c0f</code> sky;
+        <code>--touch-hit</code> measures 3.3:1 there, so it is a fill color,
+        not a small-text color.</p>
+        <div class="wiki-table-wrap">
+          <table class="wiki-table">
+            <thead><tr><th>Token</th><th>Value</th><th>Carries</th></tr></thead>
+            <tbody>
+              <tr><td><code>--touch-hit</code></td><td><code>#6a6700</code></td><td>seen files (olive)</td></tr>
+              <tr><td><code>--touch-read</code></td><td><code>#5399d1</code></td><td>read files (steel)</td></tr>
+              <tr><td><code>--touch-edit</code></td><td><code>#78a31e</code></td><td>edited files (lime)</td></tr>
+              <tr><td><code>--hot</code> / <code>--alarm</code></td><td><code>#c8674c</code></td><td>errors and the trail ember — rust is reserved for trouble</td></tr>
+              <tr><td><code>--act-search</code></td><td><code>#99927e</code></td><td>search activity, a deliberate warm neutral</td></tr>
+              <tr><td><code>--act-exec</code></td><td><code>#57687d</code></td><td>exec activity, a deliberate cool neutral</td></tr>
+              <tr><td><code>--act-verify</code></td><td><code>#477120</code></td><td>verification runs</td></tr>
+              <tr><td><code>--accent</code> / <code>--accent-deep</code></td><td><code>#a8d94f</code> / <code>#83d63a</code></td><td>UI accent, matching the XO logo green</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="wiki-table-wrap">
+          <table class="wiki-table wiki-matrix">
+            <thead><tr><th>Where the knobs live</th><th>What it owns</th></tr></thead>
+            <tbody>
+              <tr><td><code>web/src/styles.css</code> <code>:root</code></td><td>The flat data swatches above, and the <code>#0b0c0f</code> sky.</td></tr>
+              <tr><td><code>web/src/scene/sceneUtils.ts</code></td><td>Emissive touch tints shared by both scenes.</td></tr>
+              <tr><td><code>web/src/scene/CityScene.tsx</code></td><td>Column height bases, plus the unvisited, ghost, and lines-of-code gradient colors.</td></tr>
+              <tr><td><code>web/src/scene/treeLayout.ts</code></td><td>Angular slots and the outer radius of the firefly tree.</td></tr>
+              <tr><td><code>web/src/ui/Timeline.tsx</code></td><td>Histogram bucket count and the playback speeds.</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <ol class="wiki-steps">
+          <li><b>Add a harness adapter.</b><p>Implement the five-method
+          <code>adapter.Source</code> interface in a new
+          <code>internal/adapter/&lt;name&gt;</code> package. Detection must
+          be content-based: set a recognized flag per line and return an error
+          otherwise, so the adapter chain can fall through.</p></li>
+          <li><b>Register it in three chains.</b><p>The server adapter list in
+          <code>internal/server/server.go</code>, the CLI fallthrough in
+          <code>cmd/spacewalk/main.go</code>, and the offline bench in
+          <code>cmd/rubriceval/main.go</code> — which today registers
+          claude-code and codex only, so add yours there too if you want it
+          benchable. Give serve and open a --&lt;name&gt;-dir flag.</p></li>
+          <li><b>Update schema and tests together.</b><p>Any change to an
+          exported JSON shape lands with its mirror in
+          <code>schema/</code> and the tests in the same change — the repo
+          contract treats the schemas as part of the API.</p></li>
+        </ol>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Space Walk in the quirq program</h2>
+        <p>The quirq calculus prices a unit of work u = (S₀, G, τ, B): commit
+        a before-state, a weighted check battery, a threshold, and a budget,
+        then score only the captured after-state S₁. Axiom A2 is that checks
+        read captured state only, never the worker’s transcript — which is
+        exactly why traces matter here: a trace can never be a check, which
+        makes it the natural audit-evidence layer for the gold-score sampling
+        §2.7 uses to estimate its gaps. That pairing is this wiki’s proposal,
+        not a dependency the whitepaper already has. A trace carries
+        <code>session.cwd</code> and <code>session.commit</code>, so sessions
+        join deterministically to a repository and to tag-delimited unit
+        windows. The recipes below pair Space Walk with the quirq
+        calculator’s git observation API; quirq’s machine-local watcher state
+        is a different layer.</p>
+      </section>
+
+      <aside class="wiki-callout wiki-tab-callout">
+        <div><b>Watcher state is the other half</b><p>Space Walk reads the
+        runtimes’ native session logs directly; quirq’s watcher derives its own
+        operational model from the same sources. The Sessions tab reads the
+        same Claude Code and Codex stores for token telemetry, where Space Walk
+        reads them for geometry — neither writes them. Compare machine-local
+        watcher state with portable .xo outputs side by side in the Quirq
+        view, opened from Setup’s header.</p></div>
+        <button type="button" data-open-tab="quirq">Open Quirq</button>
+      </aside>
+
+      <section class="wiki-section">
+        <h2>Recipe 1 · Did the walk stay inside the settled diff?</h2>
+        <div class="wiki-recipe">
+          <div class="wiki-recipe-step"><small>1</small><b>Pin the states</b>
+          <code>POST /api/repo/tag</code>
+          <p>Tag S₀ in the calculator when the unit starts and S₁ at
+          settlement; the body carries path, name, and an optional ref.</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>2</small><b>Pull both records</b>
+          <code>GET /api/repo/compare?path=&lt;repo&gt;&amp;from=u42-s0&amp;to=u42-s1</code>
+          <p>The net per-file diff is the state delta the check battery G
+          reads; <code>spacewalk trace</code> gives the touch map of the same
+          repository.</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>3</small><b>Overlay</b>
+          <p>Touched but absent from the diff is churn that never reached S₁ —
+          cost without Q. Changed but never touched is an out-of-band edit: a
+          human-rescue or contamination candidate, and Definition 4’s
+          attribution rule — human rescue attributed to the rescued unit —
+          says it must land on this unit’s C_total instead of being
+          dropped.</p></div>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Recipe 2 · What audit evidence backs V?</h2>
+        <div class="wiki-recipe">
+          <div class="wiki-recipe-step"><small>1</small><b>Judge the session</b>
+          <code>spacewalk analyze &lt;session&gt;</code>
+          <p>The rubric derives task-specific criteria and scores them against
+          real event seqs.</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>2</small><b>Read a shadow V</b>
+          <p>Per-criterion verdicts approximate a gold score for the unit, and
+          coverage grades force insufficient-data instead of guessing.</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>3</small><b>Feed O</b>
+          <p>Compare the shadow score against the state-addressed V from G to
+          estimate the overstatement gap O(T), which is the only gap the
+          correction spends: QER*(T) = QER(T)·(1 − O(T)). The understatement
+          gap U(T) is defined beside it but unused, and the whitepaper marks
+          the whole correction OPEN — it discounts linearly and applies a
+          portfolio-level fix to a concentrated problem.</p></div>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Recipe 3 · What did the human leg cost?</h2>
+        <div class="wiki-recipe">
+          <div class="wiki-recipe-step"><small>1</small><b>Collect marks</b>
+          <code>marks[] type user-message</code>
+          <p>Every mid-unit human message is a seq-positioned mark, and
+          <code>stats.userTurns</code> counts them.</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>2</small><b>Meter h</b>
+          <p>Count marks — and duration, via event timestamps — between the S₀
+          and S₁ tags, price the time at r_human, and add the leg to
+          C_total.</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>3</small><b>Respect the bias
+          bound</b>
+          <p>Omitting the human leg inflates efficiency: at a $0.128
+          machine-cost unit and a $65/h loaded rate, 30 seconds of rescue
+          inflates naive QER 5.2× — and cheaper inference makes that worse, not
+          better. Noise in the meter is tolerable; gaps in it are not.</p></div>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Recipe 4 · What is QER for this repository?</h2>
+        <div class="wiki-recipe">
+          <div class="wiki-recipe-step"><small>1</small><b>Group sessions</b>
+          <code>trace.session.cwd + commit</code>
+          <p>Sessions group deterministically to a repository and to the unit
+          windows the calculator’s tags delimit.</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>2</small><b>Compute honestly</b>
+          <p>QER(T) = ΣQ/ΣC strictly as a ratio of sums — the whitepaper’s
+          worked example shows mean-of-ratios flattering the portfolio by
+          55% — and never quoted without n and CV.</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>3</small><b>Drill into light</b>
+          <code>GET /api/sessions/{selector}/snapshot</code>
+          <p>Click any unit tile in the dashboard and replay that session on
+          its map.</p></div>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Recipe 5 · Is inference changing S₁ at all?</h2>
+        <div class="wiki-recipe">
+          <div class="wiki-recipe-step"><small>1</small><b>Input meter</b>
+          <code>events[].resultBytes</code>
+          <p>Cumulative result bytes and action counts are the input meter —
+          light moving on the map.</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>2</small><b>Output meter</b>
+          <p>The running S₀→S₁ diff footprint from the calculator is the
+          output meter: files whose settled content actually changed.</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>3</small><b>Spot divergence</b>
+          <p>A glowing map with no settled change is meter separation made
+          visible: inference that does not change S₁ cannot change V or Q,
+          while it does change C_total.
+          <code>stats.eventsBeforeFirstEdit</code> already summarizes the
+          opening stretch of exactly this pattern.</p></div>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Interpretation and troubleshooting</h2>
+        <div class="wiki-check-grid">
+          <div><b>No sessions listed</b><p>Point the scan at the right
+          directories with --claude-dir, --codex-dir, or --pi-dir. Recognition
+          is content-based, so a renamed <code>.jsonl</code> still parses, but
+          a wrong directory yields nothing at all.</p></div>
+          <div><b>Empty terrain, live trace</b><p>The session’s
+          <code>cwd</code> is not this repository. The map is built from cwd
+          plus commit, never from the paths the events happen to name.</p></div>
+          <div><b>Tilde on the error count</b><p>Estimated observability: codex
+          infers failures from output text, and a claude-code or pi session
+          grades estimated too as soon as its log leaves one outcome
+          unknown.</p></div>
+          <div><b>Wireframe orbs or grey tiles</b><p>Ghosts — strongly attested
+          touches provably gone from the repo. A file that is merely
+          unreadable gets no tile, because a ghost there would lie.</p></div>
+          <div><b>Judge unavailable</b><p>Neither <code>claude</code> nor
+          <code>codex</code> is on PATH; the report route lists the CLIs it
+          actually found.</p></div>
+          <div><b>429 on analyze</b><p>Two judge runs are already active. The
+          server caps concurrency at two subprocesses and asks you to wait for
+          one to finish.</p></div>
+          <div><b>Stale session list</b><p>The list is cached 5 seconds and
+          <code>?fresh=1</code> bypasses it; repository maps are cached 30
+          seconds.</p></div>
+          <div><b>Heights look wrong</b><p>Attention height exists only with a
+          session loaded. In the session-less map view the same tiles extrude
+          by lines of code instead.</p></div>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Primary research sources</h2>
+        <div class="wiki-table-wrap">
+          <table class="wiki-table wiki-matrix wiki-sources">
+            <thead><tr><th>Source</th><th>What it establishes</th></tr></thead>
+            <tbody>
+              <tr><td><a href="https://github.com/cosmtrek/mindwalk" target="_blank" rel="noreferrer">github.com/cosmtrek/mindwalk</a></td><td>The upstream project Space Walk forks — MIT-licensed, by cosmtrek (Ricko Yu).</td></tr>
+              <tr><td><a href="https://www.win.tue.nl/~vanwijk/stm.pdf" target="_blank" rel="noreferrer">Bruls, Huizing &amp; van Wijk — Squarified Treemaps</a></td><td>The layout family <code>squarified-treemap-v1</code> derives from: rows packed against the shorter remaining side to keep tiles near-square. Space Walk’s v1 scores row breaks with the paper’s aspect metric but lays each row along the longer side, so it is deterministic without being the paper’s procedure.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <aside class="wiki-callout">
+        <b>Short mental model</b>
+        <p>The trace remembers where the agent’s attention went. The citymap
+        remembers what the repository looks like. Space Walk multiplies the
+        two into light — and quirq prices what the light settled.</p>
       </aside>
     </article>`;
 }

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -175,7 +175,12 @@ class RuntimeConfigTests(unittest.TestCase):
             ),
         ):
             self.assertTrue(runtime_config.secrets_restart_required())
-            self.assertEqual(runtime_config.restart_reasons(), ["secrets"])
+            with patch.object(
+                runtime_config,
+                "roots_restart_required",
+                return_value=False,
+            ):
+                self.assertEqual(runtime_config.restart_reasons(), ["secrets"])
 
     def test_source_diagnostics_count_sessions_without_reading_values(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -205,6 +210,73 @@ class RuntimeConfigTests(unittest.TestCase):
             self.assertTrue(rows[0]["watched"])
             self.assertTrue(rows[0]["secrets"][0]["configured"])
             self.assertNotIn("redacted", repr(rows))
+
+    def test_applied_roots_come_from_the_shared_project_layout_helper(self) -> None:
+        """Setup must report the root the rest of the app resolves, not a
+        second copy of the env lookup."""
+        with tempfile.TemporaryDirectory() as tmp:
+            projects_root = Path(tmp) / "projects"
+            state_root = Path(tmp) / "state"
+            state_root.mkdir()
+            env = {
+                "XO_PROJECTS_ROOT": str(projects_root),
+                "QUIRQ_STATE_ROOT": str(state_root),
+            }
+            for stale in ("QUIRQ_HOST_PROJECTS_ROOT", "QUIRQ_HOST_STATE_ROOT"):
+                os.environ.pop(stale, None)
+            with patch.dict(os.environ, env, clear=False):
+                from services.cowork_agent.project_layout import xo_projects_root
+
+                applied = runtime_config.applied_roots()
+                self.assertEqual(
+                    applied["xo_projects_root"],
+                    str(xo_projects_root()),
+                )
+                # Nothing saved yet: configured mirrors applied, no restart.
+                status = runtime_config.root_settings()
+                self.assertFalse(status["change_required"])
+                self.assertTrue(status["applied_on_restart"])
+                self.assertFalse(runtime_config.roots_restart_required())
+
+    def test_saved_root_marks_a_restart_and_survives_symlinked_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            real = Path(tmp) / "real-projects"
+            real.mkdir()
+            link = Path(tmp) / "linked-projects"
+            link.symlink_to(real, target_is_directory=True)
+            state_root = Path(tmp) / "state"
+            state_root.mkdir()
+            for stale in ("QUIRQ_HOST_PROJECTS_ROOT", "QUIRQ_HOST_STATE_ROOT"):
+                os.environ.pop(stale, None)
+            env = {
+                "XO_PROJECTS_ROOT": str(link),
+                "QUIRQ_STATE_ROOT": str(state_root),
+            }
+            with patch.dict(os.environ, env, clear=False):
+                # Saving the symlinked spelling of the root in use is not a
+                # change: xo_projects_root() resolves, the Setup field does not.
+                runtime_config.save_root_settings(
+                    {
+                        "xo_projects_root": str(link),
+                        "quirq_state_root": str(state_root),
+                    }
+                )
+                self.assertFalse(runtime_config.root_settings()["change_required"])
+                self.assertNotIn("roots", runtime_config.restart_reasons())
+
+                # A genuinely different root is a restart reason, because
+                # startup reads roots.env (see server.py).
+                elsewhere = Path(tmp) / "other-projects"
+                runtime_config.save_root_settings(
+                    {
+                        "xo_projects_root": str(elsewhere),
+                        "quirq_state_root": str(state_root),
+                    }
+                )
+                status = runtime_config.root_settings()
+                self.assertTrue(status["change_required"])
+                self.assertEqual(status["configured"]["xo_projects_root"], str(elsewhere))
+                self.assertIn("roots", runtime_config.restart_reasons())
 
     def test_watcher_can_load_every_manifest_source(self) -> None:
         manifests = [

--- a/tests/test_space_wiki.py
+++ b/tests/test_space_wiki.py
@@ -1,10 +1,27 @@
 from __future__ import annotations
 
+import re
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def view_contract(view: str) -> str:
+    """The `export default {...}` head of a Space view module.
+
+    Nav assertions have to be scoped to this slice, not run against the whole
+    file: wiki.js is mostly documentation prose that legitimately quotes the
+    view contract (``nav:false``, ``parent:'secrets'``) while describing how
+    the app is wired, and a whole-file assertNotIn would fail on the docs
+    rather than on the behaviour it means to pin.
+    """
+    source = (
+        ROOT / "space_ui" / "js" / "views" / f"{view}.js"
+    ).read_text(encoding="utf-8")
+    head = source.split("export default", 1)[1]
+    return head[: head.index("mount(")]
 
 
 class SpaceWikiTests(unittest.TestCase):
@@ -15,18 +32,13 @@ class SpaceWikiTests(unittest.TestCase):
         self.assertIn("import wikiView from './views/wiki.js?v=", app)
         self.assertIn("registerView(wikiView);", app)
         self.assertIn('href="css/wiki.css?v=', index)
-        # The wiki has no top-level tab: it opens from the Setup header
-        # button, and Setup's tab stays lit while it is open.
-        wikijs = (
-            ROOT / "space_ui" / "js" / "views" / "wiki.js"
-        ).read_text(encoding="utf-8")
-        self.assertIn("nav:false", wikijs)
-        self.assertIn("parent:'secrets'", wikijs)
-        secrets = (
-            ROOT / "space_ui" / "js" / "views" / "secrets.js"
-        ).read_text(encoding="utf-8")
-        self.assertIn('id="setup-wiki"', secrets)
-        self.assertIn("switchTo('wiki')", secrets)
+        # The wiki is a top-level tab of its own. Order 7 is load-bearing:
+        # it keeps Wiki between Sessions (4) and Setup (9), which is the nav
+        # slot — and therefore the number hotkey — Quirq used to hold.
+        contract = view_contract("wiki")
+        self.assertIn("id:'wiki',label:'Wiki',order:7,", contract)
+        self.assertNotIn("nav:false", contract)
+        self.assertNotIn("parent:", contract)
         # The intro overlays are gone from Graph and Dashboard.
         self.assertNotIn('id="intro"', index)
         dashboard_builder = (
@@ -72,6 +84,23 @@ class SpaceWikiTests(unittest.TestCase):
         self.assertIn('href="css/quirq.css?v=', index)
         self.assertIn("id:'quirq'", quirq)
         self.assertIn("/api/quirq", quirq)
+        # Quirq has no top-level tab: it opens from the Setup header button,
+        # and Setup's tab stays lit while it is open.
+        contract = view_contract("quirq")
+        self.assertIn("nav:false", contract)
+        self.assertIn("parent:'secrets'", contract)
+        # The button id and the handler that reads it must move together: an
+        # unguarded querySelector on a renamed id throws inside mount(), and
+        # the registry bulkheads the whole Setup view behind its error card —
+        # taking the only in-app route to Quirq down with it.
+        secrets = (
+            ROOT / "space_ui" / "js" / "views" / "secrets.js"
+        ).read_text(encoding="utf-8")
+        self.assertIn('id="setup-quirq"', secrets)
+        self.assertIn("Open Quirq state", secrets)
+        self.assertIn("querySelector('#setup-quirq')", secrets)
+        self.assertIn("switchTo('quirq')", secrets)
+        self.assertNotIn("setup-wiki", secrets)
         # Six Degrees was removed: no child lens, no lens switch, no view.
         self.assertNotIn("data-atlas-lens", index)
         self.assertNotIn("view-six", index)
@@ -136,13 +165,71 @@ class SpaceWikiTests(unittest.TestCase):
         self.assertIn("support.google.com/docs/answer/190843", wiki)
         index = (ROOT / "space_ui" / "index.html").read_text(encoding="utf-8")
         self.assertIn("css/wiki.css?v=20260725-collaboration1", index)
-        self.assertIn("js/app.js?v=20260813-timeline3", index)
 
-    def test_wiki_has_a_dedicated_guide_for_every_top_level_tab(self) -> None:
+    def test_wiki_documents_space_walk_session_replay(self) -> None:
         wiki = (ROOT / "space_ui" / "js" / "views" / "wiki.js").read_text(
             encoding="utf-8"
         )
 
+        self.assertIn("id:'spacewalk'", wiki)
+        self.assertIn("spacewalk:spaceWalkArticle", wiki)
+        self.assertIn("Space Walk session replay", wiki)
+        self.assertIn("Sessions replayed as light", wiki)
+        self.assertIn("bin/spacewalk serve --port 8765", wiki)
+        # The local-except-the-judge carve-out the upstream README also makes.
+        self.assertIn("Replay is entirely local", wiki)
+        self.assertIn("The one exception is the optional", wiki)
+        self.assertNotIn("Everything runs locally", wiki)
+        # The touch lattice and its data-encoding palette (hexes live in the
+        # token table only, so the lattice table cannot drift from them).
+        self.assertIn("edit &gt; read &gt; hit", wiki)
+        self.assertIn("#6a6700", wiki)
+        self.assertIn("#5399d1", wiki)
+        self.assertIn("#78a31e", wiki)
+        self.assertNotIn("validated for color-vision", wiki)
+        # Geometry facts verified against the Space Walk source tree.
+        self.assertIn("squarified-treemap-v1", wiki)
+        self.assertIn("sqrt(max(lines, bytes/4096, 16))", wiki)
+        self.assertIn("160-bucket histogram", wiki)
+        # Per-session observability grading, not per-harness.
+        self.assertIn("session, not per harness", wiki)
+        # Boundaries: a trace is transcript-adjacent, and nothing is written back.
+        self.assertIn("A trace is not <code>.xo</code>-safe", wiki)
+        self.assertIn("~/.spacewalk/judge", wiki)
+        # Failure handling, the idiom every other long article carries.
+        self.assertIn("Interpretation and troubleshooting", wiki)
+        self.assertIn("Tilde on the error count", wiki)
+        # HTTP surface, CLI, and the judge report cache.
+        self.assertIn("GET /api/sessions/{selector}/snapshot", wiki)
+        self.assertIn("spacewalk analyze &lt;session&gt;", wiki)
+        self.assertIn("~/.spacewalk/reports/&lt;sessionKey&gt;.json", wiki)
+        # Quirq recipes cross-link the Quirq view (opened from Setup) and
+        # the upstream project. data-open-tab routes through ctx.switchTo,
+        # which reaches nav:false views just as well as tabs.
+        self.assertIn('data-open-tab="quirq"', wiki)
+        self.assertIn("Recipe 5 · Is inference changing S₁ at all?", wiki)
+        self.assertIn("https://github.com/cosmtrek/mindwalk", wiki)
+        # Calculator routes are callable as printed, and the quirq citations
+        # match the corpus: Definition 4 attributes rescue, O alone corrects.
+        self.assertIn(
+            "GET /api/repo/compare?path=&lt;repo&gt;&amp;from=u42-s0&amp;to=u42-s1",
+            wiki,
+        )
+        self.assertIn("human rescue attributed to the rescued unit", wiki)
+        self.assertIn("QER*(T) = QER(T)·(1 − O(T))", wiki)
+        self.assertIn("$65/h loaded rate", wiki)
+        self.assertNotIn("that A2 says must be", wiki)
+        # The cache-bust chain itself is checked structurally in
+        # test_cache_bust_chain_is_intact, not pinned to a literal here.
+
+    def test_wiki_has_a_dedicated_guide_for_every_reachable_view(self) -> None:
+        wiki = (ROOT / "space_ui" / "js" / "views" / "wiki.js").read_text(
+            encoding="utf-8"
+        )
+
+        # Every navbar tab, plus Quirq — which has no tab of its own but is
+        # reachable from Setup's header and by #/quirq, so it still earns a
+        # guide. Adding a navbar tab without a guide should fail here.
         for page_id in (
             "tab-dashboard",
             "tab-files",
@@ -154,8 +241,8 @@ class SpaceWikiTests(unittest.TestCase):
         ):
             self.assertIn(f"id:'{page_id}'", wiki)
             self.assertIn(f"'{page_id}':", wiki)
-        # Chat is hidden from the tab bar, so it gets no tab guide; Graph and
-        # Projects merged into the Files tab and its single guide.
+        # Chat is hidden from the tab bar and unregistered, so it gets no
+        # guide; Graph and Projects merged into the Files tab and its guide.
         self.assertNotIn("id:'tab-chat'", wiki)
         self.assertNotIn("id:'tab-graph'", wiki)
         self.assertNotIn("id:'tab-projects'", wiki)
@@ -165,6 +252,251 @@ class SpaceWikiTests(unittest.TestCase):
         self.assertNotIn("Six Degrees", wiki)
         self.assertIn("one page per tab", wiki)
         self.assertIn("space:wiki-page", wiki)
+
+    def test_dashboard_todos_are_ui_state_not_graph_data(self) -> None:
+        """Clicking a Dashboard project shows its todos on the map and in the
+        panel — without ever putting them in the graph model.
+
+        The model is built once from the dataset and read as a snapshot by
+        LEAVES-derived counts, the timeline's lanes and axis, search and the
+        re-root walk. A todo pushed in there would invent a timeline lane and
+        inflate "N projects". The assertions below are the machine-checkable
+        half of that rule: after the model is built, nothing may push a node
+        or edge or add a byId key.
+        """
+        atlas = (
+            ROOT / "space_ui" / "js" / "views" / "atlas.js"
+        ).read_text(encoding="utf-8")
+
+        # wired: fetch, lifecycle, both surfaces
+        self.assertIn("/api/xo-projects/", atlas)
+        self.assertIn("/todos", atlas)
+        self.assertIn("syncSats(n)", atlas)      # follows the selection
+        self.assertIn("clearSats()", atlas)      # and leaves with it
+        self.assertIn('id="panel-todos"', atlas)  # the list
+        self.assertIn("drawSatDots", atlas)       # the map
+        # dashboard only: in space.json a leaf is a file, not a project
+        self.assertIn("bootDataset==='dashboard'", atlas)
+
+        after_model = atlas.split("const byId=new Map(", 1)[1]
+        for mutation in ("NODES.push(", "EDGES.push(", "byId.set(", "byId.delete("):
+            self.assertNotIn(
+                mutation,
+                after_model,
+                f"{mutation} after the model is built: graph data must come "
+                "from the dataset, not from a view interaction",
+            )
+
+    def test_tree_lens_is_the_third_files_lens(self) -> None:
+        """Tree is a lens of the Files tab, not a tab of its own, and both
+        pills offer all three lenses. A pill that lists a lens the registry
+        does not know about is a dead button."""
+        app = (ROOT / "space_ui" / "js" / "app.js").read_text(encoding="utf-8")
+        index = (ROOT / "space_ui" / "index.html").read_text(encoding="utf-8")
+        projects = (
+            ROOT / "space_ui" / "js" / "views" / "projects.js"
+        ).read_text(encoding="utf-8")
+        tree = (ROOT / "space_ui" / "js" / "views" / "tree.js").read_text(
+            encoding="utf-8"
+        )
+        wiki = (ROOT / "space_ui" / "js" / "views" / "wiki.js").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("import treeView from './views/tree.js?v=", app)
+        self.assertIn("registerView(treeView);", app)
+        contract = view_contract("tree")
+        self.assertIn("id:'tree',label:'Tree'", contract)
+        self.assertIn("nav:false", contract)
+        self.assertIn("parent:'projects'", contract)
+        # every surface that renders the pill offers the same three lenses
+        for source in (index, projects, tree):
+            for lens in ("projects", "graph", "tree"):
+                self.assertIn(f'data-files-lens="{lens}"', source)
+        # it reads the same dataset as the Graph
+        self.assertIn("data/space.json", tree)
+        # clicking a file previews it; it must not navigate. The Graph
+        # hand-off lives in the previewer, as an explicit button.
+        self.assertIn("space:preview-file", tree)
+        self.assertNotIn("space:focus-project", tree)
+        # horizontal: the root is at depth 0 on the left and every level of
+        # containers opens one column to the right, drawn on an absolutely
+        # positioned surface with an SVG connector layer under the chips.
+        self.assertIn("const COL_W=", tree)
+        self.assertIn("PAD_X+depth*COL_W", tree)
+        self.assertIn("tv-surface", tree)
+        self.assertIn("tv-links", tree)
+        # leaves are the exception: they stack vertically beside their folder
+        # instead of each claiming a column of their own
+        self.assertIn("tv-stack", tree)
+        self.assertIn("FILE_H", tree)
+        # the tree reads as growth: branch thickness scales with what a limb
+        # holds, new limbs draw themselves in, and the node you expanded stays
+        # put instead of the reflow shoving the root off screen
+        self.assertIn("const weight=", tree)
+        self.assertIn("pathLength=", tree)
+        self.assertIn("is-growing", tree)
+        self.assertIn("function restoreScroll", tree)
+        self.assertIn("anchor=", tree)
+        # Wiki Files guide must stay aligned with the three-lens UI (drift here
+        # is how "two lenses" docs survive after Tree ships).
+        self.assertIn("three lenses", wiki)
+        self.assertIn("List | Graph | Tree", wiki)
+        self.assertIn("#/tree", wiki)
+        self.assertIn("/api/xo-projects/{id}/tree", wiki)
+        self.assertNotIn("one home, two lenses", wiki)
+        self.assertNotIn("'List | Graph lens switch'", wiki)
+
+    def test_file_explorer_reads_the_detailed_tree_endpoint(self) -> None:
+        """The Files drawer browses a project folder by folder, and the wire
+        model carries the detail it renders."""
+        projects = (
+            ROOT / "space_ui" / "js" / "views" / "projects.js"
+        ).read_text(encoding="utf-8")
+        bff = (
+            ROOT / "routers" / "cowork_agent" / "bff" / "xo_projects.py"
+        ).read_text(encoding="utf-8")
+        layout = (
+            ROOT / "services" / "cowork_agent" / "project_layout.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("/tree", projects)
+        self.assertIn("relative_path=", projects)
+        self.assertIn("fx-crumbs", projects)      # breadcrumb navigation
+        # folders and files get their own pane: one mixed list means hunting
+        # for the folder rows among fifty files at every level
+        self.assertIn("fx-dirs", projects)
+        self.assertIn("fx-files", projects)
+        self.assertIn("size_bytes", projects)     # per-file detail
+        self.assertIn("modified_at", projects)
+        # the detail fields are optional on the wire: a broken symlink or a
+        # file deleted mid-listing must still list, just without detail
+        for field in ("is_dir: bool", "size_bytes: Optional[int]",
+                      "modified_at: Optional[str]", "entries: Optional[int]"):
+            self.assertIn(field, bff)
+        self.assertIn("st_size", layout)
+        self.assertIn("st_mtime", layout)
+
+    def test_previewer_renders_untrusted_files_safely(self) -> None:
+        """Opening a file shows it in the side drawer without navigating, and
+        without giving a file on disk the run of this document.
+
+        Workspace files are agent output, not trusted content, and this page
+        holds the user's session. Markdown goes through the escape-first
+        renderer; HTML renders in an iframe with an EMPTY sandbox attribute
+        (no allow-scripts, no allow-same-origin) so it cannot reach the page,
+        its storage, or the API it is served from.
+        """
+        preview = (
+            ROOT / "space_ui" / "js" / "core" / "preview.js"
+        ).read_text(encoding="utf-8")
+        app = (ROOT / "space_ui" / "js" / "app.js").read_text(encoding="utf-8")
+        index = (ROOT / "space_ui" / "index.html").read_text(encoding="utf-8")
+
+        self.assertIn("initPreview", app)
+        self.assertIn('id="preview"', index)
+        self.assertIn('href="css/preview.css?v=', index)
+        # markdown through the escape-first renderer, never raw
+        self.assertIn("mdToHtml", preview)
+        # HTML only ever inside an empty sandbox
+        self.assertIn('sandbox=""', preview)
+        self.assertIn("srcdoc=", preview)
+        self.assertNotIn("allow-scripts", preview)
+        self.assertNotIn("allow-same-origin", preview)
+        # every surface opens it through the event, so no view imports another
+        for view in ("tree", "projects", "atlas"):
+            source = (
+                ROOT / "space_ui" / "js" / "views" / f"{view}.js"
+            ).read_text(encoding="utf-8")
+            self.assertIn("space:preview-file", source)
+            self.assertNotIn("core/preview.js", source)
+
+    def test_file_preview_endpoint_is_bounded_and_scoped(self) -> None:
+        """The preview endpoint addresses files by project id + relative path,
+        never by absolute host path, and refuses anything it cannot show."""
+        bff = (
+            ROOT / "routers" / "cowork_agent" / "bff" / "xo_projects.py"
+        ).read_text(encoding="utf-8")
+        layout = (
+            ROOT / "services" / "cowork_agent" / "project_layout.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('"/api/xo-projects/{project_id}/file"', bff)
+        self.assertIn("PREVIEW_MAX_BYTES", bff)
+        self.assertIn("PREVIEW_SUFFIXES", bff)
+        self.assertIn("preview_unsupported", bff)
+        # the read helper enforces the same path rules as the tree listing
+        self.assertIn("def read_project_file", layout)
+        self.assertIn("relative_path escapes project root", layout)
+        self.assertIn("max_bytes", layout)
+
+    def test_files_list_rows_carry_signal_and_are_operable(self) -> None:
+        """The List lens is the Files tab's landing view; a row has to say
+        something. It fills its columns from workspace-wide requests — four
+        in total, not four per project — and its header is a real button."""
+        projects = (
+            ROOT / "space_ui" / "js" / "views" / "projects.js"
+        ).read_text(encoding="utf-8")
+        workspace = (
+            ROOT / "space_ui" / "js" / "core" / "workspace.js"
+        ).read_text(encoding="utf-8")
+
+        # counts come from the one cached dataset, never per project
+        self.assertIn("workspaceCounts", projects)
+        self.assertIn("data/space.json", workspace)
+        # live + last-active come from the workspace-scope endpoints
+        self.assertIn("/api/xo-projects/activity", projects)
+        self.assertIn("/api/xo-projects/timeline?limit=", projects)
+        self.assertNotIn("/todos'", projects.split("const PANELS")[0])
+        # operable: filter, sort, and a refresh that keeps the open drawer
+        self.assertIn('id="prj-filter"', projects)
+        self.assertIn("data-sort=", projects)
+        self.assertIn("if(expanded&&!items.some", projects)
+        # accessible: a real button that reports its state, with Map outside
+        # it (a button inside a button is invalid markup)
+        self.assertIn('<button class="prj-row-head"', projects)
+        self.assertIn('aria-expanded="', projects)
+        self.assertIn('aria-controls="prj-drawer-', projects)
+        head = projects.split('class="prj-row-head"')[1].split("</button>")[0]
+        self.assertNotIn("prj-map", head)
+
+    def test_project_description_falls_back_to_project_docs(self) -> None:
+        """Every row showing only "created 11d ago" was the complaint. The
+        list endpoint fills `description` from the project's own docs when
+        .xo/project.json has none — excluding AGENTS.md, whose opening line
+        is identical in every scaffolded project."""
+        bff = (
+            ROOT / "routers" / "cowork_agent" / "bff" / "xo_projects.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("_DESC_FILES", bff)
+        self.assertIn('"README.md"', bff)
+        self.assertNotIn('"AGENTS.md"', bff)
+        self.assertIn("_described(name)", bff)
+        self.assertIn("_DESC_MAX", bff)
+
+    def test_cache_bust_chain_is_intact(self) -> None:
+        """index.html's app.js stamp must be at least as new as every view stamp.
+
+        Starlette's StaticFiles mount (routers/space.py) sends no Cache-Control,
+        so browsers apply heuristic freshness to these module URLs. app.js is
+        versioned only by the script tag in index.html: a browser holding the
+        cached app.js keeps importing the OLD per-view URLs, which silently
+        defeats every per-view bump. Pinning literals here instead just turns
+        unrelated tests red on the next legitimate bump.
+        """
+        app = (ROOT / "space_ui" / "js" / "app.js").read_text(encoding="utf-8")
+        index = (ROOT / "space_ui" / "index.html").read_text(encoding="utf-8")
+
+        view_stamps = re.findall(r"\?v=(\d{8})-[a-z0-9]+", app)
+        self.assertTrue(view_stamps, "app.js carries no ?v= stamps")
+        shell = re.search(r"js/app\.js\?v=(\d{8})-[a-z0-9]+", index)
+        self.assertIsNotNone(shell, "index.html does not version js/app.js")
+        self.assertGreaterEqual(
+            shell.group(1),
+            max(view_stamps),
+            "bump the app.js stamp in index.html whenever a view stamp moves",
+        )
 
     def test_installation_guide_documents_one_command_setup(self) -> None:
         guide = (ROOT / "INSTALLATION.md").read_text(encoding="utf-8")

--- a/tests/test_xo_root_identity.py
+++ b/tests/test_xo_root_identity.py
@@ -1,0 +1,142 @@
+"""One XO root, one project identity.
+
+Two invariants the Space tabs depend on:
+
+1. **The directory name is the project id.** ``project_layout`` resolves
+   every path as ``xo_projects_root() / name``, so a stale ``name`` inside
+   ``.xo/project.json`` (left behind by a folder rename) must not become the
+   id — it would send readers to the wrong folder and collapse two folders
+   into one node. This is what made the Timeline plot one project while
+   Files listed five: the renamed project's git history was read from a
+   different, git-less folder.
+2. **The XO root the Setup tab saves is the root the process boots with.**
+   ``server.py`` reads ``<state root>/roots.env`` at startup, under the same
+   precedence install.sh uses: shell/container env > roots.env > .env.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from services.cowork_agent import project_layout
+
+# Imported at module scope on purpose: importing server runs its dotenv
+# bootstrap, which mutates os.environ from the developer's real .env and
+# ~/.quirq/roots.env. Doing that lazily inside a test would undo the very
+# environment the test just set up, and the suite would pass or fail
+# depending on whether some earlier test had already imported it.
+import server  # noqa: E402
+
+
+def _project(root: Path, folder: str, meta: dict) -> None:
+    xo = root / folder / ".xo"
+    xo.mkdir(parents=True)
+    (xo / "project.json").write_text(json.dumps(meta), encoding="utf-8")
+
+
+class ProjectIdentityTests(unittest.TestCase):
+    def test_directory_name_wins_over_a_stale_metadata_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # "writings" was created as "site" and renamed on disk later.
+            _project(root, "writings", {"name": "site", "created_at": "2026-07-25"})
+            _project(root, "site", {"name": "site", "created_at": "2026-08-05"})
+            with patch.dict(os.environ, {"XO_PROJECTS_ROOT": str(root)}, clear=False):
+                items = project_layout.list_projects()
+
+        names = sorted(item["name"] for item in items)
+        self.assertEqual(names, ["site", "writings"])
+        # Descriptive fields survive; the id and the label do not lie.
+        display = {item["name"]: item["display_name"] for item in items}
+        self.assertEqual(display["writings"], "writings")
+        self.assertEqual(display["site"], "site")
+
+    def test_a_deliberate_display_name_is_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _project(
+                root,
+                "writings",
+                {"name": "site", "display_name": "The Quirq Papers"},
+            )
+            with patch.dict(os.environ, {"XO_PROJECTS_ROOT": str(root)}, clear=False):
+                items = project_layout.list_projects()
+
+        self.assertEqual(items[0]["name"], "writings")
+        self.assertEqual(items[0]["display_name"], "The Quirq Papers")
+
+    def test_ids_resolve_back_to_their_own_directory(self) -> None:
+        """The id list is only useful if project_dir() round-trips it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _project(root, "writings", {"name": "site"})
+            (root / "writings" / "marker.md").write_text("x", encoding="utf-8")
+            with patch.dict(os.environ, {"XO_PROJECTS_ROOT": str(root)}, clear=False):
+                item = project_layout.list_projects()[0]
+                resolved = project_layout.project_dir(item["name"])
+                self.assertTrue((resolved / "marker.md").is_file())
+
+
+class StorageRootBootTests(unittest.TestCase):
+    """server.py's roots.env loader — the seam that makes the Setup tab's XO
+    root take effect for every tab after a restart."""
+
+    def _load(self, state_root: Path, shell_keys: frozenset[str]):
+        with patch.object(server, "_shell_env_keys", shell_keys):
+            with patch.dict(
+                os.environ,
+                {"QUIRQ_STATE_ROOT": str(state_root)},
+                clear=False,
+            ):
+                server._load_storage_roots()
+                return os.environ.get("XO_PROJECTS_ROOT", "")
+
+    def test_saved_root_is_applied_at_startup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / "state"
+            state_root.mkdir()
+            saved = Path(tmp) / "saved-projects"
+            (state_root / "roots.env").write_text(
+                f"# managed\nXO_PROJECTS_ROOT={saved}\n",
+                encoding="utf-8",
+            )
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("XO_PROJECTS_ROOT", None)
+                self.assertEqual(self._load(state_root, frozenset()), str(saved))
+
+    def test_shell_environment_outranks_the_saved_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / "state"
+            state_root.mkdir()
+            saved = Path(tmp) / "saved-projects"
+            exported = Path(tmp) / "exported-projects"
+            (state_root / "roots.env").write_text(
+                f"XO_PROJECTS_ROOT={saved}\n", encoding="utf-8"
+            )
+            with patch.dict(
+                os.environ,
+                {"XO_PROJECTS_ROOT": str(exported)},
+                clear=False,
+            ):
+                applied = self._load(
+                    state_root,
+                    frozenset({"XO_PROJECTS_ROOT"}),
+                )
+            self.assertEqual(applied, str(exported))
+
+    def test_a_missing_file_changes_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_root = Path(tmp) / "state"
+            state_root.mkdir()
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("XO_PROJECTS_ROOT", None)
+                self.assertEqual(self._load(state_root, frozenset()), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Files gains two sibling lenses and the List is rebuilt; Wiki returns to the navbar and Quirq moves under Setup; one storage root now feeds every tab.

Data + identity
- The directory name is the project id. list_projects() took it from .xo/project.json, so a folder renamed after creation resolved to another project's directory: `writings` (stale name "site") collapsed onto `site`, which is why the Timeline plotted one project while Files listed five.
- server.py reads <state root>/roots.env at startup, under install.sh's precedence (shell/container env > roots.env > .env), so the XO root saved in Setup is the root the process boots with. runtime_config, quirq_catalog and the install pointer now resolve through xo_projects_root() instead of re-implementing the lookup; saved-but-unapplied roots are a restart reason.
- /api/xo-projects/{id}/tree carries is_dir, size_bytes, modified_at and a folder's entry count; new /api/xo-projects/{id}/file previews one text file by project id + relative path (256 KB cap, suffix allowlist) rather than the absolute host path the older /api/files/content takes.
- The list endpoint fills an empty `description` from the project's own README/PROJECT/OBJECTIVES first paragraph. AGENTS.md is excluded: it is the scaffold contract, identical in every project.

UI
- Files -> List: a column grid (project, files, last active) fed by four workspace-wide requests, not four per project, with filter, sort, skeletons, a real <button aria-expanded> row header and a two-pane folder browser.
- Files -> Tree: a new lens. Horizontal hierarchy from the workspace root, one column per depth, files stacked as leaf cards beside the branch that holds them; branch weight scales with subtree size and expansion is anchored so the reflow cannot shove the root off screen.
- Dashboard: clicking a project shows its todos as satellites around the node and as a list in the panel. Satellites are UI state - nothing enters NODES/EDGES/byId, so counts, search and the timeline are untouched.
- File previewer (core/preview.js): markdown through the escape-first renderer, HTML inside an empty-sandbox iframe, everything else as escaped source. Opening a file does not navigate.
- Wiki is a top-level tab again; Quirq keeps #/quirq and opens from Setup's header. Contrast: --ink-3/--ink-4 measured 3.97:1 and 2.27:1 on --bg-3; lifted to 4.57:1 and reserved --ink-4 for glyphs and rules.

Timeline states its coverage ("2 of 5 projects") instead of silently plotting only the projects that have git history.

Not split into per-concern commits: the changes interleave inside shared files (index.html, app.js, projects.js, atlas.js, tests/test_space_wiki.py) and separating them would need interactive staging. wiki.js and tests/test_space_wiki.py also carry uncommitted Space Walk documentation work from an earlier session, which rides along here.

88 tests pass; import gate clean under claude_code / openclaw / hermes / antigravity; all nine UI routes load with no console errors.