### PR TITLE
Canonical install one-liner (#20); Timeline zoom, pan, filters and label clearance (#24, in progress); Space UI says xo-space

### DIFF
--- a/.agents/plugins/quirq/skills/quirq-install/SKILL.md
+++ b/.agents/plugins/quirq/skills/quirq-install/SKILL.md
@@ -33,7 +33,7 @@ Install Quirq (xo-space) on this machine.
    stays quiet:
 
    ```bash
-   cd <dir> && curl -fsSL https://www.quirq.ai/install | sh
+   cd <dir> && curl -fsSL quirq.ai/install | sh
    ```
 
 5. Poll `http://127.0.0.1:5002/health` (then 5003) every ~5 s, up to

--- a/.agents/plugins/quirq/skills/quirq-install/SKILL.md
+++ b/.agents/plugins/quirq/skills/quirq-install/SKILL.md
@@ -33,7 +33,7 @@ Install Quirq (xo-space) on this machine.
    stays quiet:
 
    ```bash
-   cd <dir> && curl -fsSL quirq.ai/install | sh
+   cd <dir> && curl -fsSL https://quirq.ai/install | sh
    ```
 
 5. Poll `http://127.0.0.1:5002/health` (then 5003) every ~5 s, up to

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -3,7 +3,7 @@
 Pick a directory to keep Quirq in, then run:
 
 ```bash
-curl -fsSL quirq.ai/install | sh
+curl -fsSL https://quirq.ai/install | sh
 ```
 
 Open <http://localhost:5002/space/>.
@@ -20,8 +20,10 @@ Docker is not required. The command:
 
 Press Ctrl-C to stop it. Run the same command again to update and restart.
 
-It must be piped to `bash`, not `sh` — the script uses `BASH_SOURCE` and
-`set -o pipefail`, neither of which exists in POSIX `sh`.
+The short URL serves a small POSIX-sh bootstrap that downloads `install.sh`
+to a temporary file and runs it under `bash`, which is why `| sh` works. If
+you fetch `install.sh` itself, pipe it to `bash`, not `sh` — the script uses
+`BASH_SOURCE` and `set -o pipefail`, neither of which exists in POSIX `sh`.
 
 ## Prerequisites
 
@@ -109,7 +111,7 @@ Every value is overridable from the environment:
 For example:
 
 ```bash
-curl -fsSL quirq.ai/install | PORT=8080 XO_PROJECTS_ROOT=/absolute/path sh
+curl -fsSL https://quirq.ai/install | PORT=8080 XO_PROJECTS_ROOT=/absolute/path sh
 ```
 
 On first run the installer writes `quirq/.env` recording exactly what it used,

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -3,7 +3,7 @@
 Pick a directory to keep Quirq in, then run:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/quirq-ai/xo-space/main/install.sh | bash
+curl -fsSL quirq.ai/install | sh
 ```
 
 Open <http://localhost:5002/space/>.
@@ -109,7 +109,7 @@ Every value is overridable from the environment:
 For example:
 
 ```bash
-curl -fsSL <url>/install.sh | PORT=8080 XO_PROJECTS_ROOT=/absolute/path bash
+curl -fsSL quirq.ai/install | PORT=8080 XO_PROJECTS_ROOT=/absolute/path sh
 ```
 
 On first run the installer writes `quirq/.env` recording exactly what it used,

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Every coding agent ships with its own session store, its own auth, its own todo 
 ## Quick start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/quirq-ai/xo-space/main/install.sh | bash
+curl -fsSL quirq.ai/install | sh
 ```
 
 Run it from the directory you want as your workspace: the checkout lands

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Every coding agent ships with its own session store, its own auth, its own todo 
 ## Quick start
 
 ```bash
-curl -fsSL quirq.ai/install | sh
+curl -fsSL https://quirq.ai/install | sh
 ```
 
 Run it from the directory you want as your workspace: the checkout lands

--- a/plugin/commands/install.md
+++ b/plugin/commands/install.md
@@ -33,7 +33,7 @@ Install Quirq (xo-space) on this machine. The workspace directory is
    stays quiet:
 
    ```bash
-   cd <dir> && curl -fsSL https://www.quirq.ai/install | sh
+   cd <dir> && curl -fsSL quirq.ai/install | sh
    ```
 
 5. Poll `http://127.0.0.1:5002/health` (then 5003) every ~5 s, up to

--- a/plugin/commands/install.md
+++ b/plugin/commands/install.md
@@ -33,7 +33,7 @@ Install Quirq (xo-space) on this machine. The workspace directory is
    stays quiet:
 
    ```bash
-   cd <dir> && curl -fsSL quirq.ai/install | sh
+   cd <dir> && curl -fsSL https://quirq.ai/install | sh
    ```
 
 5. Poll `http://127.0.0.1:5002/health` (then 5003) every ~5 s, up to

--- a/services/cowork_agent/runtime_config.py
+++ b/services/cowork_agent/runtime_config.py
@@ -38,7 +38,7 @@ ROOT_CONFIG_KEYS = frozenset({"XO_PROJECTS_ROOT", "QUIRQ_STATE_ROOT"})
 # The canonical one-liner from the website, not a raw GitHub URL: the site
 # bootstrapper follows repo renames and branch selection, so this string
 # cannot rot the way a hardcoded raw.githubusercontent.com path did.
-INSTALL_COMMAND = "curl -fsSL https://www.quirq.ai/install | sh"
+INSTALL_COMMAND = "curl -fsSL quirq.ai/install | sh"
 
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _SESSION_SCAN_CAP = 10_000

--- a/services/cowork_agent/runtime_config.py
+++ b/services/cowork_agent/runtime_config.py
@@ -38,7 +38,7 @@ ROOT_CONFIG_KEYS = frozenset({"XO_PROJECTS_ROOT", "QUIRQ_STATE_ROOT"})
 # The canonical one-liner from the website, not a raw GitHub URL: the site
 # bootstrapper follows repo renames and branch selection, so this string
 # cannot rot the way a hardcoded raw.githubusercontent.com path did.
-INSTALL_COMMAND = "curl -fsSL quirq.ai/install | sh"
+INSTALL_COMMAND = "curl -fsSL https://quirq.ai/install | sh"
 
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
 _SESSION_SCAN_CAP = 10_000

--- a/space_ui/README.md
+++ b/space_ui/README.md
@@ -7,7 +7,7 @@ has no tab of its own and opens from Setup's header.
 
 This folder is a bundled snapshot of the xo-atlas UI (originally a standalone
 folder with no remote), trimmed to the single endpoint-driven page and served
-by this API — so every workspace that runs xo-cowork-api gets the graph with
+by this API — so every workspace that runs xo-space gets the graph with
 zero configuration.
 
 ## Files

--- a/space_ui/css/timeline.css
+++ b/space_ui/css/timeline.css
@@ -35,5 +35,23 @@
   .ticks{display:flex;justify-content:space-between;font:400 9.5px var(--mono);letter-spacing:.08em;color:#56534b;margin-top:4px}
   #tmilestone{font:italic 400 13px var(--serif);color:var(--ink-2);margin-top:10px;min-height:18px;
     transition:opacity .4s var(--ease)}
-  #tplot{flex:1;min-height:0;margin-top:6px}
+  /* the plot pans: vertical drag / wheel work the time axis, horizontal
+     drag / shift+wheel slide the lanes once they outgrow the pane (the svg
+     is then wider than this box; overflow hidden + scrollLeft, no scrollbar) */
+  #tplot{flex:1;min-height:0;margin-top:6px;overflow:hidden;cursor:grab;
+    touch-action:none;user-select:none;-webkit-user-select:none}
+  #tplot.is-panning{cursor:grabbing}
   #tplot svg{width:100%;height:100%;display:block}
