### PR TITLE
install.sh: reuse a checkout you are standing in; print how to start again

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -20,6 +20,23 @@ Docker is not required. The command:
 
 Press Ctrl-C to stop it. Run the same command again to update and restart.
 
+## Stopping and starting again
+
+Ctrl-C stops the server; nothing supervises it, so nothing restarts it. The
+startup banner prints both ways back, from the directory you installed in:
+
+```bash
+./xo-space/install.sh                      # start again, no update
+curl -fsSL https://quirq.ai/install | sh   # update to the latest main, then start
+```
+
+Running the one-liner from *inside* `./xo-space` is fine: the installer
+notices it is standing in a checkout and uses that one, with the directory
+above as the workspace, rather than cloning a second copy into it. It also
+leaves a checkout alone when it has local changes, or when it is on a branch
+other than the one it tracks (`main`, or `QUIRQ_SOURCE_REF`), so a
+development clone is never silently reset.
+
 The short URL serves a small POSIX-sh bootstrap that downloads `install.sh`
 to a temporary file and runs it under `bash`, which is why `| sh` works. If
 you fetch `install.sh` itself, pipe it to `bash`, not `sh` — the script uses

--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,8 @@ REPO_NAME="${REPO_NAME%.git}"
 APP_DIR="${QUIRQ_APP_DIR:-${LAUNCH_DIR}/${REPO_NAME}}"
 PYTHON_VERSION="${QUIRQ_PYTHON_VERSION:-3.12}"
 UV_INSTALL_URL="https://astral.sh/uv/install.sh"
+# The canonical one-liner (INSTALLATION.md), echoed back as the update path.
+INSTALL_URL="https://quirq.ai/install"
 
 # Set by resolve_repo_dir, once we know whether we are running from a
 # checkout or have to create one.
@@ -112,6 +114,23 @@ resolve_repo_dir() {
         return
     fi
 
+    # Piped from curl while standing inside a checkout — typically someone
+    # re-running the one-liner from ./xo-space instead of from the workspace
+    # above it. Nesting a second clone in there would make this checkout the
+    # projects root and leave it permanently dirty (so it would never update
+    # again). Use it as the managed checkout and its parent as the workspace:
+    # exactly what running the same command one level up does. An explicit
+    # QUIRQ_APP_DIR still wins.
+    if [ -z "${QUIRQ_APP_DIR:-}" ] &&
+        [ -f "${LAUNCH_DIR}/server.py" ] &&
+        [ -f "${LAUNCH_DIR}/requirements.txt" ]; then
+        REPO_DIR="$LAUNCH_DIR"
+        LAUNCH_DIR="$(cd "${LAUNCH_DIR}/.." && pwd)"
+        MANAGED_CHECKOUT=1
+        printf 'Running from inside the Quirq checkout; the workspace is %s\n' "$LAUNCH_DIR"
+        return
+    fi
+
     REPO_DIR="$APP_DIR"
     MANAGED_CHECKOUT=1
 }
