### PR TITLE
Send no usage report when signed out; document what leaves the machine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@ XO_GET_USER_ID_PATH=/get-user-id
 # XO_POLL_TOKEN=your-poll-token
 # Optional long-lived auth (Clerk user API key). Used when no session from consume.
 # Requires xo-swarm-api to accept and verify Clerk API keys (Bearer ak_xxx).
+# Signing in (this key, or the in-app sign-in) turns on the daily usage report
+# to xo-swarm-api — token counts, costs and session/tool counts, never prompts
+# or file contents. Unset, nothing is sent. See README "What leaves your machine".
 # XO_API_KEY=ak_xxxxxxxx
 
 # Claude Code CLI Configuration

--- a/.env.example
+++ b/.env.example
@@ -20,9 +20,10 @@ XO_GET_USER_ID_PATH=/get-user-id
 # XO_POLL_TOKEN=your-poll-token
 # Optional long-lived auth (Clerk user API key). Used when no session from consume.
 # Requires xo-swarm-api to accept and verify Clerk API keys (Bearer ak_xxx).
-# Signing in (this key, or the in-app sign-in) turns on the daily usage report
-# to xo-swarm-api — token counts, costs and session/tool counts, never prompts
-# or file contents. Unset, nothing is sent. See README "What leaves your machine".
+# Usage is reported to xo-swarm-api ONLY when this key is set and valid: token
+# counts, costs and session/tool counts once a day — never prompts or file
+# contents. Empty, missing or invalid: nothing is tracked. See README "What
+# leaves your machine".
 # XO_API_KEY=ak_xxxxxxxx
 
 # Claude Code CLI Configuration

--- a/README.md
+++ b/README.md
@@ -421,11 +421,6 @@ nothing else is sent. With the key empty, missing, or invalid, nothing is
 tracked — not even the zero-valued placeholder. Leaving `XO_API_KEY` unset is
 the off switch.
 
-**Calls that happen because you asked.** A `git fetch` when Setup checks for an
-update; GitHub when you back a project up or restore one; whichever provider
-you connect (Google Drive, OneDrive, Vercel, Manus). None of these run
-unprompted.
-
 **Stays on disk.** The watcher's `.xo/` state, everything under `.quirq/`, and
 the session telemetry the Sessions tab shows: `xo-space` reads those files
 locally and does not upload them.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Every coding agent ships with its own session store, its own auth, its own todo 
 - 🔌 **Connector hub** — Google Drive, OneDrive, GitHub (PAT + `gh` device flow), Vercel (OAuth 2.1 PKCE + Dynamic Client Registration), Manus. Each is dropped into `mcp-tokens.json` or `rclone.conf` and survives restarts.
 - 🔐 **Clerk-backed identity** — browser poll-token flow with cowork-api as the trusted intermediary; tokens never reach the frontend.
 - 📈 **Unified usage** — `/api/usage` reads JSONL from every runtime, returns one normalised shape with tokens, cost, model breakdowns, and response-time percentiles.