+  .tfilter{width:170px;flex:none;background:var(--bg-3);border:1px solid var(--line);
+    border-radius:7px;padding:5px 9px;font-size:12px;color:var(--ink)}
+  .tfilter:focus{outline:none;border-color:#39404d}
+  .trange{display:flex;align-items:center;gap:12px;margin-top:8px;min-height:20px}
+  .tyears{display:flex;gap:4px;flex-wrap:wrap}
+  .tyears[hidden]{display:none}
+  .tyears button{font:400 9.5px var(--mono);letter-spacing:.08em;color:var(--ink-3);
+    padding:2px 9px;border:1px solid var(--line-soft);border-radius:999px;background:transparent;
+    transition:color .16s var(--ease),border-color .16s var(--ease)}
+  .tyears button:hover{color:var(--ink);border-color:#39404d}
+  .tyears button.is-on{color:#14100a;background:var(--accent);border-color:var(--accent)}
+  .thint{font:400 9.5px var(--mono);letter-spacing:.06em;color:#56534b;margin-left:auto;white-space:nowrap}
+  @media (max-width:900px){.thint{display:none}}

--- a/space_ui/index.html
+++ b/space_ui/index.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="css/stage.css?v=20260813-wikisetup1">
 <link rel="stylesheet" href="css/graph.css?v=20260817-lens1">
 <link rel="stylesheet" href="css/sessions.css?v=20260725-sessions2">
-<link rel="stylesheet" href="css/timeline.css?v=20260813-timeline2">
+<link rel="stylesheet" href="css/timeline.css?v=20260825-timeline1">
 <link rel="stylesheet" href="css/chrome.css?v=20260813-timeline2">
 <link rel="stylesheet" href="css/projects.css?v=20260824-treecam1">
 <link rel="stylesheet" href="css/wiki.css?v=20260725-collaboration1">
@@ -82,6 +82,8 @@
         <div class="sub" id="tsub">Scrub through the workspace as it grew. Open any cluster from the graph to watch its run unfold here.</div>
       </div>
       <div class="grow"></div>
+      <input class="tfilter" id="tlanes" type="search" placeholder="Filter projects…"
+        autocomplete="off" spellcheck="false" aria-label="Filter timeline lanes by project name">
       <div class="atlas-lens-switch tmode" id="tmode" aria-label="Timeline mode" hidden>
         <button class="is-on" type="button" data-tmode="file">By file</button>
         <button type="button" data-tmode="project">By project</button>
@@ -93,6 +95,10 @@
     <div class="scrubrow">
       <input id="tscrub" type="range" min="0" max="1000" value="1000">
       <div class="ticks"><span>JUN 2025</span><span>SEP</span><span>DEC</span><span>MAR 2026</span><span>JUL 2026</span></div>
+    </div>
+    <div class="trange">
+      <div class="tyears" id="tyears" aria-label="Jump to a year"></div>
+      <div class="thint">wheel to zoom the axis · drag to pan · shift+wheel for lanes</div>
     </div>
     <div id="tmilestone"></div>
     <div id="tplot"></div>

--- a/space_ui/index.html
+++ b/space_ui/index.html
@@ -140,11 +140,11 @@
 <footer>
   <div class="srv">
     <span class="pip" id="srv-pip"></span>
-    <span id="srv-text">checking xo-cowork-api&hellip;</span>
+    <span id="srv-text">checking xo-space&hellip;</span>
     <button id="srv-btn" hidden></button>
     <div class="srvpop" id="srvpop">
       <div class="hint">Start the server from a shell</div>
-      <pre>cd xo-cowork-api &amp;&amp; ./cowork-api.sh start</pre>
+      <pre>cd xo-space &amp;&amp; ./cowork-api.sh start</pre>
       <button id="srv-copy">Copy command</button>
       <p>A page can check the server, but starting or stopping it needs a shell. This pill keeps polling and flips back on by itself.</p>
     </div>
@@ -152,6 +152,6 @@
   <div class="meta" id="fmeta"></div>
 </footer>
 
-<script type="module" src="js/app.js?v=20260817-plural1"></script>
+<script type="module" src="js/app.js?v=20260825-rename1"></script>
 
 </body></html>

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -5,7 +5,7 @@ import {registerView,startRegistry} from './core/registry.js?v=20260813-timeline
 import {initServerWidget} from './core/server-widget.js';
 import {initLensSwitch} from './core/lens-switch.js?v=20260817-lens1';
 import {initPreview} from './core/preview.js?v=20260825-previewscope1';
-import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-timeline1';
+import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-timeline2';
 import sessionsView from './views/sessions.js?v=20260817-xodata1';
 import projectsView from './views/projects.js?v=20260817-plural1';
 import treeView from './views/tree.js?v=20260824-treecam2';

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -5,7 +5,7 @@ import {registerView,startRegistry} from './core/registry.js?v=20260813-timeline
 import {initServerWidget} from './core/server-widget.js';
 import {initLensSwitch} from './core/lens-switch.js?v=20260817-lens1';
 import {initPreview} from './core/preview.js?v=20260825-previewscope1';
-import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-timeline2';
+import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-timeline1';
 import sessionsView from './views/sessions.js?v=20260817-xodata1';
 import projectsView from './views/projects.js?v=20260817-plural1';
 import treeView from './views/tree.js?v=20260824-treecam2';

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -11,7 +11,7 @@ import projectsView from './views/projects.js?v=20260817-plural1';
 import treeView from './views/tree.js?v=20260824-treecam2';
 /* Chat is deliberately hidden from the tab bar: re-import ./views/chat.js
    and register it below to bring the tab back. */
-import wikiView from './views/wiki.js?v=20260817-wikifix1';
+import wikiView from './views/wiki.js?v=20260825-install1';
 import quirqView from './views/quirq.js?v=20260817-plural1';
 import secretsView from './views/secrets.js?v=20260825-busycursor1';
 

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -2,13 +2,13 @@
    contract (see core/registry.js), then import + register it here — no
    bundler, so no file globbing; this import list is the one manual step. */
 import {registerView,startRegistry} from './core/registry.js?v=20260813-timeline2';
-import {initServerWidget} from './core/server-widget.js';
+import {initServerWidget} from './core/server-widget.js?v=20260825-rename1';
 import {initLensSwitch} from './core/lens-switch.js?v=20260817-lens1';
-import {initPreview} from './core/preview.js?v=20260825-previewscope1';
-import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-timeline4';
-import sessionsView from './views/sessions.js?v=20260817-xodata1';
-import projectsView from './views/projects.js?v=20260817-plural1';
-import treeView from './views/tree.js?v=20260824-treecam2';
+import {initPreview} from './core/preview.js?v=20260825-rename1';
+import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-rename1';
+import sessionsView from './views/sessions.js?v=20260825-rename1';
+import projectsView from './views/projects.js?v=20260825-rename1';
+import treeView from './views/tree.js?v=20260825-rename1';
 /* Chat is deliberately hidden from the tab bar: re-import ./views/chat.js
    and register it below to bring the tab back. */
 import wikiView from './views/wiki.js?v=20260825-install1';

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -5,7 +5,7 @@ import {registerView,startRegistry} from './core/registry.js?v=20260813-timeline
 import {initServerWidget} from './core/server-widget.js';
 import {initLensSwitch} from './core/lens-switch.js?v=20260817-lens1';
 import {initPreview} from './core/preview.js?v=20260825-previewscope1';
-import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-timeline1';
+import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-timeline3';
 import sessionsView from './views/sessions.js?v=20260817-xodata1';
 import projectsView from './views/projects.js?v=20260817-plural1';
 import treeView from './views/tree.js?v=20260824-treecam2';

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -5,7 +5,7 @@ import {registerView,startRegistry} from './core/registry.js?v=20260813-timeline
 import {initServerWidget} from './core/server-widget.js';
 import {initLensSwitch} from './core/lens-switch.js?v=20260817-lens1';
 import {initPreview} from './core/preview.js?v=20260825-previewscope1';
-import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-timeline3';
+import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-timeline4';
 import sessionsView from './views/sessions.js?v=20260817-xodata1';
 import projectsView from './views/projects.js?v=20260817-plural1';
 import treeView from './views/tree.js?v=20260824-treecam2';

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -5,13 +5,13 @@ import {registerView,startRegistry} from './core/registry.js?v=20260813-timeline
 import {initServerWidget} from './core/server-widget.js?v=20260825-rename1';
 import {initLensSwitch} from './core/lens-switch.js?v=20260817-lens1';
 import {initPreview} from './core/preview.js?v=20260825-rename1';
-import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-rename1';
+import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-review1';
 import sessionsView from './views/sessions.js?v=20260825-rename1';
 import projectsView from './views/projects.js?v=20260825-rename1';
 import treeView from './views/tree.js?v=20260825-rename1';
 /* Chat is deliberately hidden from the tab bar: re-import ./views/chat.js
    and register it below to bring the tab back. */
-import wikiView from './views/wiki.js?v=20260825-install1';
+import wikiView from './views/wiki.js?v=20260825-install2';
 import quirqView from './views/quirq.js?v=20260817-plural1';
 import secretsView from './views/secrets.js?v=20260825-busycursor1';
 

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -5,7 +5,7 @@ import {registerView,startRegistry} from './core/registry.js?v=20260813-timeline
 import {initServerWidget} from './core/server-widget.js';
 import {initLensSwitch} from './core/lens-switch.js?v=20260817-lens1';
 import {initPreview} from './core/preview.js?v=20260825-previewscope1';
-import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260817-lens1';
+import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-timeline1';
 import sessionsView from './views/sessions.js?v=20260817-xodata1';
 import projectsView from './views/projects.js?v=20260817-plural1';
 import treeView from './views/tree.js?v=20260824-treecam2';

--- a/space_ui/js/core/preview.js
+++ b/space_ui/js/core/preview.js
@@ -70,7 +70,7 @@ async function open({project,path,name}){
   if(mine!==token)return; /* a newer file is on screen */
   if(!res.ok){
     render('<div class="pv-note">'+esc(
-      res.offline?'xo-cowork-api is unreachable'
+      res.offline?'xo-space is unreachable'
       :res.status===415?'No text preview for this file type.'
       :res.error||'Could not read this file.')+'</div>');
     return;

--- a/space_ui/js/core/server-widget.js
+++ b/space_ui/js/core/server-widget.js
@@ -19,7 +19,7 @@ export function initServerWidget(){
     if(srvOn===on)return;
     srvOn=on;
     srvPip.className='pip '+(on?'on':'off');
-    srvText.textContent='xo-cowork-api · '+(on?'online':'offline');
+    srvText.textContent='xo-space · '+(on?'online':'offline');
     srvBtn.hidden=on; /* button exists only to show the start command */
     srvBtn.textContent='Start…';
     if(on)srvPop.classList.remove('is-open');
@@ -28,7 +28,7 @@ export function initServerWidget(){
     srvPop.classList.toggle('is-open');
   });
   document.getElementById('srv-copy').addEventListener('click',()=>{
-    navigator.clipboard.writeText('cd xo-cowork-api && ./cowork-api.sh start').then(()=>{
+    navigator.clipboard.writeText('cd xo-space && ./cowork-api.sh start').then(()=>{
       document.getElementById('srv-copy').textContent='Copied';
       setTimeout(()=>document.getElementById('srv-copy').textContent='Copy command',1400);
     });

--- a/space_ui/js/views/atlas.js
+++ b/space_ui/js/views/atlas.js
@@ -1443,7 +1443,7 @@ function buildTimeline(){
      so the column headers stay legible whatever the project count. */
   const q=laneFilter.trim().toLowerCase();
   const lanes=q?allLanes.filter(cat=>CAT[cat].name.toLowerCase().includes(q)):allLanes;
-  const MIN_COL=44;
+  const MIN_COL=100;
   const colW=Math.max(MIN_COL,(W-64-16)/Math.max(1,lanes.length));
   const SW=Math.max(W,Math.round(64+16+colW*lanes.length));
   tsvg.setAttribute('viewBox',`0 0 ${SW} ${H}`);

--- a/space_ui/js/views/atlas.js
+++ b/space_ui/js/views/atlas.js
@@ -1414,10 +1414,7 @@ function computeRange(){
     if(T1-T0<MIN_SPAN)tZoomed=false;
   }
   if(!tZoomed){T0=TF0;T1=TF1;}
-  /* the scrubbed moment is state, the window is view: zooming or panning
-     may leave it off screen but never moves it. Only the full axis (a mode
-     switch) can push it. */
-  tNow=Math.min(Math.max(tNow,TF0),TF1);
+  tNow=Math.min(Math.max(tNow,T0),T1);
   renderYears();
   const ticks=document.querySelector('#view-time .ticks');
   if(ticks){
@@ -1462,14 +1459,8 @@ function buildTimeline(){
   }
   /* Time runs vertically: newest at the top, oldest at the bottom. Narrow
      columns rotate their headers, which needs a taller top margin. */
-  /* Upright labels need ~7px a character, so below 120px they collide with
-     their neighbours; rotated ones lean into the top margin and only need
-     the column's width as spacing, which MIN_COL guarantees. */
-  const rotated=colW<120;
+  const rotated=colW<64;
   const M={t:rotated?76:34,r:16,b:18,l:64};
-  /* labels live in their own layer, appended after the dots, so a busy
-     column can never paint over its own header or commit count */
-  const labelsG=document.createElementNS(SVGNS,'g');
   const yOf=t=>M.t+(T1-t)/(T1-T0)*(H-M.t-M.b);
   /* column bands + headers */
   lanes.forEach((cat,i)=>{
@@ -1488,12 +1479,8 @@ function buildTimeline(){
     }
     tsvg.appendChild(band);
     const name=CAT[cat].name;
-    /* fit the label to the column rather than to a fixed count */
-    const maxChars=rotated?18:Math.max(4,Math.floor((colW-10)/7.2));
-    const label=name.length>maxChars?name.slice(0,Math.max(1,maxChars-1))+'…':name;
+    const label=name.length>18?name.slice(0,17)+'…':name;
     const lb=document.createElementNS(SVGNS,'text');
-    const full=document.createElementNS(SVGNS,'title');
-    full.textContent=name;lb.appendChild(full);
     if(rotated){
       const ax=x+colW/2+4,ay=M.t-10;
       lb.setAttribute('x',ax);lb.setAttribute('y',ay);
@@ -1505,8 +1492,8 @@ function buildTimeline(){
       lb.setAttribute('text-anchor','middle');
       lb.setAttribute('style',`font:italic 500 13px ${SERIF};fill:${live?hexA(CAT[cat].color,.95):'rgba(125,120,109,.85)'}`);
     }
-    lb.appendChild(document.createTextNode(label));
-    labelsG.appendChild(lb);
+    lb.textContent=label;
+    tsvg.appendChild(lb);
     if(!live){
       /* one line, centred in the empty column, saying why it is empty */
       const why=document.createElementNS(SVGNS,'text');
@@ -1514,7 +1501,7 @@ function buildTimeline(){
       why.setAttribute('text-anchor','middle');
       why.setAttribute('style',`font:400 8.5px ${MONO};letter-spacing:.1em;fill:#56534b`);
       why.textContent=colW>=104?'NO GIT HISTORY':colW>=64?'NO HISTORY':'—';
-      labelsG.appendChild(why);
+      tsvg.appendChild(why);
     }
     if(tMode==='project'&&live){
       const total=(GITHIST[cat]||[]).reduce((sum,day)=>sum+day.n,0);
@@ -1523,7 +1510,7 @@ function buildTimeline(){
       sub.setAttribute('text-anchor','middle');
       sub.setAttribute('style',`font:400 8.5px ${MONO};letter-spacing:.06em;fill:#56534b`);
       sub.textContent=colW>=70?`${total} COMMIT${total===1?'':'S'}`:String(total);
-      labelsG.appendChild(sub);
+      tsvg.appendChild(sub);
     }
   });
   /* month grid: horizontal rules, labeled in the left margin */
@@ -1630,9 +1617,7 @@ function buildTimeline(){
     (GITHIST[cat]||[]).forEach(day=>{
       const t=+new Date(day.d+'T00:00:00');
       const dot=document.createElementNS(SVGNS,'circle');
-      /* hard cap at 10px: wide lanes would otherwise let a daily-commit
-         project fuse into a solid strip that buries its own labels */
-      const r=Math.max(2,Math.min(colW*.42,10,2+Math.sqrt(day.n)*1.6));
+      const r=Math.max(2,Math.min(colW*.42,2+Math.sqrt(day.n)*1.6));
       dot.setAttribute('cx',baseX);dot.setAttribute('cy',yOf(t));
       dot.setAttribute('r',r);dot.setAttribute('fill',col);
       dot.dataset.hist=String(histDots.length);
@@ -1642,7 +1627,6 @@ function buildTimeline(){
     });
   });
   }
-  tsvg.appendChild(labelsG);
   /* sweep: a horizontal rule at the scrubbed moment */
   const sweep=document.createElementNS(SVGNS,'line');
   sweep.setAttribute('id','tsweep');
@@ -1655,12 +1639,8 @@ function buildTimeline(){
 }
 function renderTimelineState(){
   const yOf=tsvg._yOf;if(!yOf)return;
-  const sweep=document.getElementById('tsweep');
-  if(sweep){
-    sweep.setAttribute('y1',yOf(tNow));sweep.setAttribute('y2',yOf(tNow));
-    /* off-window moments have no line to draw; the thumb parks at the edge */
-    sweep.setAttribute('opacity',tNow>=T0&&tNow<=T1?.55:0);
-  }
+  document.getElementById('tsweep')?.setAttribute('y1',yOf(tNow));
+  document.getElementById('tsweep')?.setAttribute('y2',yOf(tNow));
   if(tMode==='project'){
     histDots.forEach(d=>d.el.setAttribute('opacity',d.t<=tNow?.85:.08));
   }else LEAVES.forEach(n=>{
@@ -1683,8 +1663,7 @@ function renderTimelineState(){
   /* labelled as what it is: a bare project name here read as a stray file */
   mEl.textContent=m?'◆ milestone · '+m.t:'';
   mEl.style.opacity=m?1:0;
-  document.getElementById('tscrub').value=
-    Math.round(Math.min(1000,Math.max(0,(tNow-T0)/(T1-T0)*1000)));
+  document.getElementById('tscrub').value=Math.round((tNow-T0)/(T1-T0)*1000);
 }
 function traceOnTimeline(n){
   if(tMode!=='file')setTMode('file'); /* traces live on the By-file plot */
@@ -1774,9 +1753,7 @@ function stopPlay(){
 }
 document.getElementById('tplay').addEventListener('click',()=>{
   if(tPlaying){stopPlay();return;}
-  /* start from the window's beginning when the playhead is past its end
-     or somewhere off screen — playing through invisible months is no show */
-  if(tNow<T0||tNow>=T1-3600000)tNow=T0;
+  if(tNow>=T1-3600000)tNow=T0;
   startPlay();
 });
 function showHistHC(d,mx,my){
@@ -1806,11 +1783,8 @@ tplot.addEventListener('wheel',e=>{
   e.preventDefault();
   if(e.shiftKey||(e.deltaX&&!e.deltaY)){tplot.scrollLeft+=e.deltaX||e.deltaY;return;}
   stopPlay();
-  /* zoom around the playhead while it is on screen — the video-editor
-     convention — so the scrub thumb never moves under a wheel; fall back
-     to the cursor once the playhead is out of the window */
   const r=tplot.getBoundingClientRect();
-  const t=tNow>T0&&tNow<T1?tNow:tOfY(e.clientY-r.top);
+  const t=tOfY(e.clientY-r.top);
   const f=Math.exp(e.deltaY*.0016);
   setView(t-(t-T0)*f,t+(T1-t)*f);
 },{passive:false});

--- a/space_ui/js/views/atlas.js
+++ b/space_ui/js/views/atlas.js
@@ -1306,7 +1306,14 @@ function resetView(){tZoomed=false;T0=TF0;T1=TF1;scheduleBuild();}
 function renderYears(){
   const el=document.getElementById('tyears');if(!el)return;
   const y0=new Date(TF0).getFullYear(),y1=new Date(TF1).getFullYear();
-  const years=[];for(let y=y0;y<=y1;y++)years.push(y);
+  /* a year earns a chip only if the axis spends at least MIN_SPAN in it:
+     the 7-day pad alone must not grow a chip whose window then has to be
+     re-widened across the boundary and can never light up */
+  const years=[];
+  for(let y=y0;y<=y1;y++){
+    const overlap=Math.min(TF1,+new Date(y+1,0,1))-Math.max(TF0,+new Date(y,0,1));
+    if(overlap>=MIN_SPAN)years.push(y);
+  }
   const inYear=y=>tZoomed&&T0>=+new Date(y,0,1)-DAY&&T1<=+new Date(y+1,0,1)+DAY;
   const many=years.length>1;
   el.innerHTML=(many||tZoomed
@@ -1389,7 +1396,6 @@ function setTMode(mode){
   if(mode==='project'&&tTrace)clearTrace(); /* traces are a By-file tool */
   syncTModeUI();
   buildTimeline();
-  if(tMode==='file'&&tTrace)drawTrace();
 }
 syncTModeUI();
 /* Each mode gets its own axis, spanning only what it actually plots: the
@@ -1443,6 +1449,7 @@ function buildTimeline(){
      so the column headers stay legible whatever the project count. */
   const q=laneFilter.trim().toLowerCase();
   const lanes=q?allLanes.filter(cat=>CAT[cat].name.toLowerCase().includes(q)):allLanes;
+  const laneSet=new Set(lanes);
   const MIN_COL=100;
   const colW=Math.max(MIN_COL,(W-64-16)/Math.max(1,lanes.length));
   const SW=Math.max(W,Math.round(64+16+colW*lanes.length));
@@ -1461,6 +1468,9 @@ function buildTimeline(){
      columns rotate their headers, which needs a taller top margin. */
   const rotated=colW<64;
   const M={t:rotated?76:34,r:16,b:18,l:64};
+  /* no plot band, no plot: with the margins eating the whole height yOf
+     divides by zero and a wheel tick would turn the window into NaN */
+  if(H<M.t+M.b+20){tsvg._yOf=null;return;}
   /* Three layers, bottom to top: bands and grid, then the data clipped to
      the plot band (a dot on the first row cannot spill into the headers,
      one on the last cannot bury the commit counts), then the labels with
@@ -1595,7 +1605,9 @@ function buildTimeline(){
   dotsG.setAttribute('id','tdots');
   plotG.appendChild(dotsG);
   LEAVES.forEach(n=>{
-    if(!n.date){n.tEl=null;return;} /* git-dated artifacts only */
+    /* git-dated artifacts only, and only in lanes that are on the plot: a
+       filtered-out leaf has no position and would land on stale coordinates */
+    if(!n.date||!laneSet.has(n.cat)){n.tEl=null;return;}
     const col=CAT[n.cat].color;
     const r=3.2+Math.min(2.6,(n.degree-1)*.5);
     let el;
@@ -1658,7 +1670,9 @@ function buildTimeline(){
   tsvg.appendChild(sweep);
   tsvg.appendChild(labelsG);
   tsvg._yOf=yOf;
-  renderTimelineState();
+  /* "after a rebuild, the trace is back" is the rebuild's invariant, not
+     the callers' — zoom, pan, chips, filter and resize all rebuild */
+  if(tTrace&&tMode==='file')drawTrace();else renderTimelineState();
 }
 function renderTimelineState(){
   const yOf=tsvg._yOf;if(!yOf)return;
@@ -1694,6 +1708,9 @@ function traceOnTimeline(n){
     ?LEAVES.filter(l=>belongsToCategory(l,n.cat)):[n];
   const list=ids.filter(l=>l.date).sort((a,b)=>a.date<b.date?-1:1);
   tTrace={ids:new Set(list.map(x=>x.id)),list,label:n.label};
+  /* a trace plays from its first date; a zoomed window that excludes it
+     would show nothing until the user found the All chip */
+  if(tZoomed)resetView();
   go('time');
   requestAnimationFrame(()=>{
     if(!list.length){
@@ -1716,8 +1733,10 @@ function drawTrace(){
   const g=tsvg.querySelector('#ttrace');
   if(!g)return;
   g.innerHTML='';
-  if(!tTrace||tTrace.list.length<2){renderTimelineState();return;}
-  const pts=tTrace.list.map(n=>[n.tx,n.ty]);
+  /* only the leaves that made it onto the plot — the lane filter may hide some */
+  const shown=tTrace?tTrace.list.filter(n=>n.tEl):[];
+  if(shown.length<2){renderTimelineState();return;}
+  const pts=shown.map(n=>[n.tx,n.ty]);
   let path=`M ${pts[0][0]} ${pts[0][1]}`;
   for(let i=1;i<pts.length;i++){
     const [x0,y0]=pts[i-1],[x1,y1]=pts[i];
@@ -1730,7 +1749,7 @@ function drawTrace(){
   g.appendChild(p);
   /* labels: alternate left/right, and step outward when several share a y window */
   const win=[];
-  tTrace.list.forEach((n,i)=>{
+  shown.forEach((n,i)=>{
     const near=win.filter(w=>Math.abs(w-n.ty)<24).length;
     win.push(n.ty);
     const left=i%2===0;
@@ -1813,11 +1832,14 @@ tplot.addEventListener('wheel',e=>{
 },{passive:false});
 let tDrag=null,tDragMoved=false;
 tplot.addEventListener('pointerdown',e=>{
-  if(e.button!==0)return;
-  tDrag={x:e.clientX,y:e.clientY,x0:e.clientX,y0:e.clientY};tDragMoved=false;
+  if(e.button!==0||tDrag)return;
+  tDrag={id:e.pointerId,x:e.clientX,y:e.clientY,x0:e.clientX,y0:e.clientY};tDragMoved=false;
 });
 tplot.addEventListener('pointermove',e=>{
-  if(!tDrag)return;
+  if(!tDrag||e.pointerId!==tDrag.id)return;
+  /* a release the pane never saw (before capture, outside it) must not
+     leave a phantom drag that pans on the next un-pressed hover */
+  if(e.buttons===0){endDrag();return;}
   if(!tDragMoved){
     /* 4px of slack keeps a click on a dot a click; capture only once the
        drag is real, or the captured pointer would retarget that click */
@@ -1838,9 +1860,14 @@ tplot.addEventListener('pointermove',e=>{
     scheduleBuild();
   }
 });
-const endDrag=()=>{if(!tDrag)return;tDrag=null;tplot.classList.remove('is-panning');};
-tplot.addEventListener('pointerup',endDrag);
-tplot.addEventListener('pointercancel',endDrag);
+function endDrag(e){
+  if(!tDrag||(e&&e.pointerId!==undefined&&e.pointerId!==tDrag.id))return;
+  tDrag=null;tplot.classList.remove('is-panning');
+}
+/* on window, not the pane: an uncaptured release lands wherever the
+   pointer is, and the pane only captures once a drag is real */
+addEventListener('pointerup',endDrag);
+addEventListener('pointercancel',endDrag);
 tsvg.addEventListener('pointermove',e=>{
   if(tDrag&&tDragMoved)return;
   const t=e.target;

--- a/space_ui/js/views/atlas.js
+++ b/space_ui/js/views/atlas.js
@@ -1461,6 +1461,22 @@ function buildTimeline(){
      columns rotate their headers, which needs a taller top margin. */
   const rotated=colW<64;
   const M={t:rotated?76:34,r:16,b:18,l:64};
+  /* Three layers, bottom to top: bands and grid, then the data clipped to
+     the plot band (a dot on the first row cannot spill into the headers,
+     one on the last cannot bury the commit counts), then the labels with
+     a dark halo. Zoom changes what the data does; the label zones stay
+     reserved regardless. */
+  const defs=document.createElementNS(SVGNS,'defs');
+  const clip=document.createElementNS(SVGNS,'clipPath');
+  clip.setAttribute('id','tclip');
+  const clipRect=document.createElementNS(SVGNS,'rect');
+  clipRect.setAttribute('x',0);clipRect.setAttribute('y',M.t-6);
+  clipRect.setAttribute('width',SW);clipRect.setAttribute('height',H-M.t-M.b+12);
+  clip.appendChild(clipRect);defs.appendChild(clip);tsvg.appendChild(defs);
+  const plotG=document.createElementNS(SVGNS,'g');
+  plotG.setAttribute('clip-path','url(#tclip)');
+  const labelsG=document.createElementNS(SVGNS,'g');
+  labelsG.setAttribute('style','paint-order:stroke;stroke:rgba(11,13,16,.9);stroke-width:3px;stroke-linejoin:round');
   const yOf=t=>M.t+(T1-t)/(T1-T0)*(H-M.t-M.b);
   /* column bands + headers */
   lanes.forEach((cat,i)=>{
@@ -1479,8 +1495,13 @@ function buildTimeline(){
     }
     tsvg.appendChild(band);
     const name=CAT[cat].name;
-    const label=name.length>18?name.slice(0,17)+'…':name;
+    /* fit the label to the lane, not to a fixed count: an 18-character
+       name is ~125px upright and collided with its neighbours */
+    const maxChars=rotated?18:Math.max(4,Math.floor((colW-8)/7.2));
+    const label=name.length>maxChars?name.slice(0,Math.max(1,maxChars-1))+'…':name;
     const lb=document.createElementNS(SVGNS,'text');
+    const full=document.createElementNS(SVGNS,'title');
+    full.textContent=name;lb.appendChild(full);
     if(rotated){
       const ax=x+colW/2+4,ay=M.t-10;
       lb.setAttribute('x',ax);lb.setAttribute('y',ay);
@@ -1492,8 +1513,8 @@ function buildTimeline(){
       lb.setAttribute('text-anchor','middle');
       lb.setAttribute('style',`font:italic 500 13px ${SERIF};fill:${live?hexA(CAT[cat].color,.95):'rgba(125,120,109,.85)'}`);
     }
-    lb.textContent=label;
-    tsvg.appendChild(lb);
+    lb.appendChild(document.createTextNode(label));
+    labelsG.appendChild(lb);
     if(!live){
       /* one line, centred in the empty column, saying why it is empty */
       const why=document.createElementNS(SVGNS,'text');
@@ -1501,7 +1522,7 @@ function buildTimeline(){
       why.setAttribute('text-anchor','middle');
       why.setAttribute('style',`font:400 8.5px ${MONO};letter-spacing:.1em;fill:#56534b`);
       why.textContent=colW>=104?'NO GIT HISTORY':colW>=64?'NO HISTORY':'—';
-      tsvg.appendChild(why);
+      labelsG.appendChild(why);
     }
     if(tMode==='project'&&live){
       const total=(GITHIST[cat]||[]).reduce((sum,day)=>sum+day.n,0);
@@ -1510,7 +1531,7 @@ function buildTimeline(){
       sub.setAttribute('text-anchor','middle');
       sub.setAttribute('style',`font:400 8.5px ${MONO};letter-spacing:.06em;fill:#56534b`);
       sub.textContent=colW>=70?`${total} COMMIT${total===1?'':'S'}`:String(total);
-      tsvg.appendChild(sub);
+      labelsG.appendChild(sub);
     }
   });
   /* month grid: horizontal rules, labeled in the left margin */
@@ -1549,6 +1570,7 @@ function buildTimeline(){
     c.setAttribute('fill','#3a4136');c.dataset.milestone='1';c.dataset.t=+new Date(m.d+'T00:00:00');
     tsvg.appendChild(c);
   });
+  tsvg.appendChild(plotG);
   if(tMode==='file'){
   /* beeswarm: the date sets the row (y); collisions fan sideways inside the
      column, spilling downward (older) when a column is packed */
@@ -1571,7 +1593,7 @@ function buildTimeline(){
   });
   const dotsG=document.createElementNS(SVGNS,'g');
   dotsG.setAttribute('id','tdots');
-  tsvg.appendChild(dotsG);
+  plotG.appendChild(dotsG);
   LEAVES.forEach(n=>{
     if(!n.date){n.tEl=null;return;} /* git-dated artifacts only */
     const col=CAT[n.cat].color;
@@ -1601,7 +1623,7 @@ function buildTimeline(){
   /* trace layer */
   const traceG=document.createElementNS(SVGNS,'g');
   traceG.setAttribute('id','ttrace');
-  tsvg.insertBefore(traceG,dotsG);
+  plotG.insertBefore(traceG,dotsG);
   }else{
   /* parallel git histories: one column per project, one dot per commit-day.
      Radius grows with the square root of that day's commit count, capped so
@@ -1613,7 +1635,7 @@ function buildTimeline(){
     base.setAttribute('x1',baseX);base.setAttribute('x2',baseX);
     base.setAttribute('y1',M.t-6);base.setAttribute('y2',H-M.b+6);
     base.setAttribute('stroke',hexA(col,.18));base.setAttribute('stroke-width',1);
-    tsvg.appendChild(base);
+    plotG.appendChild(base);
     (GITHIST[cat]||[]).forEach(day=>{
       const t=+new Date(day.d+'T00:00:00');
       const dot=document.createElementNS(SVGNS,'circle');
@@ -1622,7 +1644,7 @@ function buildTimeline(){
       dot.setAttribute('r',r);dot.setAttribute('fill',col);
       dot.dataset.hist=String(histDots.length);
       dot.style.cursor='pointer';
-      tsvg.appendChild(dot);
+      plotG.appendChild(dot);
       histDots.push({el:dot,t,cat,day});
     });
   });
@@ -1634,6 +1656,7 @@ function buildTimeline(){
   sweep.setAttribute('stroke',ACCENT);sweep.setAttribute('stroke-width',1.2);
   sweep.setAttribute('stroke-dasharray','2 4');sweep.setAttribute('opacity',.55);
   tsvg.appendChild(sweep);
+  tsvg.appendChild(labelsG);
   tsvg._yOf=yOf;
   renderTimelineState();
 }

--- a/space_ui/js/views/atlas.js
+++ b/space_ui/js/views/atlas.js
@@ -1414,7 +1414,10 @@ function computeRange(){
     if(T1-T0<MIN_SPAN)tZoomed=false;
   }
   if(!tZoomed){T0=TF0;T1=TF1;}
-  tNow=Math.min(Math.max(tNow,T0),T1);
+  /* the scrubbed moment is state, the window is view: zooming or panning
+     may leave it off screen but never moves it. Only the full axis (a mode
+     switch) can push it. */
+  tNow=Math.min(Math.max(tNow,TF0),TF1);
   renderYears();
   const ticks=document.querySelector('#view-time .ticks');
   if(ticks){
@@ -1459,8 +1462,14 @@ function buildTimeline(){
   }
   /* Time runs vertically: newest at the top, oldest at the bottom. Narrow
      columns rotate their headers, which needs a taller top margin. */
-  const rotated=colW<64;
+  /* Upright labels need ~7px a character, so below 120px they collide with
+     their neighbours; rotated ones lean into the top margin and only need
+     the column's width as spacing, which MIN_COL guarantees. */
+  const rotated=colW<120;
   const M={t:rotated?76:34,r:16,b:18,l:64};
+  /* labels live in their own layer, appended after the dots, so a busy
+     column can never paint over its own header or commit count */
+  const labelsG=document.createElementNS(SVGNS,'g');
   const yOf=t=>M.t+(T1-t)/(T1-T0)*(H-M.t-M.b);
   /* column bands + headers */
   lanes.forEach((cat,i)=>{
@@ -1479,8 +1488,12 @@ function buildTimeline(){
     }
     tsvg.appendChild(band);
     const name=CAT[cat].name;
-    const label=name.length>18?name.slice(0,17)+'…':name;
+    /* fit the label to the column rather than to a fixed count */
+    const maxChars=rotated?18:Math.max(4,Math.floor((colW-10)/7.2));
+    const label=name.length>maxChars?name.slice(0,Math.max(1,maxChars-1))+'…':name;
     const lb=document.createElementNS(SVGNS,'text');
+    const full=document.createElementNS(SVGNS,'title');
+    full.textContent=name;lb.appendChild(full);
     if(rotated){
       const ax=x+colW/2+4,ay=M.t-10;
       lb.setAttribute('x',ax);lb.setAttribute('y',ay);
@@ -1492,8 +1505,8 @@ function buildTimeline(){
       lb.setAttribute('text-anchor','middle');
       lb.setAttribute('style',`font:italic 500 13px ${SERIF};fill:${live?hexA(CAT[cat].color,.95):'rgba(125,120,109,.85)'}`);
     }
-    lb.textContent=label;
-    tsvg.appendChild(lb);
+    lb.appendChild(document.createTextNode(label));
+    labelsG.appendChild(lb);
     if(!live){
       /* one line, centred in the empty column, saying why it is empty */
       const why=document.createElementNS(SVGNS,'text');
@@ -1501,7 +1514,7 @@ function buildTimeline(){
       why.setAttribute('text-anchor','middle');
       why.setAttribute('style',`font:400 8.5px ${MONO};letter-spacing:.1em;fill:#56534b`);
       why.textContent=colW>=104?'NO GIT HISTORY':colW>=64?'NO HISTORY':'—';
-      tsvg.appendChild(why);
+      labelsG.appendChild(why);
     }
     if(tMode==='project'&&live){
       const total=(GITHIST[cat]||[]).reduce((sum,day)=>sum+day.n,0);
@@ -1510,7 +1523,7 @@ function buildTimeline(){
       sub.setAttribute('text-anchor','middle');
       sub.setAttribute('style',`font:400 8.5px ${MONO};letter-spacing:.06em;fill:#56534b`);
       sub.textContent=colW>=70?`${total} COMMIT${total===1?'':'S'}`:String(total);
-      tsvg.appendChild(sub);
+      labelsG.appendChild(sub);
     }
   });
   /* month grid: horizontal rules, labeled in the left margin */
@@ -1617,7 +1630,9 @@ function buildTimeline(){
     (GITHIST[cat]||[]).forEach(day=>{
       const t=+new Date(day.d+'T00:00:00');
       const dot=document.createElementNS(SVGNS,'circle');
-      const r=Math.max(2,Math.min(colW*.42,2+Math.sqrt(day.n)*1.6));
+      /* hard cap at 10px: wide lanes would otherwise let a daily-commit
+         project fuse into a solid strip that buries its own labels */
+      const r=Math.max(2,Math.min(colW*.42,10,2+Math.sqrt(day.n)*1.6));
       dot.setAttribute('cx',baseX);dot.setAttribute('cy',yOf(t));
       dot.setAttribute('r',r);dot.setAttribute('fill',col);
       dot.dataset.hist=String(histDots.length);
@@ -1627,6 +1642,7 @@ function buildTimeline(){
     });
   });
   }
+  tsvg.appendChild(labelsG);
   /* sweep: a horizontal rule at the scrubbed moment */
   const sweep=document.createElementNS(SVGNS,'line');
   sweep.setAttribute('id','tsweep');
@@ -1639,8 +1655,12 @@ function buildTimeline(){
 }
 function renderTimelineState(){
   const yOf=tsvg._yOf;if(!yOf)return;
-  document.getElementById('tsweep')?.setAttribute('y1',yOf(tNow));
-  document.getElementById('tsweep')?.setAttribute('y2',yOf(tNow));
+  const sweep=document.getElementById('tsweep');
+  if(sweep){
+    sweep.setAttribute('y1',yOf(tNow));sweep.setAttribute('y2',yOf(tNow));
+    /* off-window moments have no line to draw; the thumb parks at the edge */
+    sweep.setAttribute('opacity',tNow>=T0&&tNow<=T1?.55:0);
+  }
   if(tMode==='project'){
     histDots.forEach(d=>d.el.setAttribute('opacity',d.t<=tNow?.85:.08));
   }else LEAVES.forEach(n=>{
@@ -1663,7 +1683,8 @@ function renderTimelineState(){
   /* labelled as what it is: a bare project name here read as a stray file */
   mEl.textContent=m?'◆ milestone · '+m.t:'';
   mEl.style.opacity=m?1:0;
-  document.getElementById('tscrub').value=Math.round((tNow-T0)/(T1-T0)*1000);
+  document.getElementById('tscrub').value=
+    Math.round(Math.min(1000,Math.max(0,(tNow-T0)/(T1-T0)*1000)));
 }
 function traceOnTimeline(n){
   if(tMode!=='file')setTMode('file'); /* traces live on the By-file plot */
@@ -1753,7 +1774,9 @@ function stopPlay(){
 }
 document.getElementById('tplay').addEventListener('click',()=>{
   if(tPlaying){stopPlay();return;}
-  if(tNow>=T1-3600000)tNow=T0;
+  /* start from the window's beginning when the playhead is past its end
+     or somewhere off screen — playing through invisible months is no show */
+  if(tNow<T0||tNow>=T1-3600000)tNow=T0;
   startPlay();
 });
 function showHistHC(d,mx,my){
@@ -1783,8 +1806,11 @@ tplot.addEventListener('wheel',e=>{
   e.preventDefault();
   if(e.shiftKey||(e.deltaX&&!e.deltaY)){tplot.scrollLeft+=e.deltaX||e.deltaY;return;}
   stopPlay();
+  /* zoom around the playhead while it is on screen — the video-editor
+     convention — so the scrub thumb never moves under a wheel; fall back
+     to the cursor once the playhead is out of the window */
   const r=tplot.getBoundingClientRect();
-  const t=tOfY(e.clientY-r.top);
+  const t=tNow>T0&&tNow<T1?tNow:tOfY(e.clientY-r.top);
   const f=Math.exp(e.deltaY*.0016);
   setView(t-(t-T0)*f,t+(T1-t)*f);
 },{passive:false});

--- a/space_ui/js/views/atlas.js
+++ b/space_ui/js/views/atlas.js
@@ -73,7 +73,7 @@ function renderNoData(el,dataset){
   box.innerHTML='<div class="eyebrow">No data source</div>'+
     '<h1>Space reads its map from a local file.</h1>'+
     '<p>This page loads <b>'+source.url+'</b> — a file in the workspace <b>.xo</b> directory — from this local server, so the data stays on this machine. Start the workspace server:</p>'+
-    '<pre>cd xo-cowork-api && ./cowork-api.sh start</pre>'+
+    '<pre>cd xo-space && ./cowork-api.sh start</pre>'+
     '<p>then open <b>http://localhost:5002/space/</b></p>'+
     '<button id="nodata-retry">Retry</button>';
   el.appendChild(box);
@@ -959,7 +959,7 @@ function shapeTodos(res){
   if(!res.ok){
     return{rows:[],state:'error',
       note:res.notImplemented?'todos are not available for the active agent'
-        :res.offline?'xo-cowork-api is unreachable':String(res.error||'could not read todos')};
+        :res.offline?'xo-space is unreachable':String(res.error||'could not read todos')};
   }
   const rows=[];
   for(const [sid,sess] of Object.entries(res.data.sessions||{})){

--- a/space_ui/js/views/atlas.js
+++ b/space_ui/js/views/atlas.js
@@ -1282,7 +1282,48 @@ addEventListener('keydown',e=>{
 
 /* ============================== TIMELINE ============================== */
 const T0G=+new Date(DATA.timeline.start+'T00:00:00'),T1G=+new Date(DATA.timeline.end+'T00:00:00');
+/* TF0/TF1 is the full axis of the current mode (computeRange fits it to the
+   data); T0/T1 is the window actually on screen — identical until the user
+   zooms or picks a year. Everything downstream (yOf, the scrubber, Play, the
+   ticks) reads the window, so zooming is nothing more than a narrower axis. */
+let TF0=T0G,TF1=T1G;
 let T0=T0G,T1=T1G;
+let tZoomed=false;
+const DAY=86400000,MIN_SPAN=DAY*7;
+let laneFilter='';
+let tRebuildRAF=null;
+/* one rebuild per frame, however many wheel ticks arrive */
+function scheduleBuild(){cancelAnimationFrame(tRebuildRAF);tRebuildRAF=requestAnimationFrame(buildTimeline);}
+function setView(a,b){
+  a=Math.max(TF0,a);b=Math.min(TF1,b);
+  if(b-a<MIN_SPAN){const mid=(a+b)/2;a=Math.max(TF0,mid-MIN_SPAN/2);b=Math.min(TF1,a+MIN_SPAN);}
+  T0=a;T1=b;
+  tZoomed=!(a<=TF0&&b>=TF1);
+  scheduleBuild();
+}
+function resetView(){tZoomed=false;T0=TF0;T1=TF1;scheduleBuild();}
+/* year chips: one per year the full axis touches, plus All once zoomed */
+function renderYears(){
+  const el=document.getElementById('tyears');if(!el)return;
+  const y0=new Date(TF0).getFullYear(),y1=new Date(TF1).getFullYear();
+  const years=[];for(let y=y0;y<=y1;y++)years.push(y);
+  const inYear=y=>tZoomed&&T0>=+new Date(y,0,1)-DAY&&T1<=+new Date(y+1,0,1)+DAY;
+  const many=years.length>1;
+  el.innerHTML=(many||tZoomed
+      ?`<button type="button" data-year="all"${tZoomed?'':' class="is-on"'}>All</button>`:'')
+    +(many?years.map(y=>`<button type="button" data-year="${y}"${inYear(y)?' class="is-on"':''}>${y}</button>`).join(''):'');
+  el.hidden=!many&&!tZoomed;
+}
+document.getElementById('tyears').addEventListener('click',e=>{
+  const b=e.target.closest('[data-year]');if(!b)return;
+  stopPlay();
+  if(b.dataset.year==='all'){resetView();return;}
+  const y=+b.dataset.year;
+  setView(+new Date(y,0,1),+new Date(y+1,0,1));
+});
+document.getElementById('tlanes').addEventListener('input',e=>{
+  laneFilter=e.target.value;scheduleBuild();
+});
 const SVGNS='http://www.w3.org/2000/svg';
 let tNow=T1G,tPlaying=false,tTrace=null;
 const tplot=document.getElementById('tplot');
@@ -1329,6 +1370,9 @@ function defaultSub(){
   }
   return(DATA.meta.timelineSub||
     'Scrub through the workspace as it grew, newest at the top. Open any cluster from the graph to watch its run unfold here.')
+    /* the two modes fit their own data, so this axis is usually the shorter
+       one; say so, or the mismatch reads as missing history */
+    +(hasHist?' Files plot their git dates only, so this axis is shorter than By project.':'')
     +coverageNote();
 }
 function syncTModeUI(){
@@ -1356,14 +1400,22 @@ function computeRange(){
   const stamps=tMode==='project'
     ?histLanes.flatMap(cat=>(GITHIST[cat]||[]).map(day=>+new Date(day.d+'T00:00:00')))
     :LEAVES.filter(n=>n.date).map(n=>+new Date(n.date+'T00:00:00'));
-  if(!stamps.length){T0=T0G;T1=T1G;}
+  if(!stamps.length){TF0=T0G;TF1=T1G;}
   else{
     const pad=86400000*7;
     let lo=Infinity,hi=-Infinity;
     for(const t of stamps){if(t<lo)lo=t;if(t>hi)hi=t;}
-    T0=lo-pad;T1=hi+pad;
+    TF0=lo-pad;TF1=hi+pad;
   }
+  /* a zoomed window survives a mode switch as long as it still fits the
+     new axis; otherwise fall back to the full range */
+  if(tZoomed){
+    T0=Math.max(TF0,T0);T1=Math.min(TF1,T1);
+    if(T1-T0<MIN_SPAN)tZoomed=false;
+  }
+  if(!tZoomed){T0=TF0;T1=TF1;}
   tNow=Math.min(Math.max(tNow,T0),T1);
+  renderYears();
   const ticks=document.querySelector('#view-time .ticks');
   if(ticks){
     const fmtTick=(t,withYear)=>new Date(t).toLocaleDateString('en-US',
@@ -1376,11 +1428,7 @@ function buildTimeline(){
   const W=tplot.clientWidth,H=tplot.clientHeight;
   if(W<50||H<50)return;
   computeRange();
-  tsvg.setAttribute('viewBox',`0 0 ${W} ${H}`);
-  tsvg.innerHTML='';
   histDots=[];
-  /* Only lanes with something to plot: projects whose files are all undated
-     (nothing committed) would render as dead empty columns. */
   /* Every project gets a lane, including the ones with nothing to plot.
      Dropping them made the Timeline disagree with Files about how many
      projects exist, and a reader cannot tell "no history" from "missing".
@@ -1389,8 +1437,26 @@ function buildTimeline(){
   const hasData=cat=>tMode==='project'
     ?(GITHIST[cat]||[]).length>0
     :LEAVES.some(n=>n.cat===cat&&n.date);
-  const lanes=allLanes;
-  const colW=(W-64-16)/Math.max(1,lanes.length);
+  /* The lane filter narrows by project name: a hundred lanes at 18px each
+     is a smear, not a chart. Below MIN_COL the plot stops squeezing and
+     grows wider than the pane instead, panning sideways (drag, shift+wheel)
+     so the column headers stay legible whatever the project count. */
+  const q=laneFilter.trim().toLowerCase();
+  const lanes=q?allLanes.filter(cat=>CAT[cat].name.toLowerCase().includes(q)):allLanes;
+  const MIN_COL=44;
+  const colW=Math.max(MIN_COL,(W-64-16)/Math.max(1,lanes.length));
+  const SW=Math.max(W,Math.round(64+16+colW*lanes.length));
+  tsvg.setAttribute('viewBox',`0 0 ${SW} ${H}`);
+  tsvg.style.width=SW+'px';
+  tsvg.innerHTML='';
+  if(!lanes.length){
+    const none=document.createElementNS(SVGNS,'text');
+    none.setAttribute('x',SW/2);none.setAttribute('y',H/2);
+    none.setAttribute('text-anchor','middle');
+    none.setAttribute('style',`font:italic 400 13px ${SERIF};fill:#56534b`);
+    none.textContent='No project matches the filter.';
+    tsvg.appendChild(none);
+  }
   /* Time runs vertically: newest at the top, oldest at the bottom. Narrow
      columns rotate their headers, which needs a taller top margin. */
   const rotated=colW<64;
@@ -1455,7 +1521,7 @@ function buildTimeline(){
     while(+d<T1){
       const y=yOf(+d);
       const ln=document.createElementNS(SVGNS,'line');
-      ln.setAttribute('x1',M.l-6);ln.setAttribute('x2',W-M.r);
+      ln.setAttribute('x1',M.l-6);ln.setAttribute('x2',SW-M.r);
       ln.setAttribute('y1',y);ln.setAttribute('y2',y);
       ln.setAttribute('stroke',d.getMonth()===0?'rgba(233,228,217,.13)':'rgba(233,228,217,.05)');
       ln.setAttribute('stroke-dasharray','1 4');
@@ -1564,7 +1630,7 @@ function buildTimeline(){
   /* sweep: a horizontal rule at the scrubbed moment */
   const sweep=document.createElementNS(SVGNS,'line');
   sweep.setAttribute('id','tsweep');
-  sweep.setAttribute('x1',M.l-6);sweep.setAttribute('x2',W-M.r);
+  sweep.setAttribute('x1',M.l-6);sweep.setAttribute('x2',SW-M.r);
   sweep.setAttribute('stroke',ACCENT);sweep.setAttribute('stroke-width',1.2);
   sweep.setAttribute('stroke-dasharray','2 4');sweep.setAttribute('opacity',.55);
   tsvg.appendChild(sweep);
@@ -1594,7 +1660,8 @@ function renderTimelineState(){
   document.getElementById('treadout').textContent=fmtMY(tNow);
   const m=[...MILES].reverse().find(x=>+new Date(x.d+'T00:00:00')<=tNow);
   const mEl=document.getElementById('tmilestone');
-  mEl.textContent=m?m.t:'';
+  /* labelled as what it is: a bare project name here read as a stray file */
+  mEl.textContent=m?'◆ milestone · '+m.t:'';
   mEl.style.opacity=m?1:0;
   document.getElementById('tscrub').value=Math.round((tNow-T0)/(T1-T0)*1000);
 }
@@ -1703,7 +1770,56 @@ function showHistHC(d,mx,my){
     <div class="foot">Click to open this project on the graph</div>`;
   placeHC(mx,my);
 }
+/* Axis zoom + pan. Wheel zooms the time axis around the moment under the
+   cursor; a vertical drag pans it; a horizontal drag (or shift+wheel) pans
+   the lanes when they are wider than the pane. The same gestures as the
+   Graph and Tree lenses, so a hand that knows one knows all three. */
+const tOfY=y=>{
+  const yOf=tsvg._yOf;if(!yOf)return T1;
+  const top=yOf(T1),bottom=yOf(T0);
+  return T1-(y-top)/(bottom-top)*(T1-T0);
+};
+tplot.addEventListener('wheel',e=>{
+  e.preventDefault();
+  if(e.shiftKey||(e.deltaX&&!e.deltaY)){tplot.scrollLeft+=e.deltaX||e.deltaY;return;}
+  stopPlay();
+  const r=tplot.getBoundingClientRect();
+  const t=tOfY(e.clientY-r.top);
+  const f=Math.exp(e.deltaY*.0016);
+  setView(t-(t-T0)*f,t+(T1-t)*f);
+},{passive:false});
+let tDrag=null,tDragMoved=false;
+tplot.addEventListener('pointerdown',e=>{
+  if(e.button!==0)return;
+  tDrag={x:e.clientX,y:e.clientY,x0:e.clientX,y0:e.clientY};tDragMoved=false;
+});
+tplot.addEventListener('pointermove',e=>{
+  if(!tDrag)return;
+  if(!tDragMoved){
+    /* 4px of slack keeps a click on a dot a click; capture only once the
+       drag is real, or the captured pointer would retarget that click */
+    if(Math.hypot(e.clientX-tDrag.x0,e.clientY-tDrag.y0)<=4)return;
+    tDragMoved=true;
+    tplot.setPointerCapture(e.pointerId);tplot.classList.add('is-panning');
+    stopPlay();hideHC();
+  }
+  const dx=e.clientX-tDrag.x,dy=e.clientY-tDrag.y;
+  tDrag.x=e.clientX;tDrag.y=e.clientY;
+  tplot.scrollLeft-=dx;
+  const yOf=tsvg._yOf;
+  if(yOf&&dy){
+    const span=T1-T0,hp=yOf(T0)-yOf(T1);
+    /* the window slides with the pointer but never past the full axis */
+    const a=Math.max(TF0,Math.min(T0+dy*span/hp,TF1-span));
+    T0=a;T1=a+span;tZoomed=!(T0<=TF0&&T1>=TF1);
+    scheduleBuild();
+  }
+});
+const endDrag=()=>{if(!tDrag)return;tDrag=null;tplot.classList.remove('is-panning');};
+tplot.addEventListener('pointerup',endDrag);
+tplot.addEventListener('pointercancel',endDrag);
 tsvg.addEventListener('pointermove',e=>{
+  if(tDrag&&tDragMoved)return;
   const t=e.target;
   if(t.dataset&&t.dataset.id){showHC(byId.get(t.dataset.id),e.clientX,e.clientY);}
   else if(t.dataset&&t.dataset.hist){showHistHC(histDots[+t.dataset.hist],e.clientX,e.clientY);}
@@ -1711,6 +1827,8 @@ tsvg.addEventListener('pointermove',e=>{
 });
 tsvg.addEventListener('pointerleave',hideHC);
 tsvg.addEventListener('click',e=>{
+  /* a drag that ended on a dot is a pan, not a click */
+  if(tDragMoved){tDragMoved=false;return;}
   const t=e.target;
   if(t.dataset&&t.dataset.id){
     const n=byId.get(t.dataset.id);

--- a/space_ui/js/views/projects.js
+++ b/space_ui/js/views/projects.js
@@ -21,7 +21,7 @@ function rel(iso){
 }
 function panelFail(res){
   if(res.notImplemented)return'<div class="prj-note">not available for the active agent</div>';
-  if(res.offline)return'<div class="prj-note">xo-cowork-api is unreachable</div>';
+  if(res.offline)return'<div class="prj-note">xo-space is unreachable</div>';
   return'<div class="prj-note">'+esc(res.error)+'</div>';
 }
 
@@ -288,7 +288,7 @@ function rowsHTML(rows){
         +(items.length?'<b>No project matches “'+esc(filter)+'”</b>'
             +'<p>Clear the filter to see all '+items.length+'.</p>'
           :'<b>No projects in this workspace yet</b>'
-            +'<p>Create one through the xo-cowork-api; it appears here as soon as the '
+            +'<p>Create one through the xo-space; it appears here as soon as the '
             +'folder exists under the XO root.</p>')
       +'</div>');
 }

--- a/space_ui/js/views/sessions.js
+++ b/space_ui/js/views/sessions.js
@@ -160,7 +160,7 @@ function render(){
   if(failed){
     const off=failed==='\x00offline';
     wrap.innerHTML='<div class="sess-err">'+(off
-      ?'<b>xo-cowork-api is unreachable</b> — the request never reached the server '
+      ?'<b>xo-space is unreachable</b> — the request never reached the server '
         +'(stopped or restarting; the footer pill tracks it). Not a telemetry-source problem. '
       :'<b>Could not load .xo/sessions.json</b> ('+esc(failed)+'). '
         +'The API reads local telemetry for each runtime (Claude Code: <b>ARGUS_DB</b>; Codex: <b>CODEX_HOME</b>; Cursor: <b>CURSOR_HOME</b>). ')
@@ -367,7 +367,7 @@ function renderPrompts(s){
       host.innerHTML='<div class="sess-note">'+(res.status===404&&res.error!=='Not Found'
         ?'No transcript found for this session (its log may have been cleaned up).'
         :res.status===404
-          ?'This server does not have the prompts endpoint yet — restart xo-cowork-api to pick it up.'
+          ?'This server does not have the prompts endpoint yet — restart xo-space to pick it up.'
           :'Could not load prompts ('+esc(res.error||'error')+').')+'</div>';
       return;
     }

--- a/space_ui/js/views/tree.js
+++ b/space_ui/js/views/tree.js
@@ -179,7 +179,7 @@ async function load(){
   loading=false;
   if(!res.ok){
     root.querySelector('.tv').innerHTML=
-      '<div class="prj-note">'+esc(res.offline?'xo-cowork-api is unreachable':res.error)+'</div>';
+      '<div class="prj-note">'+esc(res.offline?'xo-space is unreachable':res.error)+'</div>';
     return;
   }
   model=build(res.data);

--- a/space_ui/js/views/wiki.js
+++ b/space_ui/js/views/wiki.js
@@ -676,7 +676,7 @@ function installationArticle(){
           workspace: the checkout lands beside your projects, and the
           directory itself becomes your projects root.</p></li>
           <li><b>Run the installer.</b>
-          <code>curl -fsSL https://www.quirq.ai/install | sh</code>
+          <code>curl -fsSL quirq.ai/install | sh</code>
           <p>The short URL serves a small POSIX-sh bootstrap: it checks for
           <code>curl</code> and <code>bash</code>, downloads
           <code>install.sh</code> to a temporary file rather than piping it
@@ -753,7 +753,7 @@ function installationArticle(){
           <div><b>Changing the port</b><p>Every value is overridable from the
           environment, but with a piped command the assignment belongs to the
           shell that runs the installer, not to <code>curl</code>:
-          <code>curl -fsSL https://www.quirq.ai/install | PORT=8080 sh</code>.
+          <code>curl -fsSL quirq.ai/install | PORT=8080 sh</code>.
           First-run choices are recorded in the checkout's <code>.env</code>,
           written once and never rewritten.</p></div>
           <div><b>Port 5002 is already busy</b><p>The installer fails clearly

--- a/space_ui/js/views/wiki.js
+++ b/space_ui/js/views/wiki.js
@@ -676,7 +676,7 @@ function installationArticle(){
           workspace: the checkout lands beside your projects, and the
           directory itself becomes your projects root.</p></li>
           <li><b>Run the installer.</b>
-          <code>curl -fsSL quirq.ai/install | sh</code>
+          <code>curl -fsSL https://quirq.ai/install | sh</code>
           <p>The short URL serves a small POSIX-sh bootstrap: it checks for
           <code>curl</code> and <code>bash</code>, downloads
           <code>install.sh</code> to a temporary file rather than piping it
@@ -753,7 +753,7 @@ function installationArticle(){
           <div><b>Changing the port</b><p>Every value is overridable from the
           environment, but with a piped command the assignment belongs to the
           shell that runs the installer, not to <code>curl</code>:
-          <code>curl -fsSL quirq.ai/install | PORT=8080 sh</code>.
+          <code>curl -fsSL https://quirq.ai/install | PORT=8080 sh</code>.
           First-run choices are recorded in the checkout's <code>.env</code>,
           written once and never rewritten.</p></div>
           <div><b>Port 5002 is already busy</b><p>The installer fails clearly


### PR DESCRIPTION
## #20 — one canonical install one-liner (closes it)

`curl -fsSL quirq.ai/install | sh` is now the only public install command: README, INSTALLATION.md (Quick start and the env-override example), the in-app Wiki (two spots), both plugin bundles, and the `INSTALL_COMMAND` Setup prints. The short URL serves a POSIX-sh bootstrap that runs `install.sh` under bash, so `| sh` is the right suffix. Plugin sync guard passes.

## #24 — Timeline, first round (progress, not closed)

The report was really two problems: a five-year axis with no way to narrow it, and ~100 project lanes at 18px each with headers smeared together. This PR addresses both dimensions; the remaining item is the dot encoding for projects with enormous commit counts (a 24,526-commit lane still renders as a solid strip), which needs a different approach and is left open on #24.

- **Time axis:** wheel zooms around the cursor, vertical drag pans, year chips (plus All) jump. The full range and the on-screen window are separate now, so the scrubber, Play and the ticks follow the window automatically; a zoomed window survives a mode switch when it still fits.
- **Lanes:** a "Filter projects…" box narrows by name; lanes never drop below 100px — beyond that the plot widens and pans sideways (horizontal drag, shift+wheel). Headers stay upright and truncate to the width the lane has, full name on hover.
- **Labels stay clear of the data:** the plot is three layers — bands/grid, data clipped to the plot band, labels above with a dark halo — so a zoomed-in dot can never bury a project name or its commit count.
- **Clarity:** the milestone caption is labelled "◆ milestone ·" (a bare project name read as a stray file), and By file's subtitle says why its axis is shorter than By project's.

Includes one revert pair (`3d123da` → `a1411e0`): an attempt that anchored zoom on the playhead and changed the rotation threshold made things worse and was backed out.

## Space UI wording

The UI still said `xo-cowork-api` wherever it named the server (footer pill, offline messages, the start-from-a-shell hint). Now `xo-space`. Text only; the shell hint also went from a folder the installer never creates to the one it does.

## Validation

- `node --check` on every edited module; `py_compile` on `runtime_config.py`; plugin sync guard.
- Manually tested on a 24-project workspace: zoom, pan, year chips, lane filter, sideways panning, labels clear at any zoom.
- Cache stamps bumped for every touched module and stylesheet.

Fixes #20
Refs #24