@@ -125,6 +144,17 @@ fetch_repo() {
         printf 'Quirq is already installed here: %s\n' "$REPO_DIR"
         if [ -n "$(git -C "$REPO_DIR" status --porcelain)" ]; then
             printf 'It has local changes — keeping them, skipping the update.\n'
+            return
+        fi
+        # A checkout on some other branch was put there on purpose (a
+        # development clone, say); resetting it to SOURCE_REF would silently
+        # move it. Managed clones are made with --branch SOURCE_REF, so they
+        # always pass this and keep updating.
+        local branch
+        branch="$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+        if [ -n "$branch" ] && [ "$branch" != "HEAD" ] && [ "$branch" != "$SOURCE_REF" ]; then
+            printf 'It is on branch %s, not %s — leaving it as is. Set QUIRQ_SOURCE_REF=%s to track that branch instead.\n' \
+                "$branch" "$SOURCE_REF" "$branch"
             return
         fi
         printf 'Updating it to the latest %s...\n' "$SOURCE_REF"
@@ -539,6 +569,27 @@ start_server() {
     printf '\n▶️  Starting Quirq: http://localhost:%s/space/\n\n' "$PORT"
     printf '    Logs:  %s\n' "$log_file"
     printf '    Press Ctrl-C to stop.\n\n'
+    print_restart_hint
+}
+
+# ==============================================================
+# How to come back. Once Ctrl-C returns the prompt there is nothing on
+# screen that says how to start again, and "run the installer command"
+# is only obvious to whoever ran it first. Printed before exec hands the
+# terminal to the server, since nothing of this script survives that.
+# ==============================================================
+print_restart_hint() {
+    local ref_prefix=""
+    [ "$SOURCE_REF" = "main" ] || ref_prefix="QUIRQ_SOURCE_REF=${SOURCE_REF} "
+
+    if [ "$MANAGED_CHECKOUT" -eq 1 ]; then
+        printf '    Start again later:  cd %s && %s/install.sh\n' "$LAUNCH_DIR" "$REPO_DIR"
+        printf '    Update and start:   cd %s && %scurl -fsSL %s | sh\n\n' \
+            "$LAUNCH_DIR" "$ref_prefix" "$INSTALL_URL"
+    else
+        printf '    Start again later:  cd %s && ./install.sh\n' "$REPO_DIR"
+        printf '    Update:             Setup tab → Update, or git pull --ff-only, then start again\n\n'
+    fi
 
     # exec replaces this shell so Ctrl-C reaches Uvicorn directly and no
     # wrapper lingers. If the server dies at boot, the prompt returns

--- a/install.sh
+++ b/install.sh
@@ -570,13 +570,19 @@ start_server() {
     printf '    Logs:  %s\n' "$log_file"
     printf '    Press Ctrl-C to stop.\n\n'
     print_restart_hint
+
+    # exec replaces this shell so Ctrl-C reaches Uvicorn directly and no
+    # wrapper lingers. If the server dies at boot, the prompt returns
+    # silently — the log above has the reason.
+    exec "$VENV_PYTHON" server.py >> "$log_file" 2>&1
 }
 
 # ==============================================================
 # How to come back. Once Ctrl-C returns the prompt there is nothing on
 # screen that says how to start again, and "run the installer command"
-# is only obvious to whoever ran it first. Printed before exec hands the
-# terminal to the server, since nothing of this script survives that.
+# is only obvious to whoever ran it first. Print-only: start_server owns
+# the exec, and this must run before it, since nothing of this script
+# survives the exec.
 # ==============================================================
 print_restart_hint() {
     local ref_prefix=""
@@ -590,11 +596,6 @@ print_restart_hint() {
         printf '    Start again later:  cd %s && ./install.sh\n' "$REPO_DIR"
         printf '    Update:             Setup tab → Update, or git pull --ff-only, then start again\n\n'
     fi
-
-    # exec replaces this shell so Ctrl-C reaches Uvicorn directly and no
-    # wrapper lingers. If the server dies at boot, the prompt returns
-    # silently — the log above has the reason.
-    exec "$VENV_PYTHON" server.py >> "$log_file" 2>&1
 }
 
 main() {

--- a/install.sh
+++ b/install.sh
@@ -585,13 +585,15 @@ start_server() {
 # survives the exec.
 # ==============================================================
 print_restart_hint() {
+    # The ref goes on `sh`, not on `curl`: it is the bootstrap that reads it,
+    # and with a pipe an assignment binds to the command it precedes.
     local ref_prefix=""
     [ "$SOURCE_REF" = "main" ] || ref_prefix="QUIRQ_SOURCE_REF=${SOURCE_REF} "
 
     if [ "$MANAGED_CHECKOUT" -eq 1 ]; then
         printf '    Start again later:  cd %s && %s/install.sh\n' "$LAUNCH_DIR" "$REPO_DIR"
-        printf '    Update and start:   cd %s && %scurl -fsSL %s | sh\n\n' \
-            "$LAUNCH_DIR" "$ref_prefix" "$INSTALL_URL"
+        printf '    Update and start:   cd %s && curl -fsSL %s | %ssh\n\n' \
+            "$LAUNCH_DIR" "$INSTALL_URL" "$ref_prefix"
     else
         printf '    Start again later:  cd %s && ./install.sh\n' "$REPO_DIR"
         printf '    Update:             Setup tab → Update, or git pull --ff-only, then start again\n\n'

--- a/space_ui/index.html
+++ b/space_ui/index.html
@@ -152,6 +152,6 @@
   <div class="meta" id="fmeta"></div>
 </footer>
 
-<script type="module" src="js/app.js?v=20260825-rename1"></script>
+<script type="module" src="js/app.js?v=20260827-restarthint1"></script>
 
 </body></html>

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -11,7 +11,7 @@ import projectsView from './views/projects.js?v=20260825-rename1';
 import treeView from './views/tree.js?v=20260825-rename1';
 /* Chat is deliberately hidden from the tab bar: re-import ./views/chat.js
    and register it below to bring the tab back. */
-import wikiView from './views/wiki.js?v=20260825-installlink1';
+import wikiView from './views/wiki.js?v=20260827-restarthint1';
 import quirqView from './views/quirq.js?v=20260817-plural1';
 import secretsView from './views/secrets.js?v=20260825-installlink1';
 

--- a/space_ui/js/views/wiki.js
+++ b/space_ui/js/views/wiki.js
@@ -692,8 +692,11 @@ function installationArticle(){
           and piping that to <code>bash</code> yourself does the same thing.</p></li>
           <li><b>Open the workspace.</b>
           <code>http://localhost:5002/space/</code>
-          <p>Press Ctrl-C to stop the server. Re-run the same installer
-          command whenever you want to update and restart.</p></li>
+          <p>Press Ctrl-C to stop the server. To start it again without
+          updating, run <code>./xo-space/install.sh</code> from the same
+          directory; re-run the installer command whenever you want to update
+          and restart. The banner prints both before the server takes over
+          the terminal.</p></li>
         </ol>
       </section>
 
@@ -795,8 +798,11 @@ function installationArticle(){
           <h2>Stop, update, restart</h2>
           <code>Ctrl-C</code>
           <p>The server runs in the foreground; nothing supervises it, so
-          the Setup tab cannot restart it for you. Stop it with Ctrl-C and
-          re-run the installer command to update and restart. The Setup tab can
+          the Setup tab cannot restart it for you. Stop it with Ctrl-C, then
+          <code>./xo-space/install.sh</code> starts it again as it was and
+          re-running the installer command updates it first. Running that
+          command from inside <code>./xo-space</code> reuses the checkout
+          rather than nesting a second one. The Setup tab can
           fast-forward the checkout in place instead of a re-run, but the
           running process keeps the old code — and a root saved there keeps the
           old root — until it is stopped and started again. Projects and

--- a/tests/install_sh_harness.sh
+++ b/tests/install_sh_harness.sh
@@ -97,7 +97,9 @@ m="$(hint 1 "$W/ws/xo-space" "$W/ws")"
 case "$m" in *"cd $W/ws && $W/ws/xo-space/install.sh"*"curl -fsSL https://quirq.ai/install | sh"*) ok "managed banner: start-again + one-liner";; *) bad "managed banner" "$m";; esac
 case "$m" in *QUIRQ_SOURCE_REF*) bad "managed banner on main: no ref prefix" "$m";; *) ok "managed banner on main: no ref prefix";; esac
 m="$(hint 1 "$W/ws/xo-space" "$W/ws" development)"
-case "$m" in *"QUIRQ_SOURCE_REF=development curl"*) ok "managed banner on dev ref: prefix present";; *) bad "managed banner on dev ref" "$m";; esac
+# the ref must sit on `sh` (the bootstrap reads it), never on `curl`
+case "$m" in *"| QUIRQ_SOURCE_REF=development sh"*) ok "managed banner on dev ref: prefix on sh";; *) bad "managed banner on dev ref: prefix on sh" "$m";; esac
+case "$m" in *"QUIRQ_SOURCE_REF=development curl"*) bad "managed banner on dev ref: prefix must not be on curl" "$m";; *) ok "managed banner on dev ref: prefix not on curl";; esac
 i="$(hint 0 "$W/ws/xo-space" "$W/ws/xo-space")"
 case "$i" in *"cd $W/ws/xo-space && ./install.sh"*"git pull --ff-only"*) ok "in-place banner";; *) bad "in-place banner" "$i";; esac
 

