### PR TITLE
Setup: link a runtime's install docs when it is Missing or its CLI is unavailable

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 quirq-ai
+Copyright (c) 2026 XO Labs, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/config/agents/antigravity/manifest.json
+++ b/config/agents/antigravity/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "antigravity",
   "binary": "agy",
-  "install_url": "https://antigravity.google/",
+  "install_url": "https://antigravity.google/download?os=",
   "home_dir": "~/.gemini/antigravity-cli",
   "env_file": "~/.gemini/antigravity-cli/.env",
   "config_file": "~/.gemini/antigravity-cli/settings.json",

--- a/config/agents/antigravity/manifest.json
+++ b/config/agents/antigravity/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "antigravity",
   "binary": "agy",
+  "install_url": "https://antigravity.google/",
   "home_dir": "~/.gemini/antigravity-cli",
   "env_file": "~/.gemini/antigravity-cli/.env",
   "config_file": "~/.gemini/antigravity-cli/settings.json",

--- a/config/agents/antigravity/manifest.json
+++ b/config/agents/antigravity/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "antigravity",
   "binary": "agy",
-  "install_url": "https://antigravity.google/download?os=",
+  "install_url": "https://antigravity.google/download",
   "home_dir": "~/.gemini/antigravity-cli",
   "env_file": "~/.gemini/antigravity-cli/.env",
   "config_file": "~/.gemini/antigravity-cli/settings.json",

--- a/config/agents/claude_code/manifest.json
+++ b/config/agents/claude_code/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "claude_code",
   "binary": "claude",
+  "install_url": "https://docs.claude.com/en/docs/claude-code/setup",
   "home_dir": "~/.claude",
   "env_file": "~/.claude/.env",
   "config_file": "~/.claude/settings.json",

--- a/config/agents/codex/manifest.json
+++ b/config/agents/codex/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "codex",
   "binary": "codex",
-  "install_url": "https://github.com/openai/codex#readme",
+  "install_url": "https://learn.chatgpt.com/docs/codex/cli",
   "home_dir": "~/.codex",
   "env_file": "~/.codex/.env",
   "config_file": "~/.codex/config.toml",

--- a/config/agents/codex/manifest.json
+++ b/config/agents/codex/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "codex",
   "binary": "codex",
+  "install_url": "https://github.com/openai/codex#readme",
   "home_dir": "~/.codex",
   "env_file": "~/.codex/.env",
   "config_file": "~/.codex/config.toml",

--- a/config/agents/hermes/manifest.json
+++ b/config/agents/hermes/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "hermes",
   "binary": "hermes",
+  "install_url": "https://github.com/NousResearch/hermes-agent#readme",
   "home_dir": "~/.hermes",
   "env_file": "~/.hermes/.env",
   "config_file": "~/.hermes/config.yaml",

--- a/config/agents/hermes/manifest.json
+++ b/config/agents/hermes/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "hermes",
   "binary": "hermes",
-  "install_url": "https://github.com/NousResearch/hermes-agent#readme",
+  "install_url": "https://hermes-agent.nousresearch.com/docs/getting-started/installation",
   "home_dir": "~/.hermes",
   "env_file": "~/.hermes/.env",
   "config_file": "~/.hermes/config.yaml",

--- a/config/agents/openclaw/manifest.json
+++ b/config/agents/openclaw/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "openclaw",
   "binary": "openclaw",
-  "install_url": "https://github.com/openclaw/openclaw#readme",
+  "install_url": "https://docs.openclaw.ai/install",
   "home_dir": "~/.openclaw",
   "env_file": "~/.openclaw/.env",
   "config_file": "~/.openclaw/openclaw.json",

--- a/config/agents/openclaw/manifest.json
+++ b/config/agents/openclaw/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "openclaw",
   "binary": "openclaw",
+  "install_url": "https://github.com/openclaw/openclaw#readme",
   "home_dir": "~/.openclaw",
   "env_file": "~/.openclaw/.env",
   "config_file": "~/.openclaw/openclaw.json",

--- a/services/cowork_agent/runtime_config.py
+++ b/services/cowork_agent/runtime_config.py
@@ -541,6 +541,9 @@ def runtime_sources() -> list[dict[str, Any]]:
                 "binary": manifest.binary,
                 "binary_available": shutil.which(manifest.binary) is not None,
                 "bootstrap_available": bool(setup.get("installs_cli")),