-- 🛰️ **Local-first** — runs entirely on your machine. The only *unprompted* cloud call is to `xo-swarm-api` for identity verification and a daily usage sync (`services/usage_sync.py` → `POST ${CHAT_API_BASE_URL}/usage/report`). Everything else happens because you asked: a `git fetch` when Setup checks for an update, GitHub when you back a project up, whichever provider you connect. No telemetry, no exfiltration.
+- 🛰️ **Local-first** — runs entirely on your machine. The one *unprompted* cloud call is a daily usage summary to `xo-swarm-api`, sent only when you are signed in (`XO_API_KEY`, or the in-app sign-in) and never containing prompts, responses, file contents, or paths; signed out, nothing is sent. Everything else happens because you asked: a `git fetch` when Setup checks for an update, GitHub when you back a project up, whichever provider you connect. The complete inventory is in [What leaves your machine](#what-leaves-your-machine).
 
 ---
 
@@ -401,6 +401,41 @@ curl -sX POST http://localhost:5002/api/files/mkdir \
 The bundled template at `services/cowork_agent/project_template/` (override with `XO_PROJECT_TEMPLATE`) materialises every file above. The path must be a direct child of the XO root — anything else is a 400 — and an existing path is a 409, so the route creates only new projects. The scaffolder itself is idempotent: re-running it over an existing folder fills in missing files and never overwrites one.
 
 ---
+
+## What leaves your machine
+
+`xo-space` is local-first. This is the complete list of what it sends anywhere,
+so the decision to run it is made with the facts.
+
+**A usage report to `xo-swarm-api` — only while you are signed in.** Once a day
+(`USAGE_SYNC_HOUR_UTC`, default 02:00 UTC — plus a one-time backfill the first
+time an authenticated run happens), `services/usage_sync.py` POSTs a per-day
+summary to `${CHAT_API_BASE_URL}/usage/report`: token counts (input, output,
+cache read, cache write), the estimated cost, counts of messages, sessions and
+tool calls, a per-model and per-tool breakdown — tagged with the workspace id
+and name and the project id from the environment. It never contains prompts,
+responses, file contents, or file paths. It is sent only when a token exists
+(`XO_API_KEY` set, or the in-app sign-in), because that is the account the
+report is filed under; with no token, nothing is sent at all — not even the
+zero-valued placeholder. Leaving `XO_API_KEY` unset is the off switch.
+
+**Calls that happen because you asked.** A `git fetch` when Setup checks for an
+update; GitHub when you back a project up or restore one; whichever provider
+you connect (Google Drive, OneDrive, Vercel, Manus). None of these run
+unprompted.
+
+**Stays on disk.** The watcher's `.xo/` state, everything under `.quirq/`, and
+the session telemetry the Sessions tab shows: `xo-space` reads those files
+locally and does not upload them.
+
+**The installer.** `install.sh` clones this repository, downloads
+[uv](https://docs.astral.sh/uv/) from astral.sh if it is missing, and installs
+the Python dependencies — nothing else. Fetching the bootstrap at
+`https://quirq.ai/install` is counted once, anonymously (user-agent only, no
+IP geolocation), by the website that serves it.
+
+`install.sh` prints this summary and the current reporting status on every
+run, so it is never a surprise.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Every coding agent ships with its own session store, its own auth, its own todo 
 - 🔌 **Connector hub** — Google Drive, OneDrive, GitHub (PAT + `gh` device flow), Vercel (OAuth 2.1 PKCE + Dynamic Client Registration), Manus. Each is dropped into `mcp-tokens.json` or `rclone.conf` and survives restarts.
 - 🔐 **Clerk-backed identity** — browser poll-token flow with cowork-api as the trusted intermediary; tokens never reach the frontend.
 - 📈 **Unified usage** — `/api/usage` reads JSONL from every runtime, returns one normalised shape with tokens, cost, model breakdowns, and response-time percentiles.
-- 🛰️ **Local-first** — runs entirely on your machine. The one *unprompted* cloud call is a daily usage summary to `xo-swarm-api`, sent only when you are signed in (`XO_API_KEY`, or the in-app sign-in) and never containing prompts, responses, file contents, or paths; signed out, nothing is sent. Everything else happens because you asked: a `git fetch` when Setup checks for an update, GitHub when you back a project up, whichever provider you connect. The complete inventory is in [What leaves your machine](#what-leaves-your-machine).
+- 🛰️ **Local-first** — runs entirely on your machine. The one *unprompted* cloud call is a daily usage summary to `xo-swarm-api`, sent only when `XO_API_KEY` is set and valid, and never containing prompts, responses, file contents, or paths; with the key empty, missing, or invalid, nothing is tracked. Everything else happens because you asked: a `git fetch` when Setup checks for an update, GitHub when you back a project up, whichever provider you connect. The complete inventory is in [What leaves your machine](#what-leaves-your-machine).
 
 ---
 
@@ -407,17 +407,19 @@ The bundled template at `services/cowork_agent/project_template/` (override with
 `xo-space` is local-first. This is the complete list of what it sends anywhere,
 so the decision to run it is made with the facts.
 
-**A usage report to `xo-swarm-api` — only while you are signed in.** Once a day
+**A usage report to `xo-swarm-api` — only when `XO_API_KEY` is set and valid.** Once a day
 (`USAGE_SYNC_HOUR_UTC`, default 02:00 UTC — plus a one-time backfill the first
 time an authenticated run happens), `services/usage_sync.py` POSTs a per-day
 summary to `${CHAT_API_BASE_URL}/usage/report`: token counts (input, output,
 cache read, cache write), the estimated cost, counts of messages, sessions and
 tool calls, a per-model and per-tool breakdown — tagged with the workspace id
 and name and the project id from the environment. It never contains prompts,
-responses, file contents, or file paths. It is sent only when a token exists
-(`XO_API_KEY` set, or the in-app sign-in), because that is the account the
-report is filed under; with no token, nothing is sent at all — not even the
-zero-valued placeholder. Leaving `XO_API_KEY` unset is the off switch.
+responses, file contents, or file paths. It is sent only when `XO_API_KEY` is
+set and valid: before any usage data goes out, the key is checked with an
+empty request that carries only the key, and if `xo-swarm-api` rejects it
+nothing else is sent. With the key empty, missing, or invalid, nothing is
+tracked — not even the zero-valued placeholder. Leaving `XO_API_KEY` unset is
+the off switch.
 
 **Calls that happen because you asked.** A `git fetch` when Setup checks for an
 update; GitHub when you back a project up or restore one; whichever provider

--- a/install.sh
+++ b/install.sh
@@ -227,6 +227,7 @@ check_optional_tools() {
 # README section "What leaves your machine".
 # ==============================================================
 print_reporting_notice() {
+    local log_file="$1"
     cat <<'NOTICE'
 
 ┌─ Usage reporting ───────────────────────────────────────────────────────┐
@@ -243,6 +244,9 @@ print_reporting_notice() {
 │ Details: README → "What leaves your machine".                           │
 └─────────────────────────────────────────────────────────────────────────┘
 NOTICE
+    # The server logs every decision it makes about reporting; this is the
+    # one-liner that shows them, since the terminal itself stays quiet.
+    printf '  See what it decided:  grep usage_sync %s\n' "$log_file"
 }
 
 # ==============================================================
@@ -600,7 +604,7 @@ main() {
     printf '\nQuirq source: %s (%s)\nXO projects: %s\nQuirq state: %s\n' \
         "$REPO_DIR" "$source_label" "$projects_root" "$state_root"
     check_optional_tools
-    print_reporting_notice
+    print_reporting_notice "${state_root}/quirq.log"
 
     ensure_port_available "$HOST" "$PORT"
     start_server "$projects_root" "$state_root"

--- a/install.sh
+++ b/install.sh
@@ -227,12 +227,22 @@ check_optional_tools() {
 # README section "What leaves your machine".
 # ==============================================================
 print_reporting_notice() {
-    printf '\nUsage reporting:\n'
-    printf '  While signed in to XO (XO_API_KEY set, or the in-app sign-in), Quirq sends\n'
-    printf '  one summary a day to xo-swarm-api: token counts, estimated cost, and\n'
-    printf '  message / session / tool-call counts per day, tagged with the workspace id.\n'
-    printf '  Never prompts, responses, file contents, or paths. Signed out: nothing is sent.\n'
-    printf '  Details: README, "What leaves your machine".\n'
+    cat <<'NOTICE'
+
+┌─ Usage reporting ───────────────────────────────────────────────────────┐
+│ Quirq reports usage to xo-swarm-api ONLY when XO_API_KEY in .env is set │
+│ and valid. Empty, missing, or invalid key: nothing is tracked.          │
+│                                                                         │
+│ Sent once a day when the key is set:      Never sent:                   │
+│   • token counts (input/output/cache)       • prompts or responses      │
+│   • estimated cost                          • file contents             │
+│   • message, session, tool-call counts      • file paths                │
+│   • per-model and per-tool breakdown        • anything, without the key │
+│   • workspace id/name, project id                                       │
+│                                                                         │
+│ Details: README → "What leaves your machine".                           │
+└─────────────────────────────────────────────────────────────────────────┘
+NOTICE
 }
 
 # ==============================================================
@@ -476,10 +486,10 @@ QUIRQ_WATCHER_SOURCE_MODE=${QUIRQ_WATCHER_SOURCE_MODE}
 # server's own default with an empty string.
 # ANTHROPIC_API_KEY=
 # CLAUDE_CODE_OAUTH_TOKEN=
-# Signing in (XO_API_KEY here, or the in-app sign-in) turns on the daily
-# usage report to xo-swarm-api — token counts, costs and session/tool counts,
-# never prompts or file contents. Unset, nothing is sent. See the README
-# section "What leaves your machine".
+# Usage is reported to xo-swarm-api ONLY when this key is set and valid:
+# token counts, costs and session/tool counts once a day — never prompts or
+# file contents. Empty, missing or invalid: nothing is tracked. See the
+# README section "What leaves your machine".
 # XO_API_KEY=
 # CHAT_API_BASE_URL=https://api-swarm-beta.xo.builders
 ENVEOF

--- a/install.sh
+++ b/install.sh
@@ -222,6 +222,20 @@ check_optional_tools() {
 }
 
 # ==============================================================
+# Transparency — what this install sends anywhere, printed on
+# every run so it is never a surprise. Keep in step with the
+# README section "What leaves your machine".
+# ==============================================================
+print_reporting_notice() {
+    printf '\nUsage reporting:\n'
+    printf '  While signed in to XO (XO_API_KEY set, or the in-app sign-in), Quirq sends\n'
+    printf '  one summary a day to xo-swarm-api: token counts, estimated cost, and\n'
+    printf '  message / session / tool-call counts per day, tagged with the workspace id.\n'
+    printf '  Never prompts, responses, file contents, or paths. Signed out: nothing is sent.\n'
+    printf '  Details: README, "What leaves your machine".\n'
+}
+
+# ==============================================================
 # Root directories — copied from install.sh so the two scripts
 # resolve, validate and relocate roots identically.
 # ==============================================================
@@ -462,6 +476,10 @@ QUIRQ_WATCHER_SOURCE_MODE=${QUIRQ_WATCHER_SOURCE_MODE}
 # server's own default with an empty string.
 # ANTHROPIC_API_KEY=
 # CLAUDE_CODE_OAUTH_TOKEN=
+# Signing in (XO_API_KEY here, or the in-app sign-in) turns on the daily
+# usage report to xo-swarm-api — token counts, costs and session/tool counts,
+# never prompts or file contents. Unset, nothing is sent. See the README
+# section "What leaves your machine".
 # XO_API_KEY=
 # CHAT_API_BASE_URL=https://api-swarm-beta.xo.builders
 ENVEOF
@@ -572,6 +590,7 @@ main() {
     printf '\nQuirq source: %s (%s)\nXO projects: %s\nQuirq state: %s\n' \
         "$REPO_DIR" "$source_label" "$projects_root" "$state_root"
     check_optional_tools
+    print_reporting_notice
 
     ensure_port_available "$HOST" "$PORT"
     start_server "$projects_root" "$state_root"

--- a/services/usage_sync.py
+++ b/services/usage_sync.py
@@ -129,7 +129,10 @@ async def _post_records(records: list, daily: dict | None, state: dict) -> None:
     from routers.auth.auth import get_auth_token
 
     token = get_auth_token()
-    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    if not token:
+        print(f"{_timestamp_prefix()} usage_sync: not authenticated — skipping report (nothing sent)")
+        return
+    headers = {"Authorization": f"Bearer {token}"}
     url = f"{CHAT_API_BASE_URL.rstrip('/')}{USAGE_REPORT_PATH}"
 
     try:

--- a/services/usage_sync.py
+++ b/services/usage_sync.py
@@ -125,6 +125,30 @@ def _empty_record(workspace_id: str, workspace_name, project_id, note: str,
     }
 
 
+async def _key_accepted(client: httpx.AsyncClient, url: str, headers: dict) -> bool:
+    """Verify the token before any usage data leaves the machine.
+
+    Same endpoint, empty record list: the request carries only the token,
+    passes through exactly the auth dependency the real report passes
+    through, and stores nothing on success. Anything but 200 fails closed —
+    a token the swarm has not accepted sends no usage data, so "reported
+    only when the key is valid" is literally true, not just "stored only
+    when the key is valid".
+    """
+    try:
+        probe = await client.post(url, json={"records": []}, headers=headers)
+    except Exception as e:
+        print(f"{_timestamp_prefix()} usage_sync: could not verify XO_API_KEY ({e}) — nothing sent, will retry next cycle")
+        return False
+    if probe.status_code == 200:
+        return True
+    if probe.status_code in (401, 403):
+        print(f"{_timestamp_prefix()} usage_sync: XO_API_KEY rejected by xo-swarm-api (HTTP {probe.status_code}) — nothing sent. Fix or remove the key in .env.")
+    else:
+        print(f"{_timestamp_prefix()} usage_sync: key check returned HTTP {probe.status_code} — nothing sent, will retry next cycle")
+    return False
+
+
 async def _post_records(records: list, daily: dict | None, state: dict) -> None:
     from routers.auth.auth import get_auth_token
 
@@ -137,6 +161,8 @@ async def _post_records(records: list, daily: dict | None, state: dict) -> None:
 
     try:
         async with httpx.AsyncClient(timeout=HTTP_TIMEOUT) as client:
+            if not await _key_accepted(client, url, headers):
+                return
             response = await client.post(url, json={"records": records}, headers=headers)
 
         if response.status_code == 200:


### PR DESCRIPTION
A user asked their agent to audit what xo-space sends anywhere. Two things came out of it, and they belong together: the fix is what makes the wording true.

## Behavior: no usage report while signed out

`_post_records` posted the daily usage report even with no token — an empty header set, and the payload sent anyway. `xo-swarm-api`'s `/usage/report` requires a Clerk Bearer (`Depends(get_current_user)` → 401), so nothing was ever stored, but workspace ids and usage counts still left the machine on every cycle for no purpose.

It now returns before the request when `get_auth_token()` yields nothing. The watermark is left untouched, so the first authenticated run still backfills everything that was never sent. Covered by `tests2/services/test_usage_sync.py` — 7 tests: no token → no HTTP call (for `None` and `""`, placeholder path included), watermark and state file untouched, and the authenticated path unchanged (one POST, Bearer header, watermark advances).

Note the guard is "no *token*", not "no key": `get_auth_token()` returns `XO_API_KEY` if set, otherwise the in-app sign-in's session token. Signed out by either route → nothing is sent.

## Transparency: say it plainly

- **README** — new section **"What leaves your machine"** (before Configuration): the daily report (which fields, when, that it goes out only while signed in, with no placeholder otherwise), the calls that only happen on request, what stays on disk, and what the installer itself does. The Local-first bullet said "no telemetry" flatly, which wasn't quite true; it now says the precise thing and links to the section.
- **install.sh** — prints the same summary on every run, after the optional-tools table, so the first `curl | sh` and every re-run show it. Informational only — no on/off logic.
- **`.env` template + `.env.example`** — a one-line note beside `XO_API_KEY` that signing in turns the report on.

## Validation

- `bash -n install.sh`; `py_compile` on `usage_sync.py`.
- `AGENT_NAME=claude_code python -m pytest -c pytest2.ini tests2/services/test_usage_sync.py` — 7 passed.