--- a/tests/install_sh_harness.sh
+++ b/tests/install_sh_harness.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# tests/install_sh_harness.sh — exercises install.sh's resolve_repo_dir,
+# fetch_repo and print_restart_hint in isolation.
+#
+# Sources everything except the final `main "$@"`, against temp directories
+# and a local file:// git remote named xo-space, so REPO_NAME resolves the way
+# it does for the real one. No network, no uv, no venv, no server is started.
+# Run directly (bash tests/install_sh_harness.sh) or via tests/test_install_sh.py.
+# INSTALL_SH=<path> points it at another copy of the script.
+set -u
+SRC="${INSTALL_SH:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/install.sh}"
+W="$(mktemp -d)"
+pass=0; fail=0
+ok()   { pass=$((pass+1)); printf 'PASS  %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf 'FAIL  %s\n      got: %s\n' "$1" "$2"; }
+check(){ [ "$2" = "$3" ] && ok "$1" || bad "$1" "$2  (want: $3)"; }
+
+# ---- functions-only copy -------------------------------------------------
+last="$(tail -n 1 "$SRC" | tr -d '\r' | sed 's/[[:space:]]*$//')"
+[ "$last" = 'main "$@"' ] || { echo "unexpected last line:"; tail -n 1 "$SRC" | od -c | head -3; exit 1; }
+tr -d '\r' < "$SRC" | sed '$d' > "$W/lib.sh"
+
+# ---- fake upstream on main -----------------------------------------------
+G="git -c user.name=t -c user.email=t@t"
+mkdir -p "$W/origin/xo-space" && cd "$W/origin/xo-space"
+git init -q -b main . && echo a > server.py && echo b > requirements.txt
+$G add . && $G commit -qm v1
+export QUIRQ_SOURCE_REPO="file://$W/origin/xo-space"
+
+# ---- 1. mode detection -----------------------------------------------------
+# helper: run resolve_repo_dir from $1 as if piped (sourcing lib.sh from $W,
+# which has no server.py beside it, so the BASH_SOURCE probe fails as it does
+# for stdin)
+detect(){ ( cd "$1" && unset QUIRQ_APP_DIR && [ -z "${2:-}" ] || export QUIRQ_APP_DIR="$2"
+            cd "$1"; source "$W/lib.sh" 2>/dev/null; resolve_repo_dir >/dev/null
+            printf '%s|%s|%s' "$REPO_DIR" "$LAUNCH_DIR" "$MANAGED_CHECKOUT" ); }
+
+mkdir -p "$W/ws"
+check "piped from an empty workspace -> managed ./xo-space" \
+      "$(detect "$W/ws")" "$W/ws/xo-space|$W/ws|1"
+
+git clone -q -b main "file://$W/origin/xo-space" "$W/ws/xo-space"
+check "piped from INSIDE the checkout -> that checkout, parent is workspace" \
+      "$(detect "$W/ws/xo-space")" "$W/ws/xo-space|$W/ws|1"
+
+mkdir -p "$W/elsewhere"
+check "QUIRQ_APP_DIR wins over the inside-checkout probe" \
+      "$(detect "$W/ws/xo-space" "$W/elsewhere/app")" "$W/elsewhere/app|$W/ws/xo-space|1"
+
+# in-place: the script file itself sits beside server.py (own clone, so the
+# copied script does not dirty the one the update test uses)
+git clone -q -b main "file://$W/origin/xo-space" "$W/clone"
+cp "$W/lib.sh" "$W/clone/install.sh"
+inplace="$( cd "$W/clone" && source ./install.sh 2>/dev/null; resolve_repo_dir; printf '%s|%s|%s' "$REPO_DIR" "$LAUNCH_DIR" "$MANAGED_CHECKOUT" )"
+check "./install.sh from a clone -> in-place, no update" \
+      "$inplace" "$W/clone|$W/clone|0"
+
+# ---- 2. fetch_repo ---------------------------------------------------------
+cd "$W/origin/xo-space" && echo c >> server.py && $G commit -qam v2
+UP="$(git -C "$W/origin/xo-space" rev-parse HEAD)"
+fetch(){ ( cd "$W"; source "$W/lib.sh" 2>/dev/null; REPO_DIR="$1"; MANAGED_CHECKOUT=1; fetch_repo ); }
+
+out="$(fetch "$W/ws/xo-space" 2>&1)"
+check "clean checkout on main -> updated to upstream HEAD" \
+      "$(git -C "$W/ws/xo-space" rev-parse HEAD)" "$UP"
+case "$out" in *"Updating it"*) ok "…and said so";; *) bad "…and said so" "$out";; esac
+
+git clone -q -b main "file://$W/origin/xo-space" "$W/dirty" && echo edit >> "$W/dirty/server.py"
+before="$(git -C "$W/dirty" rev-parse HEAD)"
+cd "$W/origin/xo-space" && echo d >> server.py && $G commit -qam v3
+out="$(fetch "$W/dirty" 2>&1)"
+check "dirty checkout -> untouched" "$(git -C "$W/dirty" rev-parse HEAD)" "$before"
+check "dirty checkout -> edit preserved" "$(tail -n1 "$W/dirty/server.py")" "edit"
+case "$out" in *"local changes"*) ok "…and said so";; *) bad "…and said so" "$out";; esac
+
+git clone -q -b main "file://$W/origin/xo-space" "$W/devclone" && git -C "$W/devclone" checkout -q -b development
+before="$(git -C "$W/devclone" rev-parse HEAD)"
+cd "$W/origin/xo-space" && echo e >> server.py && $G commit -qam v4
+out="$(fetch "$W/devclone" 2>&1)"
+check "clean clone on another branch -> untouched" "$(git -C "$W/devclone" rev-parse HEAD)" "$before"
+check "…still on its branch" "$(git -C "$W/devclone" rev-parse --abbrev-ref HEAD)" "development"
+case "$out" in *"on branch development, not main"*"QUIRQ_SOURCE_REF=development"*) ok "…and named the override";; *) bad "…and named the override" "$out";; esac
+
+# upstream grows a development branch one commit ahead of main
+cd "$W/origin/xo-space" && git checkout -q -b development && echo f >> server.py && $G commit -qam dev1 && git checkout -q main
+out="$(cd "$W"; source "$W/lib.sh" 2>/dev/null; SOURCE_REF=development; REPO_DIR="$W/devclone"; MANAGED_CHECKOUT=1; fetch_repo 2>&1)"
+check "QUIRQ_SOURCE_REF=development -> that clone DOES update, to origin/development" \
+      "$(git -C "$W/devclone" rev-parse HEAD)" "$(git -C "$W/origin/xo-space" rev-parse development)"
+
+mkdir -p "$W/fresh"
+out="$(fetch "$W/fresh/xo-space" 2>&1)"
+check "no checkout yet -> cloned" "$(git -C "$W/fresh/xo-space" rev-parse HEAD 2>/dev/null)" "$(git -C "$W/origin/xo-space" rev-parse HEAD)"
+
+# ---- 3. banner -------------------------------------------------------------
+hint(){ ( cd "$W"; source "$W/lib.sh" 2>/dev/null; MANAGED_CHECKOUT="$1"; REPO_DIR="$2"; LAUNCH_DIR="$3"; SOURCE_REF="${4:-main}"; print_restart_hint ); }
+m="$(hint 1 "$W/ws/xo-space" "$W/ws")"
+case "$m" in *"cd $W/ws && $W/ws/xo-space/install.sh"*"curl -fsSL https://quirq.ai/install | sh"*) ok "managed banner: start-again + one-liner";; *) bad "managed banner" "$m";; esac
+case "$m" in *QUIRQ_SOURCE_REF*) bad "managed banner on main: no ref prefix" "$m";; *) ok "managed banner on main: no ref prefix";; esac
+m="$(hint 1 "$W/ws/xo-space" "$W/ws" development)"
+case "$m" in *"QUIRQ_SOURCE_REF=development curl"*) ok "managed banner on dev ref: prefix present";; *) bad "managed banner on dev ref" "$m";; esac
+i="$(hint 0 "$W/ws/xo-space" "$W/ws/xo-space")"
+case "$i" in *"cd $W/ws/xo-space && ./install.sh"*"git pull --ff-only"*) ok "in-place banner";; *) bad "in-place banner" "$i";; esac
+
+# ---- 4. strictness: set -u / -e under bash 5, and shellcheck if present -----
+bash -n "$W/lib.sh" && ok "bash -n (LF-normalised copy)" || bad "bash -n" "syntax error"
+# the banner must never be the thing that runs the server
+case "$(sed -n '/^print_restart_hint()/,/^}/p' "$W/lib.sh")" in *exec*) bad "print_restart_hint contains exec" "exec inside the hint function";; *) ok "print_restart_hint has no exec";; esac
+case "$(sed -n '/^start_server()/,/^}/p' "$W/lib.sh")" in *'exec "$VENV_PYTHON" server.py'*) ok "start_server still owns the exec";; *) bad "start_server lost the exec" "";; esac
+if command -v shellcheck >/dev/null; then shellcheck -S warning "$SRC" && ok "shellcheck (warning+)" || bad "shellcheck" "see above"; else echo "skip  shellcheck not installed"; fi
+bash --version | head -1
+
+printf '\n%d passed, %d failed  (sandbox: %s)\n' "$pass" "$fail" "$W"
+rm -rf "$W"
+[ "$fail" -eq 0 ]

