### PR TITLE
README rewrite and Space wiki refresh

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -114,7 +114,7 @@ For example:
 curl -fsSL https://quirq.ai/install | PORT=8080 XO_PROJECTS_ROOT=/absolute/path sh
 ```
 
-On first run the installer writes `quirq/.env` recording exactly what it used,
+On first run the installer writes `./xo-space/.env` (the checkout's `.env`) recording exactly what it used,
 then never rewrites it — it is yours to edit. Change a value there and re-run
 `./install.sh` to apply it. Credentials are written commented out; uncomment
 the ones you need, or configure them through the Setup tab instead.
@@ -122,7 +122,7 @@ the ones you need, or configure them through the Setup tab instead.
 Precedence, highest first:
 
 1. variables exported in your shell — `PORT=8080 ./install.sh`
-2. `quirq/.env`
+2. `./xo-space/.env`
 3. the defaults above
 
 The Setup tab's `runtime.env` and `secrets.env` are loaded with `override=True`

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The checkout lands beside your projects, machine-local state goes to `./.quirq`,
 ```bash
 ./cowork-api.sh dev        # venv + reload, STAGE=local; port 5002, or 5003 if busy
 ./cowork-api.sh install    # dependencies only (venv + requirements.txt)
-./cowork-api.sh start      # daemon; PID /tmp/xo-cowork-api.pid
+./cowork-api.sh start      # daemon; PID /tmp/xo-space.pid
 ./cowork-api.sh status | logs | restart | stop
 ```
 
@@ -141,7 +141,7 @@ curl http://localhost:5002/health
 
 ### Process management
 
-Watch the installer-run server with `tail -f .quirq/quirq.log` (or `<state root>/quirq.log` if you moved the state root from Setup). The `cowork-api.sh` daemon logs to `/tmp/xo-cowork-api.log` instead. If a stray server is holding the port:
+Watch the installer-run server with `tail -f .quirq/quirq.log` (or `<state root>/quirq.log` if you moved the state root from Setup). The `cowork-api.sh` daemon logs to `/tmp/xo-space.log` instead. If a stray server is holding the port:
 
 ```bash
 lsof -i :5002   # find the PID, then kill it

--- a/README.md
+++ b/README.md
@@ -11,156 +11,111 @@
 # xo-space
 
 **The local control plane for AI coding agents.**