+                # Where to get the runtime, from its own manifest (core never
+                # knows an agent's URL). Absent → no link, nothing else changes.
+                "install_url": str(manifest.raw.get("install_url") or "").strip() or None,
                 "home": _path_status(manifest.home_dir, host_dir),
                 "session_files": session_files,
                 "latest_session_file": latest_session_file,

--- a/space_ui/css/secrets.css
+++ b/space_ui/css/secrets.css
@@ -111,6 +111,12 @@
 .source-fact{border:1px solid var(--line-soft);border-radius:999px;padding:4px 7px;font:500 8.5px var(--mono);letter-spacing:.05em;color:var(--ink-3)}
 .source-fact.is-good{border-color:rgba(168,217,79,.18);color:var(--accent-deep)}
 .source-fact.is-bad{border-color:rgba(200,103,76,.3);color:#e1937d}
+/* the way forward next to a Missing / CLI unavailable fact: same chip
+   shape, accent-coloured so it reads as the one actionable item */
+.source-install{border:1px solid rgba(168,217,79,.35);border-radius:999px;padding:4px 8px;
+  font:500 8.5px var(--mono);letter-spacing:.05em;color:var(--accent);text-decoration:none;
+  transition:border-color .16s var(--ease),background .16s var(--ease)}
+.source-install:hover{border-color:var(--accent);background:rgba(168,217,79,.08)}
 .source-path{display:grid;grid-template-columns:58px minmax(0,1fr);gap:8px;margin-top:5px;align-items:center}
 .source-path span{font:500 8.5px var(--mono);letter-spacing:.1em;text-transform:uppercase;color:var(--ink-4)}
 .source-path code{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font:400 10px var(--mono);color:var(--ink-3)}

--- a/space_ui/index.html
+++ b/space_ui/index.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="css/projects.css?v=20260824-treecam1">
 <link rel="stylesheet" href="css/wiki.css?v=20260725-collaboration1">
 <link rel="stylesheet" href="css/quirq.css?v=20260816-navswap1">
-<link rel="stylesheet" href="css/secrets.css?v=20260825-busycursor1">
+<link rel="stylesheet" href="css/secrets.css?v=20260825-installlink1">
 <link rel="stylesheet" href="css/preview.css?v=20260816-preview1">
 
 <div class="topbar">

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -11,9 +11,9 @@ import projectsView from './views/projects.js?v=20260825-rename1';
 import treeView from './views/tree.js?v=20260825-rename1';
 /* Chat is deliberately hidden from the tab bar: re-import ./views/chat.js
    and register it below to bring the tab back. */
-import wikiView from './views/wiki.js?v=20260825-install2';
+import wikiView from './views/wiki.js?v=20260825-installlink1';
 import quirqView from './views/quirq.js?v=20260817-plural1';
-import secretsView from './views/secrets.js?v=20260825-busycursor1';
+import secretsView from './views/secrets.js?v=20260825-installlink1';
 
 /* app-shell bulkhead: a fatal script error logs instead of white-screening */
 addEventListener('error',e=>console.error('Space shell error:',e.error||e.message));

--- a/space_ui/js/views/secrets.js
+++ b/space_ui/js/views/secrets.js
@@ -438,6 +438,13 @@ function renderSources(){
             source.binary_available?'good':'muted'
           )
           +fact(source.session_files+' session file'+(source.session_files===1?'':'s'),source.session_files?'good':'muted')
+          /* a Missing / CLI unavailable badge is a dead end without a way
+             forward: link the runtime's own install docs when the manifest
+             names them, only while something is actually absent */
+          +((!source.home?.exists||!source.binary_available)&&source.install_url
+            ?'<a class="source-install" href="'+esc(source.install_url)+'" target="_blank" rel="noopener noreferrer">'
+              +'Install '+esc(prettyName(source.name))+' &#8599;</a>'
+            :'')
         +'</div>'
         +'<div class="source-path"><span>Host</span><code>'+esc(source.home?.host_path||'not reported')+'</code></div>'
         +'<div class="source-path"><span>Container</span><code>'+esc(source.home?.container_path||'not reported')+'</code></div>'

--- a/space_ui/js/views/wiki.js
+++ b/space_ui/js/views/wiki.js
@@ -431,7 +431,7 @@ const TAB_GUIDES={
     ],
     checks:[
       ['Root not applied','Saving only queues it. Restart the server (or rerun the displayed installer) to boot on the new roots; every tab then reads the same XO root.'],
-      ['CLI unavailable','A manifest may support bootstrap, but required credentials must be present first.'],
+      ['CLI unavailable','A manifest may support bootstrap, but required credentials must be present first. When a runtime or its CLI is missing, the card links to that runtime’s own install docs.'],
       ['Sessions missing','Confirm the native runtime directory is mounted and watcher coverage includes it.'],
       ['Secret value hidden','That is intentional; replace the value or remove the variable.']
     ],

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -18,6 +18,7 @@ def _manifest(name: str, home: Path) -> SimpleNamespace:
         binary=f"{name}-bin",
         home_dir=home,
         raw={
+            "install_url": "https://example.test/install",
             "runtime_setup": {
                 "session_globs": ["sessions/**/*.jsonl"],
                 "secrets": [
@@ -210,6 +211,24 @@ class RuntimeConfigTests(unittest.TestCase):
             self.assertTrue(rows[0]["watched"])
             self.assertTrue(rows[0]["secrets"][0]["configured"])
             self.assertNotIn("redacted", repr(rows))
+            # the manifest's own install docs ride along for the Setup card
+            self.assertEqual(rows[0]["install_url"], "https://example.test/install")
+
+    def test_source_without_install_url_reports_none(self) -> None:
+        """No manifest field → no link; the card must not invent one."""
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = _manifest("bare", Path(tmp) / "runtime")
+            del manifest.raw["install_url"]
+            with (
+                patch.object(runtime_config, "all_agents", return_value=[manifest]),
+                patch.object(runtime_config, "get_active_agent", return_value=manifest),
+                patch.object(runtime_config, "load_env_entries", return_value=[]),
+                patch.object(runtime_config.shutil, "which", return_value=None),
+            ):
+                rows = runtime_config.runtime_sources()
+
+            self.assertIsNone(rows[0]["install_url"])
+            self.assertFalse(rows[0]["binary_available"])
 
     def test_applied_roots_come_from_the_shared_project_layout_helper(self) -> None:
         """Setup must report the root the rest of the app resolves, not a


### PR DESCRIPTION
## Problem

In Setup → Session sources, a runtime whose home directory isn't there shows a red **Missing** badge, and one whose CLI isn't on PATH shows **CLI unavailable**. Both were dead ends: the card named what was absent and offered no way to get it, so a first-time user had to leave the app and search.

## Change

- **Manifests** — each `config/agents/<name>/manifest.json` gains `install_url`, the runtime's own install page. That is the only place an agent's URL lives, so the broker rule holds: core never names an agent or its docs (modularity invariant test passes).
- **`runtime_sources()`** — passes `install_url` through as-is; a manifest without the field yields `null` and nothing else changes.
- **Setup card** — renders an accent **"Install <runtime> ↗"** chip beside the facts, only while the home directory or the CLI is actually missing. A healthy runtime looks exactly as before. Opens in a new tab with `noopener noreferrer`.
- **Wiki** — the "CLI unavailable" check mentions the link.

URLs:

| Runtime | `install_url` |
|---|---|
| Claude Code | https://docs.claude.com/en/docs/claude-code/setup |
| Codex | https://learn.chatgpt.com/docs/codex/cli |
| Hermes | https://hermes-agent.nousresearch.com/docs/getting-started/installation |
| OpenClaw | https://docs.openclaw.ai/install |
| Antigravity | https://antigravity.google/download |

## Also in this PR

- **LICENSE** — copyright holder corrected from `quirq-ai` (the GitHub org slug) to `XO Labs, Inc.` (the legal entity). MIT text otherwise unchanged.

## Validation

- `tests/test_runtime_config.py`: the field rides along in `runtime_sources()`, and a manifest without it reports `None` (new test).
- Modularity invariant (`tests2/contract`) passes; all five manifests parse; `node --check` on the edited modules.
- Cache stamps bumped for `secrets.js`, `wiki.js`, `secrets.css`.

Fixes #26
