### PR TITLE
Resolve project ids to the folder that actually exists

### DIFF
--- a/services/cowork_agent/project_layout.py
+++ b/services/cowork_agent/project_layout.py
@@ -99,8 +99,69 @@ def workspace_xo_dir() -> Path:
 # ── Per-project paths ─────────────────────────────────────────────────────────
 
 
+def _is_safe_segment(value: str) -> bool:
+    """True iff ``value`` is a single, non-hidden path component that can
+    be joined onto the root without escaping it."""
+    if not value or value in (".", ".."):
+        return False
+    if value.startswith("."):
+        return False
+    if "\x00" in value or "/" in value or "\\" in value:
+        return False
+    return Path(value).name == value
+
+
+def resolve_project_dirname(name: str) -> str:
+    """Map a caller-supplied project name onto the **actual** directory
+    name under ``xo_projects_root()``.
+
+    The directory name is the project id (see :func:`list_projects`), and
+    discovery hands that literal name to every other helper here. But not
+    every folder a user drops into the root is already in
+    ``normalize_agent_id`` form: ``Agno-RAG-Tester`` normalises to
+    ``agno-rag-tester``. Normalising unconditionally therefore pointed
+    every write at a *different* path than the one discovery found, and
+    the first write conjured an empty ghost folder holding nothing but
+    ``.xo/`` next to the real project — which then registered as a second,
+    empty project of its own.
+
+    Resolution order:
+
+    1. the literal name, when it is a safe segment naming an existing dir
+    2. the normalised name, when that names an existing dir
+    3. an existing dir that normalises to the same id (the reverse lookup,
+       for callers holding an already-normalised id)
+    4. the normalised name — the canonical id for a project that does not
+       exist yet (new-project creation keeps its old behaviour)
+
+    Cases 1-3 only ever return the name of a directory that exists in the
+    root, and case 4 is sanitised, so the result is always a safe leaf:
+    callers get the traversal defence ``normalize_agent_id`` gave them.
+    """
+    root = xo_projects_root()
+
+    if _is_safe_segment(name) and (root / name).is_dir():
+        return name
+
+    normalized = normalize_agent_id(name)
+    if (root / normalized).is_dir():
+        return normalized
+
+    try:
+        entries = sorted(root.iterdir())
+    except OSError:
+        entries = []
+    for entry in entries:
+        if entry.name.startswith(".") or not entry.is_dir():
+            continue
+        if normalize_agent_id(entry.name) == normalized:
+            return entry.name
+
+    return normalized
+
+
 def project_dir(name: str) -> Path:
-    return xo_projects_root() / normalize_agent_id(name)
+    return xo_projects_root() / resolve_project_dirname(name)
 
 
 def xo_dir(name: str) -> Path:
@@ -156,7 +217,7 @@ def scaffold_project(
 
     Returns the project metadata dict (created or already present).
     """
-    pid = normalize_agent_id(name)
+    pid = resolve_project_dirname(name)
     pdir = project_dir(pid)
     xdir = xo_dir(pid)
 
@@ -233,7 +294,7 @@ def _upsert_metadata(
 
 def load_project(name: str) -> dict | None:
     """Read .xo/project.json for an existing project, or None if absent."""
-    path = project_metadata_path(normalize_agent_id(name))
+    path = project_metadata_path(resolve_project_dirname(name))
     if not path.exists():
         return None
     try:
@@ -245,7 +306,7 @@ def load_project(name: str) -> dict | None:
 
 def project_exists(name: str) -> bool:
     """True iff the project folder has a .xo/project.json record."""
-    return project_metadata_path(normalize_agent_id(name)).exists()
+    return project_metadata_path(resolve_project_dirname(name)).exists()
 
 
 def list_projects() -> list[dict]:
@@ -313,7 +374,7 @@ def list_project_tree(name: str, relative_path: str = "") -> dict | None:
     (hidden entries, agent files at root). This helper only enforces
     path safety.
     """
-    project_id = normalize_agent_id(name)
+    project_id = resolve_project_dirname(name)
     root = project_dir(project_id)
     if not root.is_dir():
         return None
@@ -394,7 +455,7 @@ def read_project_file(name: str, relative_path: str, *, max_bytes: int) -> dict 
     streaming a 200 MB file into a browser. Decoding is non-strict: a preview
     of a file with one bad byte is more useful than an error.
     """
-    project_id = normalize_agent_id(name)
+    project_id = resolve_project_dirname(name)
     root = project_dir(project_id)
     if not root.is_dir():
         return None

--- a/services/cowork_agent/scopes.py
+++ b/services/cowork_agent/scopes.py
@@ -25,7 +25,6 @@ from typing import Optional, Union
 
 from services.cowork_agent import project_layout
 from services.cowork_agent.registry import agent_env
-from services.cowork_agent.helpers import normalize_agent_id
 from services.cowork_agent.visualizer import reader as visualizer_reader
 from services.cowork_agent.visualizer import state as watcher_state
 
@@ -155,12 +154,14 @@ class _XoReader:
 class VisualizerScope(_XoReader):
     """Read-only handle over ``<project>/.xo/`` for one project.
 
-    ``project_id`` is sanitised through ``normalize_agent_id`` before
-    any FS lookup — the same defence the rest of the BFF relies on
-    (`bff-overview.md` §"Security properties"). A traversal attempt
-    like ``"../etc"`` collapses to a safe leaf name; the resulting
-    path is always inside ``xo_projects_root()`` so we don't need a
-    second clamp here.
+    ``project_id`` is resolved through
+    ``project_layout.resolve_project_dirname`` before any FS lookup —
+    it maps the id onto the directory that actually holds the project
+    (folder name and id are the same thing) and, failing that, falls
+    back to ``normalize_agent_id``. Either way the result is a safe
+    leaf name — a traversal attempt like ``"../etc"`` collapses — so
+    the path is always inside ``xo_projects_root()`` and we don't need
+    a second clamp here (`bff-overview.md` §"Security properties").
 
     Exposes a small CRUD surface over ``.xo/todos.json`` for the
     agent-facing ``POST/PATCH/DELETE /todos`` endpoints. The CRUD
@@ -169,7 +170,7 @@ class VisualizerScope(_XoReader):
     """
 
     def __init__(self, project_id: str) -> None:
-        self.project_id = normalize_agent_id(project_id)
+        self.project_id = project_layout.resolve_project_dirname(project_id)
         self._xo_root = project_layout.xo_dir(self.project_id)
         self._activity_path = watcher_state.project_activity_path(self.project_id)
 

--- a/services/cowork_agent/visualizer/sinks/project_json.py
+++ b/services/cowork_agent/visualizer/sinks/project_json.py
@@ -49,6 +49,14 @@ def fill_identity(xo_dir: Path, project_id: str) -> bool:
 
     Returns ``True`` iff ``project.json`` was rewritten.
     """
+    if not xo_dir.parent.is_dir():
+        # The folder *is* the project (see
+        # ``project_layout.resolve_project_dirname``). If the id doesn't
+        # point at a directory that exists, writing project.json here would
+        # mkdir -p a ghost project rather than describe a real one — an
+        # empty folder that then shows up in the UI as its own project.
+        return False
+
     path = xo_dir / "project.json"
     current = read_json(path) or {}
 

--- a/tests/test_xo_root_identity.py
+++ b/tests/test_xo_root_identity.py
@@ -82,6 +82,83 @@ class ProjectIdentityTests(unittest.TestCase):
                 self.assertTrue((resolved / "marker.md").is_file())
 
 
+class MixedCaseFolderTests(unittest.TestCase):
+    """A folder whose name isn't already in normalize_agent_id form.
+
+    ``Agno-RAG-Tester`` normalises to ``agno-rag-tester``. Discovery yields
+    the literal folder name as the id, so a path helper that normalised it
+    unconditionally sent every write to a sibling that did not exist — the
+    watcher then mkdir -p'd an empty ghost folder holding only ``.xo/``,
+    which listed in the UI as a second, empty project while the real one
+    never got its ``.xo/`` at all.
+    """
+
+    def test_a_mixed_case_folder_resolves_to_itself(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Agno-RAG-Tester").mkdir()
+            (root / "Agno-RAG-Tester" / "marker.md").write_text("x", encoding="utf-8")
+            with patch.dict(os.environ, {"XO_PROJECTS_ROOT": str(root)}, clear=False):
+                resolved = project_layout.project_dir("Agno-RAG-Tester")
+                self.assertEqual(resolved.name, "Agno-RAG-Tester")
+                self.assertTrue((resolved / "marker.md").is_file())
+                # No sibling conjured by the lookup itself.
+                self.assertFalse((root / "agno-rag-tester").exists())
+
+    def test_a_normalised_id_finds_the_real_folder(self) -> None:
+        """Callers holding an already-normalised id still land on disk."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Agno-RAG-Tester").mkdir()
+            with patch.dict(os.environ, {"XO_PROJECTS_ROOT": str(root)}, clear=False):
+                self.assertEqual(
+                    project_layout.project_dir("agno-rag-tester").name,
+                    "Agno-RAG-Tester",
+                )
+
+    def test_a_new_project_still_gets_a_normalised_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.dict(os.environ, {"XO_PROJECTS_ROOT": str(root)}, clear=False):
+                self.assertEqual(
+                    project_layout.project_dir("My New Project").name,
+                    "my-new-project",
+                )
+
+    def test_traversal_still_collapses_to_a_safe_leaf(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.dict(os.environ, {"XO_PROJECTS_ROOT": str(root)}, clear=False):
+                for hostile in ("../etc", "..", ".", "", "a/b", ".hidden"):
+                    resolved = project_layout.project_dir(hostile)
+                    self.assertEqual(resolved.parent, root, hostile)
+                    self.assertFalse(resolved.name.startswith("."), hostile)
+
+    def test_the_watcher_never_conjures_an_empty_project(self) -> None:
+        from services.cowork_agent.visualizer.sinks import project_json
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Agno-RAG-Tester").mkdir()
+            with patch.dict(os.environ, {"XO_PROJECTS_ROOT": str(root)}, clear=False):
+                self.assertTrue(
+                    project_json.fill_identity(
+                        project_layout.xo_dir("Agno-RAG-Tester"), "Agno-RAG-Tester"
+                    )
+                )
+                # Identity landed in the real folder...
+                self.assertTrue(
+                    (root / "Agno-RAG-Tester" / ".xo" / "project.json").is_file()
+                )
+                self.assertFalse((root / "agno-rag-tester").exists())
+                # ...and an id pointing at nothing writes nothing at all.
+                gone = root / "deleted-project"
+                self.assertFalse(
+                    project_json.fill_identity(gone / ".xo", "deleted-project")
+                )
+                self.assertFalse(gone.exists())
+
+
 class StorageRootBootTests(unittest.TestCase):
     """server.py's roots.env loader — the seam that makes the Setup tab's XO
     root take effect for every tab after a restart."""


### PR DESCRIPTION
Discovery uses the literal directory name as the project id, but every path helper normalised it through normalize_agent_id. For a folder like Agno-RAG-Tester the two disagreed: project_dir() returned <root>/agno-rag-tester, which did not exist.

The watcher calls project_json.fill_identity(xo_dir(pid), pid) for every discovered project, and that writes via write_json_atomic, which mkdir -p's parents. So the first tick created an empty lowercase ghost folder next to the real project, holding nothing but .xo/project.json — which then listed in the UI as a second, empty project while the real folder never got its .xo/ at all. The same mismatch sent every other per-project sink, and scopes.VisualizerScope, to the ghost.

project_dir and friends now go through resolve_project_dirname, which prefers the directory that exists (literal name, then normalised, then a reverse lookup for callers holding an already-normalised id) and only falls back to normalisation for projects that do not exist yet, so new-project creation is unchanged. Every branch returns a safe leaf, so the traversal defence normalize_agent_id provided is preserved.

The project_json sink additionally refuses to write identity for an id that names no directory, so no id can conjure a project folder again.