-One workspace, many runtimes — Claude Code, OpenClaw, Hermes, Antigravity, and whatever comes next; Codex and Cursor show up as session telemetry.
+
+One workspace, many runtimes — Claude Code, Codex, OpenClaw, Hermes, Antigravity, and whatever comes next.<br>
+Cursor shows up as session telemetry.
+
+[Website](https://xo.builders) · [Install](#quick-start) · [Works with your agent](#works-with-your-agent) · [Docs](#documentation) · [Issues](https://github.com/quirq-ai/xo-space/issues)
 
 [![Python](https://img.shields.io/badge/Python-3.12%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.109%2B-009688?style=flat-square&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/github/license/quirq-ai/xo-space?style=flat-square)](LICENSE)
-[![Wiki](https://img.shields.io/badge/docs-wiki-2C2C2C?style=flat-square&logo=github)](https://github.com/quirq-ai/xo-space/wiki)
+[![Tests](https://img.shields.io/badge/tests-100%20unittest-2C2C2C?style=flat-square)](tests/)
 
 </div>
 
 ---
 
-`xo-space` is the FastAPI service that powers an **XO Cowork workspace**: a local control plane that runs inside every workspace, brokers chat to whichever coding agent runtime you've installed (Claude Code, OpenClaw, Hermes, Antigravity), reads session telemetry from the ones that only leave files behind (Codex, Cursor), and owns the on-disk project model that travels with your work.
-
-It does **not** train models, run inference, or compete with the agents — it stitches them together, adds the boring-but-critical glue (sessions, files, secrets, OAuth flows, usage reporting), and exposes one cohesive HTTP/SSE surface — consumed first by the browser UI it ships with (`space_ui/`, served at `/space/`), then by the xo-cowork desktop app and any B2B client.
-
-```
-                  ┌────────────────────────────────────────────┐
-                  │     Space UI (/space/) · xo-cowork app      │
-                  │           or any HTTP/SSE consumer          │
-                  └──────────────────────┬─────────────────────┘
-                                         │ http://localhost:5002
-                                         ▼
-       ┌─────────────────────────────────────────────────────────────────┐
-       │                          xo-space  (FastAPI)                    │
-       │                                                                  │
-       │   /api/chat/*         /api/sessions/*       /api/files/*         │
-       │   /api/agents/*       /api/xo-projects/*    /api/secrets/*       │
-       │   /api/usage/*        /api/connectors/*     /xo-auth/*           │
-       │   /space/  (UI)       /xo/*.json  (data)    /health              │
-       │                                                                  │
-       │   ┌─────────────────────┐    ┌─────────────────────────────┐   │
-       │   │  Runtime adapters   │    │  Connector services         │   │
-       │   │   • Claude Code     │    │   • Google Drive (rclone)   │   │
-       │   │   • OpenClaw        │    │   • OneDrive (rclone)       │   │
-       │   │   • Hermes          │    │   • GitHub (PAT + gh CLI)   │   │
-       │   │   • Antigravity     │    │   • Vercel (OAuth + DCR)    │   │
-       │   │   • + plug your own │    │   • Manus (API key)         │   │
-       │   └─────────────────────┘    └─────────────────────────────┘   │
-       └─────┬─────────────────────────────────────────────┬───────────┘
-             │                                             │
-             ▼                                             ▼
-       runtimes on disk                              xo-swarm-api (cloud)
-       ~/.claude/  ~/.openclaw/  ~/.hermes/         Clerk auth + daily
-       ~/.gemini/antigravity-cli/                   usage sync
-       ~/.codex/  ~/.cursor/  (telemetry only)
-```
+- 🧠 **Pluggable runtimes** — one adapter contract, one `/api/chat/*` surface. Add a runtime by dropping a folder; no core edits.
+- 🗂️ **Sharing-safe project model** — a project is a folder; its `.xo/` holds counts, timings and ids, never chat content. `tar` it, sync it, push it.
+- 📡 **SSE streaming with sane reconnects** — `text-delta` / `done` / `heartbeat` / `agent-error`, with a 600 s reconnect window per stream.
+- 🔌 **Connector hub** — Google Drive, OneDrive, GitHub, Vercel, Manus, MagicPath; credentials survive restarts.
+- 📈 **Normalised usage** — tokens, cost, model breakdowns and response-time percentiles for the active runtime, in one shape regardless of which runtime it is.
+- 🛰️ **Local-first, no tracking by default** — runs on your machine. A self-hosted install sends nothing anywhere until you sign in with a valid `XO_API_KEY`; usage reporting exists for the managed platform at [app.xo.builders](https://app.xo.builders/), where workspaces are signed in by construction. Full inventory: [What leaves your machine](#what-leaves-your-machine).
 
 ---
+
+## If you are an agent reading this
+
+This repository is edited mostly by AI coding agents. Orientation, in order:
+
+1. Read [AGENTS.md](AGENTS.md) (the binding work contract; `CLAUDE.md` is the same rules for Claude Code) and then [DEVELOPING.md](DEVELOPING.md) (architecture, the two planes, how to add a runtime, the validation playbook).
+2. Invariants you must not break:
+   - **No core file names a specific agent.** Agent-specific code lives only in `services/cowork_agent/adapters/<name>/`, `config/agents/<name>/`, and `config/models/<name>/`. The one sanctioned literal is the `openclaw` safe-boot default in `services/cowork_agent/registry/agent_registry.py`; the frozen `/openclaw/usage/*` alias router (`routers/cowork_agent/legacy/`) is the other deliberate exception. Enforced in review — see DEVELOPING.md §6.
+   - **Routers are thin; services hold logic.** `routers/` imports `services/`; the reverse exists only as three lazy in-function imports of `routers.auth.auth` (see Contributing) — don't add a fourth.
+   - **Never write chat content, credentials, or anything that wouldn't survive a `git push` into `<XO root>/<project>/`.**
+   - **`.xo/` is watcher-owned.** `services/cowork_agent/visualizer/{sinks,workspace}/` write there, plus `visualizer/todos_store.py` for `todos.json` edits made through the API and the adapters for `sessions/sessionslist.json`; everything else reads.
+   - **Request/response contracts are frozen** unless the task explicitly changes them.
+3. The running server is the API authority: `GET /openapi.json` (the surface shifts with `AGENT_NAME`). The in-app Wiki at `/space/#/wiki` is the operating manual for the exact checkout.
 
 ---
 
 ## The workspace, in a browser
 
-The server ships its own UI at **`/space/`** — no build step, no dependencies,
-just ES modules the browser loads directly. It reads its data from the
-workspace `.xo` directory (`/xo/space.json`, `/xo/dashboard.json`,
-`/xo/sessions.json`), so what you see is what the watcher wrote.
+The server ships its own UI at **`/space/`** — no build step, no dependencies, just ES modules the browser loads directly. What you see is what the watcher wrote to the workspace `.xo` directory.
 
-**Files** is one tab with three lenses over the same workspace. The **List**
-gives every project a row — description pulled from its own README, file and
-folder counts, whether an agent is live in it right now, last activity — with
-filter and sort across the workspace.
+| Tab | What it shows |
+|---|---|
+| **Files · List** | One row per project: description from its README, file/folder counts, whether an agent is live in it now, last activity. Filter and sort across the workspace. |
+| **Files · Graph** | The same workspace as a pan/zoom node graph. |
+| **Files · Tree** | The same data as a hierarchy: workspace root on the left, one column per depth, files as leaf cards; branch thickness scales with contents. |
+| **Files · Previewer** | Click a file: markdown rendered, HTML sandboxed in an iframe (no scripts, no same-origin), everything else escaped source. Never navigates away. |
+| **Project drawer** | Open a row: browse the project folder by folder beside its todos, open sessions and recent watcher events. |
+| **Dashboard** | Each project a node inside the purpose environments it belongs to; select one and its todos orbit it. |
+| **Timeline** | The workspace as it grew: every dated artifact, or every project's git history in parallel lanes. Projects without a repo still get a lane, drawn dark. |
+| **Sessions** | Session telemetry merged from every runtime that reports it. |
+| **Setup** | The whole installation on one page: storage roots, active agent backend, watcher coverage, write-only credentials, git self-update, Quirq state view. |
+| **Wiki** | The versioned operating manual for the exact build you are running. |
 
-![The Files list: one row per project with counts, activity and descriptions](brand/screenshots/files-list.png)
+<table>
+  <tr>
+    <td width="50%"><img src="brand/screenshots/files-list.png" alt="Files list: one row per project with counts, activity and descriptions"><br><sub><b>Files · List</b> — one row per project: description from its README, file/folder counts, live agents, last activity.</sub></td>
+    <td width="50%"><img src="brand/screenshots/files-tree.png" alt="Tree lens: a horizontal tree of the workspace, thicker branches holding more"><br><sub><b>Files · Tree</b> — the same data as a hierarchy, one column per depth; branch thickness scales with contents.</sub></td>
+  </tr>
+  <tr>
+    <td><img src="brand/screenshots/dashboard-todos.png" alt="Dashboard: projects inside purpose environments, todos orbiting the selected one"><br><sub><b>Dashboard</b> — each project a node inside its purpose environment; select one and its todos orbit it.</sub></td>
+    <td><img src="brand/screenshots/timeline.png" alt="Timeline: commit history in parallel lanes, projects without git drawn dark"><br><sub><b>Timeline</b> — the workspace as it grew: dated artifacts, or every project's git history in parallel lanes.</sub></td>
+  </tr>
+  <tr>
+    <td><img src="brand/screenshots/files-drawer.png" alt="Project drawer: two-pane file explorer beside todos, sessions and events"><br><sub><b>Project drawer</b> — browse a project folder by folder beside its todos, open sessions and recent watcher events.</sub></td>
+    <td><img src="brand/screenshots/file-preview.png" alt="File previewer: rendered markdown in a side drawer over the tree"><br><sub><b>Previewer</b> — markdown rendered, HTML sandboxed (no scripts, no same-origin), everything else escaped. Never navigates away.</sub></td>
+  </tr>
+</table>
 
-Open a row and the drawer browses that project folder by folder, alongside its
-todos, open sessions and recent watcher events.
+<img src="brand/screenshots/setup.png" alt="Setup tab: storage roots, runtime, credentials and update state">
 
-![A project drawer: two-pane file explorer beside todos, sessions and events](brand/screenshots/files-drawer.png)
-
-The **Tree** lens is the same data as a hierarchy: the workspace root on the
-left, one column per level of depth, files stacked as leaf cards beside the
-branch that holds them. Branch thickness scales with what a limb contains.
-
-![The Tree lens: a horizontal tree of the workspace, thicker branches holding more](brand/screenshots/files-tree.png)
-
-Clicking a file previews it in place — markdown rendered, HTML sandboxed in an
-iframe with no scripts and no same-origin access, everything else as escaped
-source. Opening a file never navigates you away.
-
-![The file previewer: rendered markdown in a side drawer over the tree](brand/screenshots/file-preview.png)
-
-**Dashboard** collapses each project to a node inside the purpose environments
-it belongs to. Select one and its todos orbit it, in-progress work tethered to
-the node, with the same list in the detail panel.
-
-![The Dashboard: projects inside purpose environments, todos orbiting the selected one](brand/screenshots/dashboard-todos.png)
-
-**Timeline** plots the workspace as it grew — every dated artifact, or every
-project's git history in parallel lanes. Projects with no repository still get
-a lane, drawn dark, so the view never quietly disagrees with Files about what
-exists.
-
-![The Timeline: commit history in parallel lanes, projects without git drawn dark](brand/screenshots/timeline.png)
-
-**Setup** is the whole installation on one page: storage roots, the active
-agent backend, watcher coverage, write-only credentials, git self-update, and
-the Quirq state view behind its header button.
-
-![The Setup tab: storage roots, runtime, credentials and update state](brand/screenshots/setup.png)
-
-**Sessions** merges telemetry from every runtime that reports it, and **Wiki**
-is the versioned operating manual for the exact build you are running.
-
----
-
-## Why it exists
-
-Every coding agent ships with its own session store, its own auth, its own todo list, its own way of organising a workspace. The moment you want to **combine** them — or share a project, or measure usage across all of them, or just see a single chat history — you hit five incompatible filesystems and three half-baked CLIs.
-
-`xo-space` is the part of the [XO Cowork](https://xo.builders) stack that puts a uniform API in front of all of them, keeps the project folder portable and sharing-safe by construction, and gives you back something you can build a product on.
-
-- 🧠 **Pluggable runtimes** — one `BaseAgentAdapter` contract, one `/api/chat/*` surface. Claude Code, OpenClaw, Hermes, and Antigravity ship full adapters (`services/cowork_agent/adapters/<name>/adapter.py`, auto-discovered — no registry dict to edit); Codex and Cursor ship telemetry-only capability modules, so they appear in Sessions but cannot serve chat. New runtimes plug in without router changes.
-- 🗂️ **Sharing-safe project model** — chat content stays in the runtime's own storage (`~/.claude/`, `~/.openclaw/`). Every direct subdirectory of the XO root is a project, and its **directory name is its id** — nothing in `.xo/` renames it. The XO root is `XO_PROJECTS_ROOT`: the directory you ran the installer from, `~/xo-projects` otherwise, repointable from the Setup tab. The folder itself is pure metadata + work files, structurally safe to share, fork, or rebase.
-- 📡 **SSE streaming with sane reconnects** — `event: text-delta` / `done` / `heartbeat` / `agent-error`, React-Strict-Mode-safe via a 600 s reconnect window, server-side single-flight on conflicts.
-- 🔌 **Connector hub** — Google Drive, OneDrive, GitHub (PAT + `gh` device flow), Vercel (OAuth 2.1 PKCE + Dynamic Client Registration), Manus. Each is dropped into `mcp-tokens.json` or `rclone.conf` and survives restarts.
-- 🔐 **Clerk-backed identity** — browser poll-token flow with cowork-api as the trusted intermediary; tokens never reach the frontend.
-- 📈 **Unified usage** — `/api/usage` reads JSONL from every runtime, returns one normalised shape with tokens, cost, model breakdowns, and response-time percentiles.
-- 🛰️ **Local-first** — runs entirely on your machine. The one *unprompted* cloud call is a daily usage summary to `xo-swarm-api`, sent only when `XO_API_KEY` is set and valid, and never containing prompts, responses, file contents, or paths; with the key empty, missing, or invalid, nothing is tracked. Everything else happens because you asked: a `git fetch` when Setup checks for an update, GitHub when you back a project up, whichever provider you connect. The complete inventory is in [What leaves your machine](#what-leaves-your-machine).
+<sub><b>Setup</b> — the whole installation on one page: storage roots, active agent backend, watcher coverage, write-only credentials, git self-update, and the Quirq state view.</sub>
 
 ---
 
 ## Quick start
 
+**🚀 One-liner** — run it from the directory you want as your workspace:
+
 ```bash
 curl -fsSL https://quirq.ai/install | sh
 ```
 
-Run it from the directory you want as your workspace: the checkout lands
-beside your projects, machine-local state goes to `./.quirq`, and the server
-runs **in your terminal** with a quiet screen — its output appends to
-`./.quirq/quirq.log`, Ctrl-C stops it, and re-running the same command
-updates and restarts it. Closing the terminal takes the server down with
-it; for an always-on server, run the same command under `tmux` or a
-supervisor of your choice.
+The checkout lands beside your projects, machine-local state goes to `./.quirq`, and the server runs **in your terminal** with a quiet screen — output appends to `./.quirq/quirq.log`, Ctrl-C stops it, and re-running the same command updates and restarts it. Closing the terminal takes the server down; for always-on, run it under `tmux` or a supervisor.
 
-[INSTALLATION.md](INSTALLATION.md) documents the same installer in full:
-what it creates, which optional tools it looks for (`node`/`npm`, `gh`,
-`rclone`, `gpg`), the local-data layout, and every environment variable it
-honours. Docker is no longer the install path; a `./quirq` compose launcher
-still sits in the checkout (`compose.local.yml`, host port 5003) as a
-development convenience.
+**🧑‍💻 From a clone** — backend contributors use the native process manager:
 
-Then open the workspace UI — the installer prints this URL as it starts:
+```bash
+./cowork-api.sh dev        # venv + reload, STAGE=local; port 5002, or 5003 if busy
+./cowork-api.sh install    # dependencies only (venv + requirements.txt)
+./cowork-api.sh start      # daemon; PID /tmp/xo-cowork-api.pid
+./cowork-api.sh status | logs | restart | stop
+```
+
+**🐳 Compose** — a development convenience, not the install path: `./quirq` launches `compose.local.yml` on host port **5003**; stop it with `docker compose -f compose.local.yml down` (project `quirq-local`, service `api`).
+
+Then open the workspace — the installer prints this URL as it starts:
 
 ```
 http://localhost:5002/space/
 ```
 
-Or check the API directly:
+### Check the API directly
 
 ```bash
 curl http://localhost:5002/health
@@ -182,44 +137,90 @@ curl http://localhost:5002/health
 }
 ```
 
-`claude_cli` resolving to a bare `claude` instead of an absolute path means
-the CLI is not on the server's PATH — install it with
-`npm install -g @anthropic-ai/claude-code`.
+`claude_cli` resolving to a bare `claude` instead of an absolute path means the CLI is not on the server's PATH — install it with `npm install -g @anthropic-ai/claude-code`.
 
 ### Process management
 
-Ctrl-C stops the server; watch it with `tail -f .quirq/quirq.log` (or
-`<state root>/quirq.log`, if you moved the state root from the Setup tab).
-If a stray server is holding the port and you can't find its terminal:
+Watch the installer-run server with `tail -f .quirq/quirq.log` (or `<state root>/quirq.log` if you moved the state root from Setup). The `cowork-api.sh` daemon logs to `/tmp/xo-cowork-api.log` instead. If a stray server is holding the port:
 
 ```bash
 lsof -i :5002   # find the PID, then kill it
 ```
 
-(If you started the compose launcher with `./quirq`, it publishes
-`http://localhost:5003/space/`; stop it with
-`docker compose -f compose.local.yml down`. The compose project is
-`quirq-local` and the service is `api` — there is no container named
-`quirq`.)
-
-Backend contributors can still use the native process manager:
-
-```bash
-./cowork-api.sh dev        # venv + reload, STAGE=local; port 5002, or 5003 if busy
-./cowork-api.sh install    # dependencies only (venv + requirements.txt)
-./cowork-api.sh start      # daemon; PID /tmp/xo-cowork-api.pid
-./cowork-api.sh status
-./cowork-api.sh logs       # tail -f /tmp/xo-cowork-api.log
-./cowork-api.sh restart    # also the default with no argument
-./cowork-api.sh stop
-```
-
-`dev` prints the URL it settled on. Note the daemon logs to `/tmp`, not to
-the state root — `.quirq/quirq.log` belongs to the `install.sh` path.
+[INSTALLATION.md](INSTALLATION.md) documents the installer in full: what it creates, which optional tools it looks for (`node`/`npm`, `gh`, `rclone`, `gpg`), the local-data layout, and every environment variable it honours.
 
 ---
 
-## A turn, end to end
+## Works with your agent
+
+Pick the runtime with `AGENT_NAME` (the Setup tab writes it to `<Quirq root>/runtime.env`, which outranks the shell). Runtimes that ship a `session_telemetry` capability (Claude Code, Codex, Cursor) appear in Sessions regardless of which one is active.
+
+| Runtime | Status | Select | Storage root | Transport |
+|---|---|---|---|---|
+| **Claude Code** | ✅ first-class | `AGENT_NAME=claude_code` | `~/.claude/projects/<encoded>/<sid>.jsonl` | `claude` CLI subprocess, `--output-format stream-json` |
+| **OpenClaw** | ✅ first-class · safe-boot default | `AGENT_NAME=openclaw` | `~/.openclaw/agents/<a>/sessions/<sid>.jsonl` | HTTP gateway on `:18789` (OpenAI-compatible SSE) |
+| **Hermes** | ✅ first-class | `AGENT_NAME=hermes` | `~/.hermes/profiles/<name>/state.db` (`~/.hermes/state.db` for `default`) | HTTP gateway on `:8642`; one per profile, pooled on `8643+` |
+| **Antigravity** | ✅ first-class | `AGENT_NAME=antigravity` | `~/.gemini/antigravity-cli/brain/<cid>/…/transcript_full.jsonl` | `agy` CLI subprocess (`-p`, transcript-tailing) + Google OAuth, self-refreshing |
+| **Codex** | ✅ first-class | `AGENT_NAME=codex` (also `AI_PROVIDER=codex` for legacy Plane A) | `~/.codex/sessions/` rollout JSONL + auth in `~/.codex/auth.json` | `codex exec --json` subprocess; no `--session-id`, so the native thread id is learned from the first `thread.started` event and `resume`d on later turns |
+| **Cursor** | 🟡 telemetry only | — | `~/.cursor/projects/*/agent-transcripts`, `~/.cursor/chats/**/store.db` | read-only — feeds Sessions, never runs a turn |
+| **Your runtime** | 🔧 fork friendly | `AGENT_NAME=<name>` | wherever you like | drop `config/agents/<name>/manifest.json` + `adapters/<name>/adapter.py` ending in `Adapter = <YourAdapter>` — auto-discovered, zero core edits |
+
+---
+
+## Why xo-space
+
+Every coding agent ships with its own session store, its own auth, its own todo list, its own way of organising a workspace. The moment you want to **combine** them — share a project, measure usage across all of them, or just see one chat history — you hit five incompatible filesystems and three half-baked CLIs.
+
+`xo-space` is the part of the [XO Cowork](https://xo.builders) stack that puts a uniform API in front of all of them, keeps the project folder portable and sharing-safe by construction, and gives you back something you can build a product on. It does **not** train models, run inference, or compete with the agents — it stitches them together, adds the boring-but-critical glue (sessions, files, secrets, OAuth flows, usage reporting), and exposes one HTTP/SSE surface consumed by the bundled Space UI, the xo-cowork desktop app, and any B2B client.
+
+| | Each agent's own CLI | Hosted agent dashboards | **xo-space** |
+|---|:---:|:---:|:---:|
+| Runs entirely on your machine | ✅ | ❌ | ✅ |
+| One API across several runtimes | ❌ | ✅ | ✅ |
+| Chat history stays in the runtime's own store | ✅ | ❌ | ✅ |
+| Project folder safe to share / push without leaking sessions | — | — | ✅ |
+| One normalised usage/cost shape whichever runtime is active | ❌ | ✅ | ✅ |
+| Add a runtime without touching core | — | ❌ | ✅ |
+| Open source (MIT) | varies | ❌ | ✅ |
+
+---
+
+## How it works
+
+```
+                  ┌────────────────────────────────────────────┐
+                  │     Space UI (/space/) · xo-cowork app      │
+                  │           or any HTTP/SSE consumer          │
+                  └──────────────────────┬─────────────────────┘
+                                         │ http://localhost:5002
+                                         ▼
+       ┌─────────────────────────────────────────────────────────────────┐
+       │                          xo-space  (FastAPI)                    │
+       │                                                                  │
+       │   /api/chat/*         /api/sessions/*       /api/files/*         │
+       │   /api/agents/*       /api/xo-projects/*    /api/secrets/*       │
+       │   /api/usage/*        /api/connectors/*     /xo-auth/*           │
+       │   /space/  (UI)       /xo/*.json  (data)    /health              │
+       │                                                                  │
+       │   ┌─────────────────────┐    ┌─────────────────────────────┐   │
+       │   │  Runtime adapters   │    │  Connector services         │   │
+       │   │   • Claude Code     │    │   • Google Drive (rclone)   │   │
+       │   │   • Codex           │    │   • OneDrive (rclone)       │   │
+       │   │   • OpenClaw        │    │   • GitHub (PAT + gh CLI)   │   │
+       │   │   • Hermes          │    │   • Vercel (OAuth + DCR)    │   │
+       │   │   • Antigravity     │    │   • Manus (API key)         │   │
+       │   │   • + plug your own │    │                             │   │
+       │   └─────────────────────┘    └─────────────────────────────┘   │
+       └─────┬─────────────────────────────────────────────┬───────────┘
+             │                                             │
+             ▼                                             ▼
+       runtimes on disk                              xo-swarm-api (cloud)
+       ~/.claude/  ~/.codex/  ~/.openclaw/          Clerk auth + daily
+       ~/.hermes/  ~/.gemini/antigravity-cli/       usage sync
+       ~/.cursor/  (telemetry only)
+```
+
+### A turn, end to end
 
 Every chat turn is two HTTP calls:
 
@@ -251,54 +252,62 @@ event: done
 data: {"finish_reason":"stop","session_id":"9d4e..."}
 ```
 
-Other events on the same stream: `model-loading` (long tool runs),
-`agent-error`, and `error` when a reconnect finds no such stream. The `id:`
-field is what a client replays with `Last-Event-ID`.
+Other events on the same stream: `model-loading` (long tool runs), `agent-error`, and `error` when a reconnect finds no such stream. Heartbeats fire every 20 s. A stream stays addressable for 600 s after it starts (`_RECENTLY_STARTED_TTL`, React-Strict-Mode-safe); a reconnect inside that window does not replay missed `text-delta`s — it waits up to 300 s for the turn to finish and re-emits `session-created` + `done`, and the client refetches the transcript from `/api/messages/{session_id}`. The full event vocabulary lives in `routers/cowork_agent/chat.py`.
 
-Full event vocabulary, reconnect semantics, and TypeScript example: see the [Frontend Chat API guide](https://github.com/quirq-ai/xo-space/wiki/Frontend-Chat-Api).
+### Pluggable runtimes
+
+Adapters live under `services/cowork_agent/adapters/<name>/`. The dispatch class in `adapter.py` implements [`BaseAgentAdapter`](services/cowork_agent/adapters/base.py): `run`, `stream`, and the `adapter_name` property (`setup`/`health`/`load_commands` are overridable). Everything else an agent provides — usage, models, status, sessions, its own routes — is a separate **capability module** (`adapters/<name>/<cap>.py`) resolved through one seam, `adapters/loader.py`. Most capabilities resolve for the active `AGENT_NAME` only, and a missing one means the router returns its empty/501 shape rather than crashing. The exception is host-level telemetry: `session_telemetry` and `session_prompts` are collected from *every* provider that implements them (`list_capability_providers`). Today `session_telemetry` ships for Claude Code, Codex and Cursor (and `session_prompts` for the first two), which is how Space's Sessions tab shows those runtimes side by side whichever one you are chatting with; OpenClaw, Hermes and Antigravity expose sessions through the active-agent `sessions` capability instead. A telemetry-only provider (Cursor) needs no `adapter.py`.
+
+The router layer (`routers/cowork_agent/chat.py`) doesn't know which adapter it's talking to. For a request carrying a `session_id` it first asks the disk who owns that session (`find_session_backend`); an explicit `agent_name` that disagrees wins, and the session is restarted fresh under it. With no session and no explicit `agent_name` it falls back to `resolve_agent_name()` — `AGENT_NAME`, then `DEFAULT_AGENT`, then the sole manifest if only one is installed, then the `openclaw` safe-boot default. See [DEVELOPING.md](DEVELOPING.md) for the "add a new agent" walkthrough.
+
+### Identity and the cloud
+
+Identity is Clerk-backed: a browser poll-token flow with cowork-api as the trusted intermediary, so tokens never reach the frontend. If `XO_API_KEY` is set it is used as Bearer for every outbound call; otherwise run `/xo-auth/start` → browser → `/xo-auth/consume` (or set `XO_AUTH_SESSION_ID` + `XO_POLL_TOKEN` to consume once at startup). Signing in is optional for a self-hosted install — everything local works without it. What signing in turns on is described next.
 
 ---
 
-## Pluggable runtimes
+## What leaves your machine
 
-Adapters live under `services/cowork_agent/adapters/<name>/`. The dispatch class in `adapter.py` implements [`BaseAgentAdapter`](services/cowork_agent/adapters/base.py): `run`, `stream`, and the `adapter_name` property (`setup`/`health`/`load_commands` are overridable). Everything else an agent provides — usage, models, status, sessions, its own routes — is a separate **capability module** (`adapters/<name>/<cap>.py`) resolved through one seam, `adapters/loader.py`. Most capabilities resolve for the active `AGENT_NAME` only, and a missing one means the router returns its empty/501 shape rather than crashing. The exception is host-level telemetry: `session_telemetry` and `session_prompts` are collected from *every* provider that implements them (`list_capability_providers`), which is how Space shows Codex and Cursor sessions alongside the runtime you are chatting with. A telemetry-only provider needs no `adapter.py`. See [DEVELOPING.md](DEVELOPING.md).
+`xo-space` is the same codebase whether it runs inside the managed platform at [app.xo.builders](https://app.xo.builders/) or on your own machine from this repository. The difference is what it reports:
 
-| Runtime | Status | Storage root | Transport |
-|---|---|---|---|
-| **Claude Code** | ✅ first-class | `~/.claude/projects/<encoded>/<sid>.jsonl` | `claude` CLI subprocess + `--output-format stream-json` |
-| **OpenClaw** | ✅ first-class | `~/.openclaw/agents/<a>/sessions/<sid>.jsonl` | HTTP gateway on `:18789` (OpenAI-compatible SSE) |
-| **Hermes** | ✅ first-class | `~/.hermes/profiles/<name>/state.db` (or `~/.hermes/state.db` for `default`) | HTTP gateway on `:8642` (OpenAI-compatible SSE); one gateway per profile, pooled on `8643+` |
-| **Antigravity** | ✅ first-class | `~/.gemini/antigravity-cli/brain/<cid>/…/transcript_full.jsonl` | `agy` CLI subprocess (`-p`, transcript-tailing) + Google consumer OAuth (token file, self-refreshing) |
-| **Codex** | 🟡 partial — auth, legacy chat, Space telemetry | `~/.codex/` (state DB + rollout JSONL) | `codex` CLI subprocess via the legacy `/ask_question*` plane (`AI_PROVIDER=codex`); no Plane-B adapter |
-| **Cursor** | 🟡 telemetry only | `~/.cursor/projects/*/agent-transcripts`, `~/.cursor/chats/**/store.db` | read-only — feeds the Space Sessions view, never runs a turn |
-| **Your runtime** | 🔧 fork friendly | wherever you like | drop `config/agents/<name>/manifest.json` + `adapters/<name>/adapter.py` ending in `Adapter = <YourAdapter>` — auto-discovered, zero core edits |
+| | Managed platform ([app.xo.builders](https://app.xo.builders/)) | Self-hosted / open source |
+|---|---|---|
+| Signed in | Always — the workspace is provisioned with an account | Only if **you** set a valid `XO_API_KEY` (or sign in from the app) |
+| Daily usage report | Sent | **Not sent.** Nothing is tracked, not even a zero-valued placeholder |
+| Prompts, responses, file contents, paths | Never sent | Never sent |
+| Off switch | — | Leave `XO_API_KEY` unset / stay signed out |
 
-The router layer (`routers/cowork_agent/chat.py`) doesn't know which adapter it's talking to. For a request carrying a `session_id` it first asks the disk who owns that session (`find_session_backend`); an explicit `agent_name` that disagrees wins, and the session is restarted fresh under it. With no session and no explicit `agent_name` it falls back to `resolve_agent_name()` — `AGENT_NAME`, then `DEFAULT_AGENT`, then the `openclaw` safe-boot default. Adapters are **auto-discovered** — adding a runtime is dropping a folder, no registry edit and no core changes.
+**The usage report, when you are signed in.** Once a day (`USAGE_SYNC_HOUR_UTC`, default 02:00 UTC, plus a one-time backfill on the first authenticated run), `services/usage_sync.py` POSTs a per-day summary to `${CHAT_API_BASE_URL}/usage/report`: token counts (input, output, cache read, cache write), estimated cost, counts of messages, sessions and tool calls, a per-model and per-tool breakdown — tagged with the workspace id and name and the project id from the environment. It never contains prompts, responses, file contents, or file paths. Before any usage data goes out, the key is checked with an empty request that carries only the key; if `xo-swarm-api` rejects it, nothing else is sent. `install.sh` prints the current reporting status on every run, and `usage_sync` logs what it decided.
 
-Deep dive: [Claude Code vs OpenClaw](https://github.com/quirq-ai/xo-space/wiki/Claude-Vs-Openclaw), [Streaming protocols compared](https://github.com/quirq-ai/xo-space/wiki/Streaming-Claude-Vs-Openclaw).
+**Everything else happens because you asked.** A `git fetch` when Setup checks for an update, GitHub when you back a project up, whichever connector you connect, whichever agent runtime you chat with (those have their own network behaviour and their own accounts).
+
+**Stays on disk.** The watcher's `.xo/` state, everything under `.quirq/`, and the session telemetry the Sessions tab shows: `xo-space` reads those files locally and does not upload them.
+
+**The installer.** `install.sh` clones this repository, downloads [uv](https://docs.astral.sh/uv/) from astral.sh if it is missing, and installs the Python dependencies — nothing else. Fetching the bootstrap at `https://quirq.ai/install` is counted once, anonymously (user-agent only, no IP geolocation), by the website that serves it.
 
 ---
 
 ## API surface at a glance
 
-About 160 paths / 177 operations under the default `claude_code` runtime. 155 of those paths are agent-independent; the rest are contributed by the active adapter's `routes.py`, so the exact surface shifts with `AGENT_NAME` (openclaw 158, antigravity 157, hermes 182 paths). `GET /openapi.json` on a running server is always the authority. Every guide below is a full integration spec — request schemas, response shapes for every status code, edge cases, TypeScript examples.
+164 paths / 185 operations under `AGENT_NAME=claude_code` (measured 2026-08-26 from `app.openapi()`). 161 of those paths are agent-independent; the rest come from the active adapter's `routes.py`, so the surface shifts with `AGENT_NAME` — claude_code adds `/api/remote-control/*` (164), openclaw adds `/api/config/openclaw`, `/api/channels/openclaw/status`, `/api/codex/status` (164), antigravity adds `/connect/antigravity{,/callback}` (163), hermes adds 27 paths (188). The frozen legacy alias `/openclaw/usage/*` is mounted under every runtime. `GET /openapi.json` on a running server is always the authority; `/docs` (Swagger UI) and `/redoc` render it.
 
-| Family | Routes | Wiki guide |
-|---|---|---|
-| **Chat** | `/api/chat/{prompt,stream/{stream_id},abort,respond,active}` + legacy `/ask_question`, `/ask_question_streaming` | [Chat API](https://github.com/quirq-ai/xo-space/wiki/Frontend-Chat-Api) |
-| **Files** | `/api/files/{upload,list-directory,content,content-binary,save,mkdir}` | [Files API](https://github.com/quirq-ai/xo-space/wiki/Frontend-Files-Api) |
-| **Sessions** | `/api/sessions/*`, `/api/messages/{id}` | [Sessions & messages](https://github.com/quirq-ai/xo-space/wiki/Frontend-Sessions-Messages-Api) |
-| **Agents** | `/api/agents/*`, `/api/models`, `/api/config/*` | [Agents & config](https://github.com/quirq-ai/xo-space/wiki/Frontend-Agents-Config-Api) |
-| **Auth** | `/xo-auth/*`, `/connect/claude-code{,/callback}`, `/connect/codex`, `/callback`, `/.well-known/oauth-protected-resource` (+ `/connect/antigravity{,/callback}` only under `AGENT_NAME=antigravity`) | [Auth & setup](https://github.com/quirq-ai/xo-space/wiki/Frontend-Auth-Api) |
-| **Connectors** | `/api/connectors/{gdrive,onedrive,github,vercel,manus}/*` | [Connectors](https://github.com/quirq-ai/xo-space/wiki/Frontend-Connectors-Api) |
-| **Secrets & misc** | `/api/secrets/*`, `/api/usage`, `/api/onboarding/*`, `/api/channels/add` | [Misc](https://github.com/quirq-ai/xo-space/wiki/Frontend-Misc-Api) |
-| **Server** | `/health`, `/sessions`, `/gateway/restart`, `/app/{restart,update}`, `/space/server/{status,stop}`, `/space/update/{status,apply}`, `/{models,providers,channels}/status` | [Server & lifecycle](https://github.com/quirq-ai/xo-space/wiki/Frontend-Server-Api) |
-| **xo-projects** | `/api/xo-projects`, `/api/xo-projects/{activity,timeline,usage/*}`, `/api/xo-projects/{id}/{tree,file,todos,timeline,activity,usage/*}` | in-app Wiki → Files / Timeline tabs |
-| **Project sync** | `/api/xo-projects-sync/{setup,status,all,all/restore,projects,projects/{id},projects/{id}/restore}` | in-app Wiki → Collaborative version history |
-| **Space data** | `/xo/{space,dashboard,sessions}.json`, `/space/data/session_prompts.json?agent=&sid=` | in-app Wiki → Storage & data map |
-| **Workspace** | `/api/workspace-memory/*`, `/api/runtime-config{,/roots,/restart}`, `/api/fts/index/{workspace}`, `/api/{skills,tools,automations,quirq}`, `/api/{mcp,plugins,ollama}/status` | [Misc](https://github.com/quirq-ai/xo-space/wiki/Frontend-Misc-Api) |
+| Family | Routes |
+|---|---|
+| **Chat** | `/api/chat/{prompt,stream/{stream_id},abort,respond,active}` + legacy `/ask_question`, `/ask_question_streaming` |
+| **Files** | `/api/files/{upload,list-directory,content,content-binary,save,mkdir}` |
+| **Sessions** | `/api/sessions/*`, `/api/messages/{id}` |
+| **Agents** | `/api/agents/*`, `/api/models`, `/api/config/*` |
+| **Auth** | `/xo-auth/*`, `/connect/claude-code{,/callback}`, `/connect/codex`, `/callback`, `/.well-known/oauth-protected-resource` (+ `/connect/antigravity{,/callback}` only under `AGENT_NAME=antigravity`) |
+| **Connectors** | `/api/connectors` (list), `/api/connectors/{gdrive,onedrive,github,vercel,manus,magicpath}/*` |
+| **Secrets & misc** | `/api/secrets/*`, `/api/usage/{analytics,summary,summary/card,sessions,sessions/{id}}`, `/api/onboarding/*`, `/api/channels{,/add}`, `/api/skills/{catalog,install}` |
+| **Server** | `/`, `/health`, `/sessions`, `DELETE /sessions/{project_id}`, `/debug/ai-auth`, `/gateway/restart`, `/app/{restart,update}`, `/space/server/{status,stop}`, `/space/update/{status,apply}`, `/{models,providers,channels}/status` |
+| **xo-projects** | `/api/xo-projects`, `/api/xo-projects/{activity,timeline,usage/*}`, `/api/xo-projects/{id}/{tree,file,todos,todos/{todo_id},timeline,activity,usage/*}` |
+| **Project sync** | `/api/xo-projects-sync/{setup,status,all,all/restore,projects,projects/{id},projects/{id}/restore}` |
+| **Space data** | `/xo/{space,dashboard,sessions}.json`, `/space/data/session_prompts.json?agent=&sid=` |
+| **Workspace** | `/api/workspace-memory/*`, `/api/runtime-config{,/roots,/restart}`, `/api/fts/index/{workspace}`, `/api/{tools,automations,quirq}`, `/api/{mcp,plugins,ollama}/status` |
+| **Legacy aliases** | `/openclaw/usage/*` (frozen, every runtime); hidden from the schema: `/claude/setup-token{,/callback}`, `/codex/setup` |
 
-📚 **Full wiki:** [github.com/quirq-ai/xo-space/wiki](https://github.com/quirq-ai/xo-space/wiki)
+The in-app Wiki at `http://localhost:5002/space/#/wiki` covers the storage map, watcher internals, the `.xo`/`.quirq` data catalogs and one section per tab; per-route request/response shapes come from `/docs`.
 
 ---
 
@@ -311,18 +320,19 @@ About 160 paths / 177 operations under the default `claude_code` runtime. 155 of
 | **GitHub** | Personal Access Token paste **or** `gh auth login --web` device flow | `mcp-tokens.json` |
 | **Vercel** | API token paste **or** OAuth 2.1 PKCE (Dynamic Client Registration on first use) | `mcp-tokens.json` |
 | **Manus** | API key paste | `mcp-tokens.json` |
+| **MagicPath** | `POST .../setup` installs the `magicpath` agent skill (`npx skills add -g`) + `magicpath-ai` CLI; `POST .../login` returns the browser URL, then exchanges the pasted code via `magicpath-ai login --code`; `.../logout`, `.../status` | `~/.magicpath/session.json`, written and deleted by the CLI only — the server never reads or stores it |
 
-The three token connectors (GitHub, Vercel, Manus) share one shape: `POST /api/connectors/{svc}/token`, `GET .../status`, `POST .../disconnect`, `POST .../reconnect`. The two rclone connectors (Drive, OneDrive) are remote-scoped instead — `GET|POST /api/connectors/{svc}/remotes`, `DELETE .../remotes/{name}`, and an OAuth session trio: `GET .../sessions/{id}` to poll, `POST .../sessions/{id}/submit` to paste the code, `POST .../sessions/{id}/cancel`. Per-service extras: `/oauth/{start,exchange}` for Vercel, which also owns the top-level `GET /callback` and `GET|OPTIONS /.well-known/oauth-protected-resource`; `/cli/{start,poll,cancel}` for the GitHub device flow. Drive alone adds folder management (`POST .../remotes/{name}/mkdir`, `GET .../remotes/{name}/folders`, `POST .../remotes/{name}/rmdir`) and `POST .../remotes/{name}/upload`, which pipes the request body straight into rclone — no disk spool, no RAM buffer — up to a 500 MiB cap.
+The three token connectors (GitHub, Vercel, Manus) share one shape: `POST /api/connectors/{svc}/token`, `GET .../status`, `POST .../disconnect`, `POST .../reconnect`. The two rclone connectors (Drive, OneDrive) are remote-scoped instead — `GET|POST /api/connectors/{svc}/remotes`, `DELETE .../remotes/{name}`, and an OAuth session trio: `GET .../sessions/{id}` to poll, `POST .../sessions/{id}/submit` to paste the code, `POST .../sessions/{id}/cancel`. Per-service extras: `/oauth/{start,exchange}` for Vercel, which owns `GET|OPTIONS /.well-known/oauth-protected-resource`; the top-level `GET /callback` is a dispatcher in the MagicPath router (mounted before Vercel's on purpose) that claims code-only JWT redirects and delegates everything carrying a PKCE `state` to Vercel's handler unchanged; `/cli/{start,poll,cancel}` for the GitHub device flow. Drive alone adds folder management (`POST .../remotes/{name}/mkdir`, `GET .../remotes/{name}/folders`, `POST .../remotes/{name}/rmdir`) and `POST .../remotes/{name}/upload`, which pipes the request body straight into rclone — no disk spool, no RAM buffer — up to a 500 MiB cap.
 
 A `:53682`-shared single-flight lock between Drive and OneDrive prevents concurrent rclone OAuth flows from colliding on the callback port (`RCLONE_OAUTH_PORT` to move it).
 
-Both credential files live in the checkout root, gitignored, not under the Quirq state root: `rclone.conf` (override with `RCLONE_CONFIG`) and `mcp-tokens.json`, which `services/cowork_agent/connectors/token_store.py` solely owns. Vercel's OAuth client is registered dynamically (RFC 7591) on first use and cached there too. See the [Connectors guide](https://github.com/quirq-ai/xo-space/wiki/Frontend-Connectors-Api).
+Both credential files live in the checkout root, gitignored, not under the Quirq state root: `rclone.conf` (override with `RCLONE_CONFIG`) and `mcp-tokens.json`, which `services/cowork_agent/connectors/token_store.py` solely owns. Vercel's OAuth client is registered dynamically (RFC 7591) on first use and cached there too.
 
 ---
 
 ## The xo-projects model
 
-Every shared project is a folder directly under the **XO root** — `XO_PROJECTS_ROOT`, default `~/xo-projects`, movable from Setup — with a canonical layout. **The directory name is the project id.** `.xo/project.json` is read for descriptive fields only, so renaming a folder renames the project and a stale `name` left inside it never wins (`services/cowork_agent/project_layout.py:260`):
+Every shared project is a folder directly under the **XO root** — `XO_PROJECTS_ROOT`, default `~/xo-projects` (or the directory you ran the installer from), movable from Setup — with a canonical layout. The installer defaults both roots to where you ran it: XO root = that directory, Quirq root = `./.quirq` inside it — the one nesting the code allows. **The directory name is the project id.** `.xo/project.json` is read for descriptive fields only, so renaming a folder renames the project and a stale `name` left inside it never wins (`list_projects` in `services/cowork_agent/project_layout.py`):
 
 ```
 <XO root>/                              ← XO_PROJECTS_ROOT, default ~/xo-projects
@@ -335,7 +345,7 @@ Every shared project is a folder directly under the **XO root** — `XO_PROJECTS
 │   ├── PROGRESS.md                     ← running narrative
 │   ├── memory/                         ← semantic / episodic / procedural / working
 │   └── .xo/                            ← metadata-only — safe to share
-│       ├── project.json                ← id, display name, description, created_at
+│       ├── project.json                ← schema, pid, name, owner_user_id, created_at (watcher-written)
 │       ├── sessions/
 │       │   ├── sessionslist.json       ← sessionId ↔ runtime, NO message content
 │       │   └── sessions-augment.json   ← message/tool/task counts, timings, usage
@@ -353,21 +363,13 @@ Every shared project is a folder directly under the **XO root** — `XO_PROJECTS
     └── xo.json                         ← capability manifest the UI reads to decide what to show
 ```
 
-Every file above is watcher-owned. Per-project files come from one sink each (`services/cowork_agent/visualizer/sinks/`); the workspace tier comes from the rollups in `visualizer/workspace/`, where `views.py` rebuilds `space.json`, `dashboard.json` and `sessions.json` at most every `XO_VIEWS_REFRESH_S` (30s) and `routers/xo_data.py` serves them one-for-one at `GET /xo/{space,dashboard,sessions}.json` — the URL mirrors the path, nothing is generated per request. Agents never write to `.xo/` themselves.
+Every file above is watcher-owned except `sessions/sessionslist.json`, which the active adapter writes. The other per-project files come from one sink each (`services/cowork_agent/visualizer/sinks/`); the workspace tier comes from the rollups in `visualizer/workspace/`, where `views.py` rebuilds `space.json`, `dashboard.json` and `sessions.json` at most every `XO_VIEWS_REFRESH_S` (30s) and `routers/xo_data.py` serves them one-for-one at `GET /xo/{space,dashboard,sessions}.json` — the URL mirrors the path; a request only triggers a rebuild if the file is missing, empty, or older than `XO_VIEW_MAX_AGE_S` (120 s). Agents never write to `.xo/` themselves.
 
 **The structural confidentiality guarantee:** no code path writes chat content into the XO root — not into a project's `.xo/`, not into the workspace tier. Conversations stay in the runtime's own store (`~/.claude/projects/`, `~/.openclaw/agents/`, `~/.codex/sessions/`, `~/.hermes/state.db`, Cursor's store) and the derived telemetry DB `~/.argus/argus.db`, none of which leaves the machine. What lands in `.xo/` is counts, timings, ids, tokens and cost. Prompt text is only ever served live, by `GET /space/data/session_prompts.json`, which reads the runtime per request and caches in memory. A project folder can be `tar`'d, sync'd, or pushed to git without leaking session history or credentials.
 
-Live presence is intentionally machine-local rather than project metadata:
-the watcher writes per-project snapshots under
-`~/.quirq/watcher/activity/projects/<id>.json`, unions them into
-`~/.quirq/watcher/activity/workspace.json`, and exposes both through
-`GET /api/xo-projects/{id}/activity` and `GET /api/xo-projects/activity`.
-An `.xo/activity.json` inside a project is a legacy file from an older
-watcher; nothing writes it any more.
+Live presence is intentionally machine-local rather than project metadata: the watcher writes per-project snapshots under `~/.quirq/watcher/activity/projects/<id>.json`, unions them into `~/.quirq/watcher/activity/workspace.json`, and exposes both through `GET /api/xo-projects/{id}/activity` and `GET /api/xo-projects/activity`. An `.xo/activity.json` inside a project is a legacy file from an older watcher; nothing writes it any more.
 
-Machine-local Quirq installation state lives under the **Quirq root** —
-`QUIRQ_STATE_ROOT`, default `~/.quirq`, and deliberately a separate,
-non-nested directory from the XO root:
+Machine-local Quirq installation state lives under the **Quirq root** — `QUIRQ_STATE_ROOT`, default `~/.quirq`, and deliberately a separate, non-nested directory from the XO root:
 
 ```
 ~/.quirq/
@@ -381,12 +383,7 @@ non-nested directory from the XO root:
     └── activity/       live presence — projects/<id>.json + workspace.json
 ```
 
-Runtime settings are read at process start, so changing one yields an honest
-`restart_required` rather than a pretend live reload. The local Docker watcher
-can combine every mounted runtime source (`QUIRQ_WATCHER_SOURCE_MODE=all`)
-while keeping one selected backend for new chats. Existing `~/.xo-cowork/`
-onboarding/cursor files are accepted as a read-only migration source, but
-every new write targets the Quirq root.
+Runtime settings are read at process start, so changing one yields an honest `restart_required` rather than a pretend live reload. The local Docker watcher can combine every mounted runtime source (`QUIRQ_WATCHER_SOURCE_MODE=all`) while keeping one selected backend for new chats. Existing `~/.xo-cowork/` onboarding/cursor files are accepted as a read-only migration source, but every new write targets the Quirq root.
 
 Create a project with the scaffolding endpoint:
 
@@ -398,41 +395,9 @@ curl -sX POST http://localhost:5002/api/files/mkdir \
   -d "{\"path\":\"${PROJECTS_ROOT}/blackhole\",\"scaffold\":true,\"display_name\":\"Blackhole\",\"description\":\"Internal research\"}"
 ```
 
-The bundled template at `services/cowork_agent/project_template/` (override with `XO_PROJECT_TEMPLATE`) materialises every file above. The path must be a direct child of the XO root — anything else is a 400 — and an existing path is a 409, so the route creates only new projects. The scaffolder itself is idempotent: re-running it over an existing folder fills in missing files and never overwrites one.
+The bundled template at `services/cowork_agent/project_template/` (override with `XO_PROJECT_TEMPLATE`) materialises the markdown files, `memory/`, and the empty `.xo/` skeleton (`project.json`, `todos.json`, `stats.json`, `sync.json`, `peers.json`, `timeline.jsonl`, `sessions/sessionslist.json`); `sessions-augment.json` appears on the first watcher tick. The path must be a direct child of the XO root — anything else is a 400 — and inside your home directory (403 otherwise), and an existing path is a 409, so the route creates only new projects. The scaffolder itself is idempotent: re-running it over an existing folder fills in missing files and never overwrites one.
 
 ---
-
-## What leaves your machine
-
-`xo-space` is local-first. This is the complete list of what it sends anywhere,
-so the decision to run it is made with the facts.
-
-**A usage report to `xo-swarm-api` — only when `XO_API_KEY` is set and valid.** Once a day
-(`USAGE_SYNC_HOUR_UTC`, default 02:00 UTC — plus a one-time backfill the first
-time an authenticated run happens), `services/usage_sync.py` POSTs a per-day
-summary to `${CHAT_API_BASE_URL}/usage/report`: token counts (input, output,
-cache read, cache write), the estimated cost, counts of messages, sessions and
-tool calls, a per-model and per-tool breakdown — tagged with the workspace id
-and name and the project id from the environment. It never contains prompts,
-responses, file contents, or file paths. It is sent only when `XO_API_KEY` is
-set and valid: before any usage data goes out, the key is checked with an
-empty request that carries only the key, and if `xo-swarm-api` rejects it
-nothing else is sent. With the key empty, missing, or invalid, nothing is
-tracked — not even the zero-valued placeholder. Leaving `XO_API_KEY` unset is
-the off switch.
-
-**Stays on disk.** The watcher's `.xo/` state, everything under `.quirq/`, and
-the session telemetry the Sessions tab shows: `xo-space` reads those files
-locally and does not upload them.
-
-**The installer.** `install.sh` clones this repository, downloads
-[uv](https://docs.astral.sh/uv/) from astral.sh if it is missing, and installs
-the Python dependencies — nothing else. Fetching the bootstrap at
-`https://quirq.ai/install` is counted once, anonymously (user-agent only, no
-IP geolocation), by the website that serves it.
-
-`install.sh` prints this summary and the current reporting status on every
-run, so it is never a surprise.
 
 ## Configuration
 
@@ -443,49 +408,15 @@ run, so it is never a surprise.
 | `HOST`, `PORT` | Bind address. Under `STAGE=local`, 5002 falls back to 5003 if taken; `install.sh` defaults `HOST` to `127.0.0.1` | `0.0.0.0:5002` |
 | `STAGE` | `local` (dev: discover CLI via `which`) or `beta` (container: `/home/coder/...`) | `beta` |
 | `AGENT_NAME` | Active Plane-B backend: the adapter, the `config/agents/<name>/` manifest and the watcher source for every `/api/*` route. Order: `AGENT_NAME` → `DEFAULT_AGENT` → sole manifest → `openclaw` safe-boot. Setup writes it to `runtime.env`, which outranks the shell | `openclaw` |
-| `XO_PROJECTS_ROOT` | The XO root: projects, plus the workspace-tier `.xo/`. Settable from Setup, which persists it to `<Quirq root>/roots.env`; must not nest with the Quirq root | `~/xo-projects` |
-| `CLAUDE_CLI_PATH` | `claude` binary location (`CODEX_CLI_PATH` resolves identically) | `/home/coder/.local/bin/claude` on `beta`; `which claude` on `local` |
-| `CLAUDE_CODE_OAUTH_TOKEN` | Claude auth for the agent setup scripts and the CLI itself; the server never reads it | falls back to `ANTHROPIC_API_KEY` |
+| `XO_PROJECTS_ROOT` | The XO root: projects, plus the workspace-tier `.xo/`. Settable from Setup, which persists it to `<Quirq root>/roots.env`. The two roots may not nest, except for the installer's own layout of a dot-prefixed Quirq root directly inside the XO root | `~/xo-projects` (installer: the launch directory) |
+| `QUIRQ_STATE_ROOT` | The Quirq root: `state.json`, `roots.env`, `runtime.env`, `secrets.env`, `watcher/` | `~/.quirq` (installer: `<launch dir>/.quirq`) |
+| `CLAUDE_CLI_PATH` | `claude` binary location (`CODEX_CLI_PATH` uses the same resolver, with a bare `codex` as its `beta` default) | `/home/coder/.local/bin/claude` on `beta`; `which claude` on `local` |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Claude auth. The Plane-A `/ask_question` client requires it and injects it into the `claude` subprocess env; the Plane-B adapter leaves auth to the CLI. Setup scripts fall back to `ANTHROPIC_API_KEY`; the Plane-A client does not | unset |
 | `OPENCLAW_API_URL` | OpenClaw gateway endpoint | `http://127.0.0.1:18789/v1/chat/completions` |
 | `OPENCLAW_GATEWAY_TOKEN` | Bearer for the local OpenClaw gateway; must match what the gateway was started with | `xo-cowork` |
 | `CHAT_API_BASE_URL` | xo-swarm-api upstream | `https://api-swarm-beta.xo.builders` |
-| `XO_API_KEY` | Long-lived Clerk PAT (skips the consume flow) | unset |
+| `XO_API_KEY` | Long-lived Clerk PAT (skips the consume flow). Setting a valid key signs the install in and turns on the daily usage report — see [What leaves your machine](#what-leaves-your-machine) | unset (no reporting) |
 | `USAGE_SYNC_HOUR_UTC` | Hour of the daily usage sync (`USAGE_SYNC_DEBUG=true` + `USAGE_SYNC_DEBUG_INTERVAL_MINUTES` to force a faster loop) | `2` |
-
-Auth flow: if `XO_API_KEY` is set, it's used as Bearer for every outbound call. Otherwise, run the `/xo-auth/start` → browser → `/xo-auth/consume` flow (or set `XO_AUTH_SESSION_ID` + `XO_POLL_TOKEN` to consume once at startup).
-
----
-
-## Documentation
-
-In-repo:
-
-- **[DEVELOPING.md](DEVELOPING.md)** — the engineering guide: broker/adapter
-  architecture, the two planes, the capability loader, adding a new agent, the
-  modularity invariant, and the validation playbook.
-- **[INSTALLATION.md](INSTALLATION.md)** — prerequisites, the agent CLI, where
-  local data goes, running from a clone, configuration, Windows.
-- **[space_ui/README.md](space_ui/README.md)** — the Space UI: every module,
-  the view contract, and how the folder is served.
-- **[plugin/README.md](plugin/README.md)** — the Claude Code plugin
-  (`/quirq:status`, `/quirq:install`, `/quirq:start`) and its Codex twin.
-- **[AGENTS.md](AGENTS.md)** / **[CLAUDE.md](CLAUDE.md)** — the rules an agent
-  editing this repo has to follow.
-- **[docs/openclaw-usage-sync-flow.md](docs/openclaw-usage-sync-flow.md)** —
-  how OpenClaw usage reaches the daily sync.
-
-The canonical API reference is the running server: **`/docs`** (Swagger UI),
-`/redoc`, and `/openapi.json` — 158 paths / 177 operations under
-`AGENT_NAME=claude_code`, and the shape changes with the active runtime, so a
-generated page is the only page that can be right.
-
-The operating manual ships with the workspace: open the **Wiki** tab at
-`http://localhost:5002/space/#/wiki`. Fifteen sections, version-matched to the
-checkout — the storage map, watcher internals, complete `.xo` and `.quirq`
-data catalogs, one section per UI tab, and flow-building recipes.
-
-(The GitHub wiki has no pages. Any `github.com/quirq-ai/xo-space/wiki/...`
-link you find in older docs redirects to the repo home.)
 
 ---
 
@@ -497,7 +428,7 @@ xo-space/
 │                                     /ask_question (Plane A)
 ├── config/
 │   ├── models/<name>/              Plane-A model clients (claude_code/, codex/) — selected by AI_PROVIDER
-│   └── agents/<name>/              per-agent config (antigravity, claude_code, hermes, openclaw):
+│   └── agents/<name>/              per-agent config (antigravity, claude_code, codex, hermes, openclaw):
 │                                     manifest.json, settings.json, capabilities.json, setup.sh,
 │                                     plus agent.sh / troubleshoot.py where the runtime needs them
 ├── routers/                        broker routes only — no agent branching
@@ -509,8 +440,8 @@ xo-space/
 │   └── cowork_agent/               /api/* — the cowork frontend-facing surface
 │       ├── chat.py  sessions.py  agents.py  config.py  channels.py  files.py
 │       ├── secrets.py  usage.py  workspace_memory.py  fts.py  misc.py  onboarding.py
-│       ├── runtime_config.py  quirq_state.py  xo_projects_sync.py
-│       ├── connectors/            gdrive onedrive github vercel manus route modules
+│       ├── runtime_config.py  quirq_state.py  xo_projects_sync.py  skills.py
+│       ├── connectors/            gdrive onedrive github vercel manus magicpath route modules
 │       ├── bff/                   xo-projects + secrets + visualizer BFF layer
 │       └── legacy/                frozen URL aliases (openclaw_usage)
 ├── services/
@@ -520,13 +451,15 @@ xo-space/
 │   │   │   ├── loader.py          load_capability() — the single agent-resolution seam
 │   │   │   ├── cli_status.py usage_common.py   shared adapter helpers
 │   │   │   └── <name>/            adapter.py usage.py sessions.py chat.py routes.py models.py …
-│   │   │                            (codex/ and cursor/ ship telemetry capabilities only)
+│   │   │                            (cursor/ ships a telemetry capability only)
 │   │   ├── engine/                dispatcher messages sessions_io chat_state usage_loader
 │   │   ├── registry/              agent_registry adapter_registry settings agent_settings agent_env
 │   │   ├── connectors/            rclone, GitHub, Vercel, Manus, token_store glue
 │   │   ├── visualizer/            the watcher and everything it writes
 │   │   │   ├── watcher.py         lifespan-started loop (~1 s tick): sources → sinks → workspace tier
-│   │   │   ├── ingest/ sources/   jsonl tailing, event types, PII filter, per-agent source loading
+│   │   │   ├── ingest/            jsonl tailing, event types, PII filter
+│   │   │   ├── sources/ source_loader.py   source base class; per-agent source loading
+│   │   │   ├── todos_store.py     the API-side writer for <project>/.xo/todos.json
 │   │   │   ├── sinks/             per-project .xo writers: project_json stats timeline todos
 │   │   │   │                        sessions_augment activity
 │   │   │   ├── workspace/         workspace-tier writers + views.py (space/dashboard/sessions)
@@ -544,9 +477,12 @@ xo-space/
 │                                     projects, tree, sessions, wiki, secrets, quirq, chat)
 ├── plugin/  .claude-plugin/        Claude Code plugin + marketplace manifest
 ├── .agents/                        the same plugin for Codex, plus this repo's agent skills
-├── tests/                          14 unittest modules, 94 tests
+├── tests/                          14 unittest modules, 100 tests
 ├── scripts/                        install_shared_deps.sh, check_plugin_sync.sh, list_runtime_mounts.py
 ├── utils/                          commands.py, local_port.py
+├── docs/                           openclaw-usage-sync-flow.md
+├── brand/                          logo + the screenshots in this README
+├── .github/workflows/              publish-container.yml
 ├── cowork-api.sh                   process manager (start|stop|restart|status|logs)
 ├── cowork-update.sh                git pull + restart in background
 ├── quirq                           one-command Docker launcher
@@ -556,53 +492,59 @@ xo-space/
 ├── AGENTS.md  CLAUDE.md            working rules for agents editing this repo
 ├── .env.example                    every environment variable, documented
 ├── Dockerfile  compose.local.yml   container image, local service and host mounts
+├── LICENSE                         MIT
 └── requirements.txt
 ```
 
-> Per-agent lifecycle scripts now live at `config/agents/<name>/agent.sh`
-> (was root `openclaw.sh` / `hermes.sh`). See **[DEVELOPING.md](DEVELOPING.md)**
-> for the full architecture and the "add a new agent" walkthrough.
+Per-agent lifecycle scripts live at `config/agents/<name>/agent.sh` (formerly root `openclaw.sh` / `hermes.sh`).
+
+---
+
+## Documentation
+
+| Where | What |
+|---|---|
+| **In-app Wiki** — `http://localhost:5002/space/#/wiki` | The operating manual, version-matched to the checkout: fifteen sections covering the storage map, installation, watcher internals, complete `.xo` and `.quirq` data catalogs, collaboration, one section per UI tab, and flow-building recipes |
+| **`/docs` · `/redoc` · `/openapi.json`** on a running server | The canonical API reference. The shape changes with the active runtime, so a generated page is the only page that can be right |
+| [DEVELOPING.md](DEVELOPING.md) | Engineering guide: broker/adapter architecture, the two planes, the capability loader, adding a new agent, the modularity invariant, the validation playbook |
+| [INSTALLATION.md](INSTALLATION.md) | Prerequisites, the agent CLI, where local data goes, running from a clone, configuration, Windows |
+| [space_ui/README.md](space_ui/README.md) | The Space UI: every module, the view contract, how the folder is served |
+| [plugin/README.md](plugin/README.md) | The Claude Code plugin (`/quirq:status`, `/quirq:install`, `/quirq:start`) and its Codex twin |
+| [AGENTS.md](AGENTS.md) / [CLAUDE.md](CLAUDE.md) | The rules an agent editing this repo has to follow |
+| [docs/openclaw-usage-sync-flow.md](docs/openclaw-usage-sync-flow.md) | How OpenClaw usage reaches the daily sync |
+
+The GitHub wiki has no pages; the in-app Wiki is the maintained one.
 
 ---
 
 ## Contributing
 
-Issues and PRs welcome. `main` is the default branch and where work lands —
-branch from it and target it (`development` exists but has been behind since
-PR #8). The codebase is ~45k lines of Python across 228 modules plus a
-build-free ~9k-line front end in `space_ui/`. Changes that touch the adapter
-contract, the session model, the `.xo` layout, or the `/xo/*.json` views need
-their documentation in the same PR: `DEVELOPING.md` for architecture,
-`space_ui/js/views/wiki.js` for the in-app operating manual.
+Issues and PRs welcome. `main` is the default branch and where work lands — branch from it and target it. The codebase is ~45k lines of Python across 228 modules plus a build-free ~9k-line front end in `space_ui/`.
+
+| Want to… | Start at |
+|---|---|
+| Add a runtime | `config/agents/<name>/` + `services/cowork_agent/adapters/<name>/` — [DEVELOPING.md](DEVELOPING.md) walkthrough |
+| Add a connector | `routers/cowork_agent/connectors/` + `services/cowork_agent/connectors/` |
+| Change the UI | `space_ui/js/views/` — one file per view, no build step |
+| Change what `.xo/` contains | `services/cowork_agent/visualizer/{sinks,workspace}/` + its `schema/` |
+| Fix a bug | [Issues](https://github.com/quirq-ai/xo-space/issues) |
+
+Changes that touch the adapter contract, the session model, the `.xo` layout, or the `/xo/*.json` views need their documentation in the same PR: `DEVELOPING.md` for architecture, `space_ui/js/views/wiki.js` for the in-app manual.
 
 Before opening a PR:
 
 ```bash
-venv/bin/python -m unittest discover -s tests -t .        # 94 tests, ~2 s
+venv/bin/python -m unittest discover -s tests -t .        # 100 tests
 AGENT_NAME=claude_code venv/bin/python -c "import server" # import gate; repeat per agent
 ./scripts/check_plugin_sync.sh                            # if you touched plugin/ or .agents/
 ```
 
 Conventions:
 
-- **Endpoints live in `routers/`** (thin handlers). Logic lives in `services/`.
-  The dependency direction is one-way: routers import services, services do not
-  import routers. The three existing exceptions are lazy in-function imports of
-  `routers.auth.auth` for the auth state (`visualizer/sinks/activity.py`,
-  `visualizer/sinks/project_json.py`, `usage_sync.py`) — don't add a fourth.
-- **Adapters are auto-discovered.** Drop `config/agents/<name>/` +
-  `services/cowork_agent/adapters/<name>/adapter.py` — no registry edit, no
-  router changes, and **no core file may name a specific agent** (the modularity
-  invariant, enforced in review; the one sanctioned literal is the `openclaw`
-  safe-boot default in `registry/agent_registry.py`, so the server boots with no
-  env configured). See [DEVELOPING.md](DEVELOPING.md).
-- **The project folder is sacred.** Don't write chat content, runtime
-  credentials, or anything else that wouldn't survive a git push into
-  `<XO root>/<project>/`.
-- **`.xo/` belongs to the watcher.** Only
-  `services/cowork_agent/visualizer/{sinks,workspace}/` write those files;
-  everything else reads them. Anything you write there is overwritten on the
-  next tick.
+- **Endpoints live in `routers/`** (thin handlers). Logic lives in `services/`. The dependency direction is one-way: routers import services, services do not import routers. The three existing exceptions are lazy in-function imports of `routers.auth.auth` for the auth state (`visualizer/sinks/activity.py`, `visualizer/sinks/project_json.py`, `usage_sync.py`) — don't add a fourth.
+- **Adapters are auto-discovered.** Drop `config/agents/<name>/` + `services/cowork_agent/adapters/<name>/adapter.py` — no registry edit, no router changes, and **no core file may name a specific agent** (the modularity invariant, enforced in review; the one sanctioned literal is the `openclaw` safe-boot default in `registry/agent_registry.py`, so the server boots with no env configured).
+- **The project folder is sacred.** Don't write chat content, runtime credentials, or anything else that wouldn't survive a git push into `<XO root>/<project>/`.
+- **`.xo/` belongs to the watcher.** Only `services/cowork_agent/visualizer/{sinks,workspace}/` write those files; everything else reads them. Anything you write there is overwritten on the next tick.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -548,6 +548,20 @@ Conventions:
 
 ---
 
+## Contributors
+
+<div align="center">
+
+<a href="https://github.com/quirq-ai/xo-space/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=quirq-ai/xo-space" alt="Everyone who has committed to xo-space" />
+</a>
+
+<sub>Made with [contrib.rocks](https://contrib.rocks). Refreshes on its own as commits land.</sub>
+
+</div>
+
+---
+
 ## License
 
 Licensed under the [MIT License](LICENSE).

--- a/space_ui/js/views/wiki.js
+++ b/space_ui/js/views/wiki.js
@@ -199,14 +199,12 @@ const TAB_GUIDES={
       ['See overlap','A project with several purposes remains one node and sits between the applicable environments; every applicable enclosure includes it.'],
       ['Read project form','Node glyphs describe project form independently of purpose: app, one-pager, docs, slides, or unknown.'],
       ['Trace an environment','Select its labeled anchor or a project and carry that focused set into Timeline.'],
-      ['Read a project’s open work','Select a project node: its todos orbit it as satellites — in-progress items keep a spoke back to the node — and list in the detail panel in status order. Dashboard only: in Graph a leaf is a file, not a project, so the feature stays off.'],
       ['Read a project’s open work','Select a project node: its todos orbit it as satellites — in-progress items keep a spoke back to the node — and list in the detail panel in status order. Dashboard only: in Graph a leaf is a file, not a project, so the feature stays off.']
     ],
     sources:[
       ['GET /xo/dashboard.json','Serves &lt;XO root&gt;/.xo/dashboard.json — the graph collapsed into five environments, materialised by the watcher from the same single scan as space.json.','Workspace .xo file'],
       ['<XO root>/<project>/.xo/project.json','An optional manual category or saved multi-category classification takes precedence over inferred filename signals.','Portable project metadata'],
       ['Project paths and filenames','App manifests, infrastructure files, writing, research formats, decks, contracts, and asset ratios infer environment memberships and node form.','Derived heuristics'],
-      ['GET /api/xo-projects/{id}/todos','Fetched when a project node is selected; feeds the todo satellites and the panel list. Held in the browser for 20 seconds per project, so re-selecting is instant.','Live project todos'],
       ['GET /api/xo-projects/{id}/todos','Fetched when a project node is selected; feeds the todo satellites and the panel list. Held in the browser for 20 seconds per project, so re-selecting is instant.','Live project todos']
     ],
     steps:[
@@ -232,11 +230,11 @@ const TAB_GUIDES={
     kicker:'Tab guide · Workspace map and project state',
     title:'Files: one home, three lenses',
     intro:'Files is one top-level tab with three lenses behind a List | Graph | Tree pill. It lands on List: every project operationally, with a per-project drawer that browses the filesystem folder-by-folder and shows todos, open sessions, and recent events. Graph maps the same workspace as projects, clusters, artifacts, and cross-links. Tree reads the same space.json dataset as a horizontal hierarchy — folders as columns, files stacked beside their parent. All three lenses are read-only.',
-    facts:['lands on List','List | Graph | Tree lens switch','map from .xo/space.json','drawer file explorer','file previewer','portable .xo history','live .quirq presence','read-only'],
+    facts:['lands on List','List | Graph | Tree lens switch','map from .xo/space.json','List filter + sort','pan/zoom Graph and Tree','drawer file explorer','file previewer','portable .xo history','live .quirq presence','read-only'],
     jobs:[
       ['Find an artifact','In Graph, search by title, tag, project, or cluster and fly to the matching node. In Tree, expand folders and filter by name; click a file to open it in the previewer, then use the previewer’s Graph button if you want that leaf focused on the map.'],
       ['Understand relationships','Select a Graph node to inspect its neighborhood and follow parent, cluster, and cross-project ties.'],
-      ['Read the hierarchy','Use Tree when the question is “what is in there”: workspace root on the left, one column per depth, files stacked beside their folder (not one column per file).'],
+      ['Read the hierarchy','Use Tree when the question is “what is in there”: workspace root on the left, one column per depth, files stacked beside their folder (not one column per file). The pane is a canvas, not a scroller: drag to pan, wheel to zoom around the cursor, Reset view to return.'],
       ['Change perspective','Use Graph root to temporarily reorganize the layout around any node without changing the XO filesystem.'],
       ['Browse project files','In List, open a project drawer: the Files panel lists one folder at a time via GET /api/xo-projects/{id}/tree, with breadcrumbs and separate folder/file panes.'],
       ['Review active work','In the same drawer, inspect todos, current sessions, and the latest normalized timeline events.'],
@@ -253,8 +251,8 @@ const TAB_GUIDES={
     ],
     steps:[
       ['Pick a lens','Files opens in List; switch with the List | Graph | Tree pill. #/projects, #/graph, and #/tree deep-link each lens.'],
-      ['Search','Press / or use Graph’s top-right search; Tree has its own name filter in the header.'],
-      ['Focus','Click a Graph node; double-click clusters to expand or collapse. In Tree, click folders to expand columns; click a file to preview it — the tree keeps its scroll and its expansion state, and the previewer’s Graph button is the explicit way to move.'],
+      ['Search','Press / for the top-bar search (it is global, on every tab). List has its own “Filter projects…” box and sorts by Activity, Name, Files or Created; Tree has a name filter in its header.'],
+      ['Focus','Click a Graph node; double-click clusters to expand or collapse. In Tree, click folders to expand columns; click a file to preview it — the tree keeps its camera and its expansion state, and the previewer’s Graph button is the explicit way to move.'],
       ['Expand one row','In List each drawer panel loads independently, so one failed data source does not hide the others.'],
       ['Browse files','In the Files panel, use breadcrumbs and folder rows to change cwd; browsing state is remembered per project for the session.'],
       ['Follow time','Choose “Show on timeline” to carry the selected run into Timeline.']
@@ -277,11 +275,12 @@ const TAB_GUIDES={
     kicker:'Tab guide · Time and relationships',
     title:'Timeline: when work happened',
     intro:'Timeline always plots the workspace dataset (space.json); opening it from Dashboard reloads once to switch datasets. It arranges dated work into vertical columns with time flowing upward: newest at the top, oldest at the bottom. Two modes: By file plots every dated artifact, and By project plots each project’s git commit history in parallel columns.',
-    facts:['same graph dataset','By file / By project modes','parallel git histories','newest at the top','date scrubber','playback mode'],
+    facts:['same graph dataset','By file / By project modes','parallel git histories','every project gets a lane','newest at the top','wheel zoom + drag pan','year chips','lane filter','date scrubber','playback mode'],
     jobs:[
       ['Replay growth','Scrub or play through the workspace to see artifacts appear in chronological order.'],
-      ['Compare project momentum','Switch to By project to read every project’s git history in parallel: one column per project, one dot per commit day, sized by commits.'],
-      ['Trace one cluster','Open a cluster from Graph and carry its related artifacts into a focused timeline trace (a By-file tool; starting one switches the mode back).']
+      ['Compare project momentum','Switch to By project to read every project’s git history in parallel: one column per project, one dot per commit day, sized by commits. Projects without a repository keep a lane, drawn dark and captioned, so the count never disagrees with Files.'],
+      ['Narrow the window','Wheel to zoom the time axis, drag to pan it, or click a year chip to jump; “Filter projects…” hides lanes by name. Shift+wheel pans sideways once the lanes outgrow the pane.'],
+      ['Trace one cluster','Open a cluster from Graph and carry its related artifacts into a focused timeline trace (a By-file tool; starting one switches the mode back and resets any zoomed window).']
     ],
     sources:[
       ['GET /xo/space.json','Serves &lt;XO root&gt;/.xo/space.json: dated leaves, categories, milestones, relationship edges, and per-project git history (gitHistory).','Workspace .xo file'],
@@ -291,11 +290,13 @@ const TAB_GUIDES={
       ['Choose Timeline','Use the top navigation tab.'],
       ['Pick a mode','By file shows every dated artifact; By project shows each project’s daily commits in parallel columns. The choice is remembered.'],
       ['Set a date','Drag the scrubber or press Play; the sweep line moves up the page as time advances.'],
+      ['Zoom and pan','Wheel over the plot to zoom the time window around the cursor and drag to slide it; year chips above the plot jump straight to a year. Shift+wheel (or a horizontal wheel) pans across lanes when there are more than fit.'],
+      ['Filter lanes','Type in “Filter projects…” to keep only matching lanes; clear it to restore all of them.'],
       ['Inspect a point','Hover an artifact or commit dot for details; click a commit dot to open its project on Graph.']
     ],
     checks:[
       ['No dots','Dates come from git only: a dot is a file’s first-commit day. Files never committed, and projects without a repo, sit out the By file plot.'],
-      ['Fewer projects than Files lists','Expected, and stated in the subtitle: Files lists every folder under the XO root, while both Timeline modes can only plot projects that have their own git repository. A project whose repo sits in a subfolder counts as having none.'],
+      ['Dark, empty lanes','Expected, and counted in the subtitle: every folder under the XO root gets a lane, and one with no git history of its own is drawn dark with a “no git history” caption rather than dropped. A project whose repo sits in a subfolder counts as having none.'],
       ['No By project toggle','The current dataset carries no git history; the toggle appears only when at least one project has git commits of its own (a repo with no commits yet does not count, and the Dashboard projection never has history).'],
       ['Trace missing','Open the cluster from Graph first or clear the existing trace and try again.']
     ],
@@ -321,7 +322,7 @@ const TAB_GUIDES={
       ['<project>/.xo and .quirq','Per-project watcher output and machine-local control state; neither is a source for this tab. The aggregate it does read, &lt;XO root&gt;/.xo/sessions.json, is a workspace file written by the same watcher.','Separate watcher stores']
     ],
     steps:[
-      ['Choose sources','Toggle available runtimes. An unavailable badge means the native store could not be read, not that it contains zero sessions.'],
+      ['Choose sources','Toggle available runtimes. An “offline” badge means the native store could not be read, not that it contains zero sessions.'],
       ['Choose a window','Select Today, 7 days, 30 days, or All.'],
       ['Choose a lens','Use Overview, Sessions, Tools, Models, or Trends.'],
       ['Sort and select','Sort and page through session rows, then open the one that needs diagnosis.'],
@@ -479,9 +480,10 @@ function tabGuideArticle(id){
         <h2>The file previewer</h2>
         <p>Three surfaces open the same side drawer: a file row in Tree, a file
         row in the List drawer’s Files panel, and “Preview file” in Graph’s
-        detail panel. Opening a file does not navigate — the view underneath
-        keeps its lens, its scroll and its expansion state, and the drawer’s
-        Graph button is the one control that moves you.</p>
+        detail panel. Opening a file does not navigate — the lens underneath
+        keeps its camera and its expansion state, and the drawer’s Graph
+        button is the one control that moves you. The drawer belongs to Files:
+        switching to any other tab closes it.</p>
         <p>How a file renders is a security contract, not a display
         preference. Markdown goes through the escape-first renderer, which
         escapes the source before it transforms it and emits only fixed,
@@ -536,9 +538,9 @@ function storageArticle(){
       <section class="wiki-section">
         <h2>The full data path</h2>
         <div class="wiki-flow wiki-flow-five" aria-label="End-to-end data path">
-          <div><small>01</small><b>Native runtime</b><span>Full messages, runtime session records, and tool payloads stay in the runtime's own storage — Claude Code, OpenClaw, Hermes, Antigravity, Codex, or Cursor.</span></div>
+          <div><small>01</small><b>Native runtime</b><span>Full messages, runtime session records, and tool payloads stay in the runtime's own storage — Claude Code, Codex, OpenClaw, Hermes, Antigravity, or Cursor.</span></div>
           <i aria-hidden="true">→</i>
-          <div><small>02</small><b>Source adapter</b><span>Reads only new records, assigns a project, and normalizes supported observations.</span></div>
+          <div><small>02</small><b>Source adapter</b><span>Reads only new records, assigns a project, and normalizes supported observations. Cursor has no source adapter: it is telemetry-only and reaches sessions.json directly, skipping steps 02–04.</span></div>
           <i aria-hidden="true">→</i>
           <div><small>03</small><b>Watcher sinks</b><span>Reduce events into indexes, counters, todos, timelines, and live presence, and rebuild the three workspace view files.</span></div>
           <i aria-hidden="true">→</i>
@@ -658,8 +660,8 @@ function installationArticle(){
           <div><b>curl</b><p>Streams the installer into your shell, and the
           installer uses it again to fetch uv if uv is not already
           installed.</p></div>
-          <div><b>A coding runtime</b><p>Claude Code, OpenClaw, Hermes, or
-          Antigravity is needed only for chat. The API, Wiki, and project
+          <div><b>A coding runtime</b><p>Claude Code, Codex, OpenClaw, Hermes,
+          or Antigravity is needed only for chat. The API, Wiki, and project
           views start without one.</p></div>
           <div><b>Optional tools</b><p><code>node</code>/<code>npm</code>,
           <code>gh</code>, <code>rclone</code>, and <code>gpg</code> each
@@ -729,8 +731,7 @@ function installationArticle(){
             <thead><tr><th>Path</th><th>Purpose</th></tr></thead>
             <tbody>
               <tr><td>.</td><td>Your projects root; each project is a subdirectory with its own portable .xo metadata</td></tr>
-              <tr><td>./.xo</td><td>The workspace tier the watcher materialises: space.json, dashboard.json and sessions.json — the three payloads the UI reads over /xo/*.json — plus workspace.json, stats, activity and the workspace timeline</td></tr>
-              <tr><td>./.xo</td><td>The workspace tier the watcher materialises: space.json, dashboard.json and sessions.json — the three payloads the UI reads over /xo/*.json — plus workspace.json, stats, activity and the workspace timeline</td></tr>
+              <tr><td>./.xo</td><td>The workspace tier the watcher materialises: space.json, dashboard.json and sessions.json — the three payloads the UI reads over /xo/*.json — plus workspace.json, stats, the sessions/ unions and the workspace timeline. Live presence is not here: it lives under ./.quirq/watcher/activity/</td></tr>
               <tr><td>./xo-space</td><td>The Quirq source checkout the installer owns and updates</td></tr>
               <tr><td>./xo-space/venv</td><td>The Python environment</td></tr>
               <tr><td>./.quirq</td><td>Machine-local state: runtime.env and secrets.env from the Setup tab, roots.env, the server log quirq.log, and watcher/ with its offsets, locks and live-presence snapshots</td></tr>
@@ -894,8 +895,8 @@ function watcherArticle(){
           <table class="wiki-table">
             <thead><tr><th>Observation</th><th>Retained data</th><th>Destinations</th></tr></thead>
             <tbody>
-              <tr><td>SessionFirstSeen</td><td>time, runtime, native session id, project</td><td>session augment, todos session bucket, stats timing, timeline</td></tr>
-              <tr><td>MessageObserved</td><td>role and time; no message text</td><td>message counters, daily message buckets, activity timing</td></tr>
+              <tr><td>SessionFirstSeen</td><td>time, runtime, native session id, project, the runtime-reported working directory</td><td>session augment, todos session bucket, stats timing, timeline</td></tr>
+              <tr><td>MessageObserved</td><td>role, time and (for assistant turns) the model; no message text</td><td>message counters, daily message buckets, per-role session counters</td></tr>
               <tr><td>UsageObserved</td><td>input/output/cache tokens, model, optional response latency</td><td>stats, per-model rollups, in-memory presence model cache</td></tr>
               <tr><td>ToolUseObserved</td><td>tool name only; no arguments</td><td>tool call counters and per-tool analytics</td></tr>
               <tr><td>TaskCreated / changed</td><td>id, content, description, active form, status</td><td>todos, task counters, added/completed timeline events</td></tr>
@@ -912,6 +913,7 @@ function watcherArticle(){
             <thead><tr><th>Runtime</th><th>Messages</th><th>Tokens</th><th>Tools</th><th>Files</th><th>Tasks</th><th>Presence</th></tr></thead>
             <tbody>
               <tr><td>Claude Code</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>native task pairing</td><td>PID session files</td></tr>
+              <tr><td>Codex</td><td>yes</td><td>yes</td><td>name only</td><td>applied patches</td><td>not yet</td><td>not yet</td></tr>
               <tr><td>OpenClaw</td><td>yes</td><td>yes</td><td>yes</td><td>not yet</td><td>todo API</td><td>not yet</td></tr>
               <tr><td>Hermes</td><td>yes</td><td>not exposed</td><td>yes</td><td>not yet</td><td>todo API</td><td>not available</td></tr>
               <tr><td>Antigravity</td><td>yes</td><td>separate usage capability</td><td>yes</td><td>supported write tools</td><td>todo API</td><td>short-lived process</td></tr>
@@ -993,7 +995,7 @@ function xoDataArticle(){
             overwrites <code>name</code> with the directory name and drops a
             <code>display_name</code> that only echoes a stale stored name, so
             a renamed folder cannot point readers at the wrong project.</p>
-            <dl><div><dt>Used for</dt><dd>project discovery, ownership, description, and an optional <code>category</code>/<code>classification</code> override for the Dashboard</dd></div><div><dt>Lifecycle</dt><dd>one-time identity fill; <code>display_name</code> and <code>description</code> can be updated later, but the directory name is always the id</dd></div></dl>
+            <dl><div><dt>Used for</dt><dd>project discovery, ownership, and an optional <code>category</code>/<code>classification</code> override for the Dashboard. The description readers see is derived server-side from README.md, PROJECT.md or OBJECTIVES.md, not stored here</dd></div><div><dt>Lifecycle</dt><dd>one-time identity fill by the watcher, which rewrites the file to exactly the five keys above; the directory name is always the id</dd></div></dl>
           </article>
 
           <article class="wiki-file">
@@ -1161,7 +1163,7 @@ function quirqDataArticle(){
 ├── runtime.env                 # mode 0600; typed restart-time controls
 ├── roots.env                   # mode 0600; storage roots, read at server startup
 ├── quirq.log                   # server output appended by the installer's run loop
-├── secrets.env                 # mode 0600; write-only credentials from Setup
+├── secrets.env                 # mode 0600; write-only credentials from Setup (when QUIRQ_SECRETS_FILE points here — the installer does)
 └── watcher/
     ├── offsets.json
     ├── hermes-offsets.json       # only when the Hermes source is watched
@@ -1217,7 +1219,11 @@ function quirqDataArticle(){
             never reads saved plaintext back; plaintext is reachable only
             through the single-key reveal endpoint and the legacy
             /api/secrets/env route. The file is written atomically with
-            owner-only permissions and loaded when Quirq starts.</p>
+            owner-only permissions and loaded when Quirq starts. It lives
+            here only when <code>QUIRQ_SECRETS_FILE</code> says so — the
+            installer sets it to <code>&lt;state root&gt;/secrets.env</code>;
+            without that variable the store is the active runtime's own
+            <code>.env</code> in its home directory.</p>
             <dl><div><dt>Writer</dt><dd>curated secrets API</dd></div><div><dt>Delete effect</dt><dd>removes the value from disk and from new child-process environments</dd></div></dl>
           </article>
 
@@ -1830,9 +1836,10 @@ function flowsArticle(){
           <i>→</i>
           <div class="wiki-recipe-step"><small>3</small><b>The telemetry</b><code>GET /xo/sessions.json</code><p>Session totals merged across every runtime that reports them, with unavailable sources named rather than hidden.</p></div>
         </div>
-        <p>These three are files, not computations: they live at
+        <p>These three are files first: they live at
         <code>&lt;XO root&gt;/.xo/{space,dashboard,sessions}.json</code> and the
-        route hands over what the watcher wrote. Read them for anything
+        route hands over what the watcher wrote, rebuilding only when a file
+        is missing or older than <code>XO_VIEW_MAX_AGE_S</code> (120 s). Read them for anything
         workspace-wide; reach for the per-project <code>/api/*</code> endpoints
         below when you need one project’s live detail, which these files
         deliberately do not carry.</p>
@@ -1843,7 +1850,7 @@ function flowsArticle(){
         <div class="wiki-recipe">
           <div class="wiki-recipe-step"><small>1</small><b>Workspace presence</b><code>GET /api/xo-projects/activity</code><p>Get all observably open sessions with project ids.</p></div>
           <i>→</i>
-          <div class="wiki-recipe-step"><small>2</small><b>Group and label</b><p>Group by project, show runtime/model, and display the response’s update timestamp.</p></div>
+          <div class="wiki-recipe-step"><small>2</small><b>Group and label</b><p>Group by project, show the runtime and agent, and display the response’s update timestamp. Model is not on this endpoint — read it from the session detail.</p></div>
           <i>→</i>
           <div class="wiki-recipe-step"><small>3</small><b>Drill into project</b><code>GET /api/xo-projects/{id}/activity</code><p>Use the project endpoint when the selected scope changes.</p></div>
         </div>
@@ -1866,7 +1873,7 @@ function flowsArticle(){
       <section class="wiki-section">
         <h2>Flow 3 · “Which session should I inspect?”</h2>
         <div class="wiki-recipe">
-          <div class="wiki-recipe-step"><small>1</small><b>Start from the index</b><code>GET /api/xo-projects/{id}/usage/sessions</code><p>Sort by last activity and show token totals and message counts; derive the runtime from the composite key. Sort by last activity and show token totals and message counts; derive the runtime from the composite key. Task counters are on neither the index nor the session detail — the watcher's <code>taskCount</code> stops at the disk row. Fetch <code>GET /api/xo-projects/{id}/todos</code> for task state.</p></div>
+          <div class="wiki-recipe-step"><small>1</small><b>Start from the index</b><code>GET /api/xo-projects/{id}/usage/sessions</code><p>Sort by last activity and show token totals and message counts; derive the runtime from the composite key. Task counters are on neither the index nor the session detail — the watcher's <code>taskCount</code> stops at the disk row. Fetch <code>GET /api/xo-projects/{id}/todos</code> for task state.</p></div>
           <i>→</i>
           <div class="wiki-recipe-step"><small>2</small><b>Select one identity</b><p>Keep the composite key as the stable list identity; native session id is also accepted for lookup.</p></div>
           <i>→</i>

--- a/tests/test_space_wiki.py
+++ b/tests/test_space_wiki.py
@@ -349,7 +349,7 @@ class SpaceWikiTests(unittest.TestCase):
         self.assertIn("const weight=", tree)
         self.assertIn("pathLength=", tree)
         self.assertIn("is-growing", tree)
-        self.assertIn("function restoreScroll", tree)
+        self.assertIn("function restoreAnchor", tree)
         self.assertIn("anchor=", tree)
         # Wiki Files guide must stay aligned with the three-lens UI (drift here
         # is how "two lenses" docs survive after Tree ships).
@@ -516,9 +516,12 @@ class SpaceWikiTests(unittest.TestCase):
 
         self.assertIn("curl -fsSL", guide)
         self.assertIn("localhost:5002", guide)
-        # Piping to `sh` fails: the installer uses BASH_SOURCE and pipefail.
-        self.assertIn("| bash", guide)
-        self.assertNotIn("| sh\n", guide)
+        # The canonical one-liner pipes to `sh`: the short URL serves a POSIX
+        # bootstrap that runs install.sh under bash. Fetching install.sh
+        # directly still needs bash (BASH_SOURCE, pipefail), and the guide
+        # must keep saying so.
+        self.assertIn("https://quirq.ai/install | sh", guide)
+        self.assertIn("pipe it to `bash`, not `sh`", guide)
         # git went from "you do not need it" to a hard prerequisite.
         self.assertNotIn("You do not need Git", guide)
 


### PR DESCRIPTION
Two commits, docs only — no code behaviour changes.

## 1. README rewrite

The old README was accurate but read like a manual: you had to scroll through the architecture before finding out what the project is or how to install it. This version is laid out so a reader decides in the first screen and finds the detail below.

**New shape**

- Hero, one-line value props, screenshot grid, quick start — first.
- **"If you are an agent reading this"** — most readers of this repo are coding agents. This block tells them what to read first (AGENTS.md → DEVELOPING.md), the rules they must not break, and that the running server's `/openapi.json` is the API authority.
- **"Works with your agent"** — the runtime table, now with the `AGENT_NAME=…` to select each one.
- **"Why xo-space"** with a comparison table (each agent's own CLI vs. hosted dashboards vs. xo-space).
- **"What leaves your machine"** (from #28) reframed around the two ways this code runs:
  - the managed platform at **app.xo.builders** — signed in by construction, usage reported;
  - **self-hosted / open source** — nothing is sent until you sign in with a valid `XO_API_KEY` (or the in-app sign-in). No key, no tracking.
- Everything else (API surface, connectors, `.xo` model, configuration, project structure) kept, under flat headings.

**Facts corrected** (each checked against the code)

- Codex is a full chat runtime (`adapters/codex/adapter.py`), not "telemetry only" — that was true before PR #11 and never got updated.
- Only Claude Code, Codex and Cursor ship `session_telemetry`; usage is per active runtime, not aggregated across runtimes.
- There is no server-side `Last-Event-ID` replay; a reconnect re-emits `session-created` + `done` and the client refetches.
- Agent resolution order includes the sole-manifest step before the `openclaw` default.
- MagicPath connector added; `GET /callback` is now a MagicPath dispatcher that hands PKCE requests to Vercel.
- Route counts re-measured: 164 paths / 185 operations (dated in the text).
- Test count 94 → 100.
- `.xo/project.json` keys as the watcher actually writes them; `/xo/*.json` rebuild after `XO_VIEW_MAX_AGE_S`; `QUIRQ_STATE_ROOT` row; `CLAUDE_CODE_OAUTH_TOKEN` / `CODEX_CLI_PATH` behaviour; missing files added to the tree (`skills.py`, `todos_store.py`, `docs/`, `brand/`, `LICENSE`, CI workflow).
- Dropped the dead `github.com/…/wiki/…` links (the GitHub wiki has no pages) and the "development is behind since PR #8" note (both branches are level).

**INSTALLATION.md**: the installer writes `./xo-space/.env`, not `quirq/.env`.

## 2. Space wiki refresh

The in-app Wiki's Timeline and Files guides were never updated for #22, #24 and #25, so they described a UI two releases old.

- **Timeline**: wheel zoom, drag pan, year chips, lane filter; every project gets a lane and no-git projects are drawn dark instead of dropped.
- **Files**: Tree is a pan/zoom canvas, not a scroller; the top-bar search is global; List's filter and sort keys are documented; the previewer closes when you leave Files.
- **Codex** added to the prerequisites, the data-path list and the watcher coverage matrix.
- Smaller corrections: `project.json` is rewritten by the watcher to five keys (the description you see is derived from README/PROJECT/OBJECTIVES); `secrets.env` location depends on `QUIRQ_SECRETS_FILE`; the workspace activity union lives under `.quirq/watcher/activity`, not `.xo`; `/api/xo-projects/activity` has no `model`; privacy table lists `cwd` and `model`; the Sessions badge reads "offline".
- Four copy-paste duplicates removed.
- The Space Walk article is untouched — it documents an external application.

`tests/test_space_wiki.py`: two assertions updated to the names the code actually uses now (`restoreAnchor`; the `| sh` one-liner). Suite is 20/20.

## Not in this PR

Found while auditing, left for a separate change: `visualizer/sinks/project_json.py` overwrites `project.json` with a fresh five-key dict on the first watcher tick, discarding the `display_name` and `description` the scaffolder wrote. The wiki now documents current behaviour; the fix belongs with a test.
