### PR TITLE
Space UI: pan/zoom canvas for the Files Tree lens; add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 quirq-ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/space_ui/css/projects.css
+++ b/space_ui/css/projects.css
@@ -124,14 +124,16 @@
   .tv-filter{width:190px;background:var(--bg-3);border:1px solid var(--line);border-radius:7px;
     padding:5px 9px;font-size:12px;color:var(--ink)}
   .tv-filter:focus{outline:none;border-color:#39404d}
-  /* The surface can be wider than the column, so the pane stays full width
-     and scrolls; its left gutter matches the centred header so the root chip
-     starts on the same line as everything else. */
-  .tv-scroll{flex:1;min-height:0;overflow:auto;
-    padding-left:max(26px,calc((100% - 1180px)/2 + 26px));padding-right:26px;
+  /* Not a scroller: the pane clips a surface the camera pans (drag) and
+     zooms (wheel, cursor-anchored) via a transform — the same read as the
+     Graph lens. The left gutter is the camera's initial x (tree.js), so the
+     root chip starts on the header's line. */
+  .tv-canvas{flex:1;min-height:0;overflow:hidden;position:relative;
+    cursor:grab;touch-action:none;user-select:none;-webkit-user-select:none;
     /* a faint vignette so the canvas reads as a surface you pan around */
     background:radial-gradient(120% 90% at 8% 40%,rgba(168,217,79,.035),transparent 62%)}
-  .tv-surface{position:relative}
+  .tv-canvas.is-panning{cursor:grabbing}
+  .tv-surface{position:absolute;left:0;top:0;transform-origin:0 0}
 
   /* ---- branches ---- */
   .tv-links{position:absolute;inset:0;pointer-events:none;overflow:visible}

--- a/space_ui/index.html
+++ b/space_ui/index.html
@@ -9,7 +9,7 @@
 <link rel="stylesheet" href="css/sessions.css?v=20260725-sessions2">
 <link rel="stylesheet" href="css/timeline.css?v=20260813-timeline2">
 <link rel="stylesheet" href="css/chrome.css?v=20260813-timeline2">
-<link rel="stylesheet" href="css/projects.css?v=20260817-lens1">
+<link rel="stylesheet" href="css/projects.css?v=20260824-treecam1">
 <link rel="stylesheet" href="css/wiki.css?v=20260725-collaboration1">
 <link rel="stylesheet" href="css/quirq.css?v=20260816-navswap1">
 <link rel="stylesheet" href="css/secrets.css?v=20260813-update1">

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -8,7 +8,7 @@ import {initPreview} from './core/preview.js?v=20260816-preview1';
 import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260817-lens1';
 import sessionsView from './views/sessions.js?v=20260817-xodata1';
 import projectsView from './views/projects.js?v=20260817-plural1';
-import treeView from './views/tree.js?v=20260824-treecam1';
+import treeView from './views/tree.js?v=20260824-treecam2';
 /* Chat is deliberately hidden from the tab bar: re-import ./views/chat.js
    and register it below to bring the tab back. */
 import wikiView from './views/wiki.js?v=20260817-wikifix1';

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -8,7 +8,7 @@ import {initPreview} from './core/preview.js?v=20260816-preview1';
 import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260817-lens1';
 import sessionsView from './views/sessions.js?v=20260817-xodata1';
 import projectsView from './views/projects.js?v=20260817-plural1';
-import treeView from './views/tree.js?v=20260817-plural1';
+import treeView from './views/tree.js?v=20260824-treecam1';
 /* Chat is deliberately hidden from the tab bar: re-import ./views/chat.js
    and register it below to bring the tab back. */
 import wikiView from './views/wiki.js?v=20260817-wikifix1';

--- a/space_ui/js/views/tree.js
+++ b/space_ui/js/views/tree.js
@@ -70,13 +70,18 @@ function onPointerDown(e){
   if(!c||e.button!==0||!cam)return;
   panning=true;panMoved=false;
   downX=px=e.clientX;downY=py=e.clientY;
-  c.classList.add('is-panning');
-  c.setPointerCapture(e.pointerId);
 }
 function onPointerMove(e){
   if(!panning)return;
-  /* 4px of slack so a click on a chip is a click, not a 0px pan */
-  if(Math.hypot(e.clientX-downX,e.clientY-downY)>4)panMoved=true;
+  /* 4px of slack so a click on a chip is a click, not a 0px pan. Capture
+     only once the pan is real: a captured pointer retargets the synthesized
+     click at the canvas, which would eat every chip's expand click. */
+  if(!panMoved){
+    if(Math.hypot(e.clientX-downX,e.clientY-downY)<=4)return;
+    panMoved=true;
+    const c=canvasEl();
+    if(c){c.classList.add('is-panning');c.setPointerCapture(e.pointerId);}
+  }
   cam.x+=e.clientX-px;cam.y+=e.clientY-py;
   px=e.clientX;py=e.clientY;
   applyCam();

--- a/space_ui/js/views/tree.js
+++ b/space_ui/js/views/tree.js
@@ -28,7 +28,7 @@ const ROW_H=34;    /* a container chip */
 const FILE_H=20;   /* a row in a leaf stack */
 const STACK_PAD=13;/* the leaf card's own padding */
 const GAP=7;       /* between sibling blocks */
-/* The left gutter is the scroll pane's padding (it matches the centred
+/* The left gutter comes from the camera's initial x (it matches the centred
    header), so the surface itself starts at zero. */
 const PAD_X=0,PAD_Y=24;
 /* A folder's files show a dozen at a time. The old cap of 40 made one folder
@@ -45,8 +45,61 @@ let loading=false;
 const expandedStacks=new Set(); /* leaf cards showing all of their files */
 let seen=new Set();             /* keys on screen last render — the rest are new */
 let growing=false;              /* this render came from an expand: draw branches in */
-let scrollLeft=0,scrollTop=0;   /* the surface is re-created each render */
-let anchor=null;                /* {key,offset} — keep this node where it was */
+let anchor=null;                /* {key,left,top} — keep this node where it was */
+
+/* ── camera ───────────────────────────────────────────────────────────────
+   The pane is not a scroller: the surface is a canvas you pan by dragging
+   and zoom with the wheel, cursor-anchored — the same feel as the Graph
+   lens next door. screen = layout*k + (x,y); k=1 is 1:1 px. The camera
+   survives re-renders (the surface is re-created, the transform re-applied). */
+let cam=null;                   /* {x,y,k}; null until the first render sizes it */
+const K_MIN=.25,K_MAX=2.5;
+let panning=false,panMoved=false,px=0,py=0,downX=0,downY=0;
+const canvasEl=()=>root.querySelector('.tv-canvas');
+function applyCam(){
+  const s=root.querySelector('.tv-surface');
+  if(s&&cam)s.style.transform='translate('+cam.x+'px,'+cam.y+'px) scale('+cam.k+')';
+}
+/* the root chip starts on the header's left line, like the old gutter did */
+function initCam(){
+  const c=canvasEl();
+  cam={x:c?Math.max(26,(c.clientWidth-1180)/2+26):26,y:0,k:1};
+}
+function onPointerDown(e){
+  const c=e.target.closest('.tv-canvas');
+  if(!c||e.button!==0||!cam)return;
+  panning=true;panMoved=false;
+  downX=px=e.clientX;downY=py=e.clientY;
+  c.classList.add('is-panning');
+  c.setPointerCapture(e.pointerId);
+}
+function onPointerMove(e){
+  if(!panning)return;
+  /* 4px of slack so a click on a chip is a click, not a 0px pan */
+  if(Math.hypot(e.clientX-downX,e.clientY-downY)>4)panMoved=true;
+  cam.x+=e.clientX-px;cam.y+=e.clientY-py;
+  px=e.clientX;py=e.clientY;
+  applyCam();
+}
+function onPointerUp(){
+  if(!panning)return;
+  panning=false;
+  const c=canvasEl();
+  if(c)c.classList.remove('is-panning');
+}
+function onWheel(e){
+  const c=e.target.closest('.tv-canvas');
+  if(!c||!cam)return;
+  e.preventDefault();
+  const nk=Math.max(K_MIN,Math.min(K_MAX,cam.k*Math.exp(-e.deltaY*.0016)));
+  /* keep the layout point under the cursor under the cursor */
+  const r=c.getBoundingClientRect();
+  const mx=e.clientX-r.left,my=e.clientY-r.top;
+  cam.x=mx-(mx-cam.x)/cam.k*nk;
+  cam.y=my-(my-cam.y)/cam.k*nk;
+  cam.k=nk;
+  applyCam();
+}
 
 export default {
   /* No tab of its own: the Files tab owns the nav slot and this is its third
@@ -58,6 +111,12 @@ export default {
     root.innerHTML='<div class="tv"><div class="prj-note">loading the workspace…</div></div>';
     root.addEventListener('click',onClick);
     root.addEventListener('input',onInput);
+    root.addEventListener('pointerdown',onPointerDown);
+    root.addEventListener('pointermove',onPointerMove);
+    root.addEventListener('pointerup',onPointerUp);
+    root.addEventListener('pointercancel',onPointerUp);
+    /* wheel must preventDefault (page zoom/scroll), so non-passive */
+    root.addEventListener('wheel',onWheel,{passive:false});
     await load();
   },
   show(){if(model===null&&!loading)load();}
@@ -205,7 +264,7 @@ function render(){
   const grew=growing;growing=false;
   root.querySelector('.tv').innerHTML=
     head()
-    +'<div class="tv-scroll"><div class="tv-surface'+(grew?' is-growing':'')
+    +'<div class="tv-canvas"><div class="tv-surface'+(grew?' is-growing':'')
       +'" style="width:'+Math.round(width)
       +'px;height:'+Math.round(height)+'px">'
       +'<svg class="tv-links" width="'+Math.round(width)+'" height="'+Math.round(height)+'">'
@@ -224,7 +283,9 @@ function render(){
     const surface=root.querySelector('.tv-surface');
     setTimeout(()=>surface&&surface.classList.remove('is-growing'),480);
   }
-  restoreScroll();
+  if(cam===null)initCam();
+  applyCam();
+  restoreAnchor();
   const input=root.querySelector('#tv-filter');
   if(input&&filter){input.focus();input.setSelectionRange(filter.length,filter.length);}
 }
@@ -236,6 +297,7 @@ function head(){
     +'<input class="tv-filter" id="tv-filter" placeholder="Filter by name…" '
       +'autocomplete="off" spellcheck="false" value="'+esc(filter)+'">'
     +'<button class="sess-refresh" data-tv="projects">Projects only</button>'
+    +'<button class="sess-refresh" data-tv="reset">Reset view</button>'
     +'<button class="sess-refresh" data-tv="reload">&#8635; Refresh</button>'
   +'</div>';
 }
@@ -291,16 +353,19 @@ function stackBlock(s,fresh){
    hand-off lives inside the previewer, so browsing the tree never costs you
    your place in it. */
 function onClick(e){
+  /* a drag that ended on a chip is a pan, not a click */
+  if(panMoved){panMoved=false;return;}
   const act=e.target.closest('[data-tv]');
   if(act){
     if(act.dataset.tv==='projects'){open=new Set(['']);expandedStacks.clear();render();}
+    else if(act.dataset.tv==='reset'){initCam();applyCam();}
     else{model=null;root.querySelector('.tv').innerHTML='<div class="prj-note">loading…</div>';load();}
     return;
   }
   const node=e.target.closest('[data-key]');
   if(node){
     const k=node.dataset.key;
-    keepScroll(k);
+    keepAnchor(k);
     if(open.has(k)){open.delete(k);}
     else{open.add(k);growing=true;}
     render();
@@ -309,7 +374,7 @@ function onClick(e){
   const more=e.target.closest('[data-stack]');
   if(more){
     const k=more.dataset.stack;
-    keepScroll(k);growing=true;
+    keepAnchor(k);growing=true;
     if(expandedStacks.has(k))expandedStacks.delete(k);else expandedStacks.add(k);
     render();
     return;
@@ -326,27 +391,26 @@ function onClick(e){
 }
 /* The surface is rebuilt on every render AND the layout reflows around the
    node you just opened — a parent re-centres over its taller subtree, which
-   can shove the whole tree (root included) off screen. Restoring the raw
-   scroll offset is not enough; the fix is to pin the clicked node to the
-   screen position it already had and let the tree grow around it. */
-function keepScroll(key){
-  const sc=root.querySelector('.tv-scroll');
-  if(!sc)return;
-  scrollLeft=sc.scrollLeft;scrollTop=sc.scrollTop;
+   can shove the whole tree (root included) off screen. The camera alone is
+   not enough; the fix is to pin the clicked node to the screen position it
+   already had and let the tree grow around it. Offsets are screen px, so
+   the same arithmetic holds at any zoom. */
+function keepAnchor(key){
   anchor=null;
   if(!key)return;
-  const el=root.querySelector('[data-key="'+CSS.escape(key)+'"]');
-  if(el)anchor={key,offset:el.getBoundingClientRect().top-sc.getBoundingClientRect().top};
+  const c=canvasEl(),el=root.querySelector('[data-key="'+CSS.escape(key)+'"]');
+  if(!c||!el)return;
+  const cr=c.getBoundingClientRect(),er=el.getBoundingClientRect();
+  anchor={key,left:er.left-cr.left,top:er.top-cr.top};
 }
-function restoreScroll(){
-  const sc=root.querySelector('.tv-scroll');
-  if(!sc)return;
-  sc.scrollLeft=scrollLeft;sc.scrollTop=scrollTop;
+function restoreAnchor(){
   if(!anchor)return;
-  const el=root.querySelector('[data-key="'+CSS.escape(anchor.key)+'"]');
-  if(el){
-    const now=el.getBoundingClientRect().top-sc.getBoundingClientRect().top;
-    sc.scrollTop+=now-anchor.offset;
+  const c=canvasEl(),el=root.querySelector('[data-key="'+CSS.escape(anchor.key)+'"]');
+  if(c&&el){
+    const cr=c.getBoundingClientRect(),er=el.getBoundingClientRect();
+    cam.x+=anchor.left-(er.left-cr.left);
+    cam.y+=anchor.top-(er.top-cr.top);
+    applyCam();
   }
   anchor=null;
 }


### PR DESCRIPTION
## What

**Files → Tree: pan/zoom canvas instead of a scroll pane.** The Tree lens clipped its surface behind a scrolling pane; navigating an expanded tree meant scrollbars. Now the pane clips a surface you move around freely:

- **Pan** by dragging anywhere on the canvas (grab/grabbing cursor).
- **Zoom** with the wheel (and trackpad pinch), anchored at the cursor, clamped 0.25×–2.5×.
- **Reset view** button restores 1:1 at the origin.
- A 4px drag threshold separates a pan from a click, so chips, file leaves, and "+N more" still click normally — and the pointer is captured only once a pan actually starts, since a captured pointer retargets the synthesized click at the canvas and would eat every chip's expand click.
- Preserved: the expand anchor (the clicked node stays pinned while the layout reflows, now computed in screen px so it holds at any zoom), camera state across re-renders, and the root chip aligned with the centred header (the old scroll-pane gutter became the camera's initial x).

**Add MIT LICENSE** (`Copyright (c) 2026 quirq-ai`) — the repo was reporting as unlicensed.

## Scope

`space_ui/` only (tree.js, projects.css, plus cache stamps in app.js/index.html) + the root LICENSE. No backend files touched.

## Validation

- `node --check` on the edited modules.
- Manually tested: drag-pan, cursor-anchored wheel zoom, expanding folders while zoomed, file preview click, Reset view.
- Cache stamps bumped (`tree.js?v=20260824-treecam2`, `projects.css?v=20260824-treecam1`) so returning browsers pick up the changes.