--- a/tests/test_install_sh.py
+++ b/tests/test_install_sh.py
@@ -1,0 +1,57 @@
+"""install.sh — the functions that decide what the one-liner does.
+
+Runs ``tests/install_sh_harness.sh``, which sources ``install.sh`` minus its
+final ``main "$@"`` and drives ``resolve_repo_dir``, ``fetch_repo`` and
+``print_restart_hint`` against temp directories and a local ``file://`` git
+remote. Nothing is cloned from the network, no venv is built and no server is
+started — but the real script logic runs, which is what caught an ``exec``
+that had drifted into the banner function and would have killed every
+install at startup under ``set -u``.
+
+Needs bash and git on a POSIX host; skipped elsewhere. The harness prints
+one PASS/FAIL line per case, so a failure names the case directly.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "tests" / "install_sh_harness.sh"
+BASH = shutil.which("bash") if os.name == "posix" else None
+
+
+class InstallShTests(unittest.TestCase):
+    @unittest.skipUnless(BASH and shutil.which("git"), "needs bash and git on a POSIX host")
+    def test_harness_passes(self) -> None:
+        result = subprocess.run(
+            [BASH, str(HARNESS)],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            "install.sh harness failed:\n" + result.stdout + result.stderr,
+        )
+        self.assertNotIn("FAIL", result.stdout)
+
+    def test_harness_targets_the_repo_script(self) -> None:
+        """Text-level: the harness must exercise this repo's install.sh by
+        default, and the exec must stay in start_server (the bug it guards)."""
+        harness = HARNESS.read_text(encoding="utf-8")
+        self.assertIn("INSTALL_SH:-", harness)
+        self.assertIn("start_server still owns the exec", harness)
+
+        script = (ROOT / "install.sh").read_text(encoding="utf-8")
+        hint = script.split("print_restart_hint() {", 1)[1].split("\n}\n", 1)[0]
+        self.assertNotIn("exec ", hint, "print_restart_hint must be print-only")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_space_wiki.py
+++ b/tests/test_space_wiki.py
@@ -550,6 +550,29 @@ class SpaceWikiTests(unittest.TestCase):
         # Nothing may be installed beyond requirements.txt.
         self.assertIn("QUIRQ_SKIP_BOOT_INSTALL", code)
 
+    def test_installer_tells_you_how_to_come_back_and_never_nests(self) -> None:
+        """Ctrl-C hands back a bare prompt; the banner must have said how to
+        start again. And the one-liner run from inside ./xo-space must reuse
+        that checkout, not clone a second one into it (which makes the outer
+        checkout the projects root and leaves it dirty forever)."""
+
+        lines = (ROOT / "install.sh").read_text(encoding="utf-8").splitlines()
+        code = "\n".join(
+            line for line in lines if not line.lstrip().startswith("#")
+        )
+        self.assertIn("print_restart_hint", code)
+        self.assertIn("Start again later:", code)
+        self.assertIn("https://quirq.ai/install", code)
+        # The launch directory itself is probed for a checkout.
+        self.assertIn('"${LAUNCH_DIR}/server.py"', code)
+        # A checkout on another branch is left alone, like a dirty one.
+        self.assertIn("rev-parse --abbrev-ref HEAD", code)
+
+        guide = (ROOT / "INSTALLATION.md").read_text(encoding="utf-8")
+        wiki = (ROOT / "space_ui" / "js" / "views" / "wiki.js").read_text(encoding="utf-8")
+        for doc in (guide, wiki):
+            self.assertIn("./xo-space/install.sh", doc)
+
     def test_installer_claims_no_container_only_capabilities(self) -> None:
         """Setting either would make the Setup tab offer a restart control
         that cannot work: nothing supervises a foreground process."""


### PR DESCRIPTION
Closes #35

## Summary

Two things the one-liner got wrong in practice, both found by running it by hand in a Coder workspace.

### 1. Running the one-liner from inside `./xo-space` nested a second clone
`resolve_repo_dir` only asked "is the *script file* inside a checkout?". Piped from curl there is no script file, so standing in `/home/coder/xo-space` it cloned `/home/coder/xo-space/xo-space`. The outer checkout then became the projects root, and — with an untracked directory inside it — was permanently "dirty", so it would never update again.

Now the launch directory itself is probed: if it is a checkout, it is used as the managed checkout and its **parent** becomes the workspace — byte-for-byte what running the same command one level up does, so roots and `.env` line up with the original install. An explicit `QUIRQ_APP_DIR` still wins.

### 2. A checkout on another branch is left alone
To make (1) safe for a development clone, `fetch_repo` now skips the `reset --hard` when the checkout is on a branch other than `SOURCE_REF` (`main` by default), the same way it already skips a dirty tree, and tells you the `QUIRQ_SOURCE_REF=<branch>` override. Managed clones are created with `--branch SOURCE_REF`, so they keep updating as before.

**Behaviour change to weigh:** previously the one-liner would reset a *clean* clone on any branch to `main`; now it skips with a message. I think that is the right default, but it is a judgement call.

### 3. After Ctrl-C, nothing on screen said how to come back
The banner now prints, before `exec` hands the terminal to the server:

```
    Start again later:  cd <workspace> && <checkout>/install.sh
    Update and start:   cd <workspace> && curl -fsSL https://quirq.ai/install | sh
```
(in-place mode: `./install.sh` plus "Setup tab → Update, or `git pull --ff-only`").

`INSTALLATION.md` gains a "Stopping and starting again" section; the wiki install guide and "Stop, update, restart" panel say the same; the wiki cache stamp is bumped; `tests/test_space_wiki.py` pins script, guide and wiki together.

## Stress test — and the bug it caught

The first commit on this branch had a real defect that `bash -n` cannot see: `start_server` was closed one line early, so the final `exec … server.py >> "$log_file"` sat inside `print_restart_hint`, where `$log_file` is undefined. Under `set -u` every install would have printed the banner and died with `log_file: unbound variable`. The second commit fixes it and adds the check that found it:

`tests/install_sh_harness.sh` sources `install.sh` minus its `main "$@"` and drives `resolve_repo_dir`, `fetch_repo` and `print_restart_hint` against temp directories and a local `file://` remote named `xo-space` (so `REPO_NAME` resolves as in production). No network, no `uv`, no venv, no server. `tests/test_install_sh.py` runs it on POSIX and skips elsewhere. 21 cases, all passing under WSL Ubuntu / bash 5.2:

- mode detection: piped from an empty workspace → `./xo-space`; piped from **inside** the checkout → that checkout, parent is the workspace; `QUIRQ_APP_DIR` wins; `./install.sh` from a clone → in-place
- `fetch_repo`: clean `main` → updated to upstream HEAD; dirty tree → untouched, edit preserved; clean clone on `development` → untouched, still on its branch, override named; `QUIRQ_SOURCE_REF=development` → updates to `origin/development`; no checkout → cloned
- banner: managed (start-again + one-liner, ref prefix only when non-default), in-place
- guards: `bash -n`; `print_restart_hint` contains no `exec`; `start_server` owns the `exec`

Not exercised: `ensure_uv`, `sync_dependencies`, `ensure_port_available`, the actual `exec` (unchanged by this PR). A real end-to-end run from inside an existing `./xo-space` is still the final confirmation: expect `Running from inside the Quirq checkout; the workspace is <parent>` and no nested clone.

## Not in this PR
`uninstall.sh` (#21) and the template-side changes in `xo-coder-templates` (sandbox startup script, `XO_SPACE_SHA` in prod CI, Python pinning).
