### PR TITLE
Docs: explain the first run - what the workspace shows and how a project gets in

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -20,6 +20,63 @@ Docker is not required. The command:
 
 Press Ctrl-C to stop it. Run the same command again to update and restart.
 
+## Your first run
+
+What you see first depends on where you ran the installer. Quirq does not
+create anything for you: it watches the directory you installed in — your
+workspace, the *XO root* — and shows what is there.
+
+- **An empty directory:** Files says **No projects in this workspace yet**,
+  and Dashboard, Graph, Tree and Timeline draw the same empty map. Setup and
+  Wiki work fully; Sessions shows *no data* until a runtime has run a session
+  on this machine.
+- **A directory that already holds folders:** every non-hidden folder is
+  listed as a project on the spot — your existing repos, scratch folders, and
+  the `xo-space` checkout the installer just made — each marked
+  *unscaffolded*. Big repos count toward the map's file cap (400 per project,
+  1,500 across the workspace), so a very full directory shows a trimmed
+  picture. If that is not the collection you meant, point the XO root at a
+  narrower directory from the Setup tab; it changes which folders are listed
+  and never moves files.
+
+**A project is a direct child folder of the workspace.** The folder name is
+the project id, and the watcher lists every non-hidden folder it finds on its
+next tick. A plain folder shows up as *unscaffolded* (browsable, no `.xo/`
+metadata yet); a project created through the API is *scaffolded* — it gets
+`.xo/project.json` and the template docs an agent works from (`AGENTS.md`,
+`PROJECT.md`, `OBJECTIVES.md`, `PLAN.md`, `PROGRESS.md`, `memory/`).
+
+Three ways to get a project in:
+
+1. **Drop a folder in** — `git clone <repo> <workspace>/my-app`, `mkdir`, or
+   copy. It appears unscaffolded within a tick.
+2. **Ask your coding agent** — Claude Code or Codex running in the workspace
+   carries the `xo-projects` skill (`.agents/skills/xo-projects/` in the
+   checkout, and the Claude Code plugin under `plugin/`). "Create an
+   xo-project called my-app" makes it call the API and scaffold the folder.
+3. **Call the API yourself:**
+
+   ```bash
+   curl -X POST http://localhost:5002/api/files/mkdir \
+     -H 'Content-Type: application/json' \
+     -d '{"path": "<XO root>/my-app", "scaffold": true, "display_name": "My App"}'
+   ```
+
+   The path must be a direct child of the XO root (400 otherwise, 409 if the
+   folder exists). The root is printed by the installer (`XO projects:`),
+   shown in the Setup tab, and returned by `GET /api/config/workspace`.
+
+Tabs fill in stages: any folder lights up Files (List, Graph, Tree) and a
+Dashboard node; a scaffolded project adds identity and todos; a `.git` inside
+the project adds a Timeline lane and file dates; an agent session adds live
+badges, drawer events and Sessions telemetry; credentials (Setup or `.env`)
+enable chat, connectors and backup. Nothing is required just to browse.
+
+Before the first chat, check three things in Setup: the roots are the ones you
+meant, the agent CLI is on the server's PATH (`claude` or `codex` — the
+installer does not install it; `npm install -g @anthropic-ai/claude-code`),
+and a credential is saved (Setup values are write-only and outrank `.env`).
+
 ## Stopping and starting again
 
 Ctrl-C stops the server; nothing supervises it, so nothing restarts it. The
@@ -83,7 +140,7 @@ self-contained and you can move or delete it as one folder.
 |---|---|
 | `.` | Your projects root — each project is a subdirectory with its own `.xo` |
 | `./xo-space` | The Quirq source checkout |
-| `./xo-space/venv` | Python environment |
+| `./xo-space/venv` | Python environment, made by uv — it has no `pip`. To add packages (e.g. the test suite): `~/.local/bin/uv pip install --python ./xo-space/venv/bin/python -r <file>`; uv itself lives in `~/.local/bin`, which the installer does not add to your shell's PATH |
 | `./.quirq` | Runtime configuration, saved credentials, watcher activity, cursors, locks, and other machine-local state |
 
 Open the **Setup** tab after installation. It shows the paths in use, CLI

--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ Then open the workspace — the installer prints this URL as it starts:
 http://localhost:5002/space/
 ```
 
+### Your first run
+
+It opens on Files. In an empty directory it says **No projects in this
+workspace yet**; in a directory that already has folders, every one of them
+is listed as an *unscaffolded* project on the spot — the checkout included.
+Both are expected: a project is any direct child folder of the directory you
+installed in (the *XO root*). Clone or `mkdir` one there, ask your coding
+agent to "create an xo-project" (the `xo-projects` skill calls the API), or
+`POST /api/files/mkdir` with `scaffold:true`. Tabs fill in stages from there
+— folders light up Files and Dashboard, git history lights up Timeline, agent
+sessions light up Sessions. The in-app Wiki page **Your first run** and
+[INSTALLATION.md](INSTALLATION.md#your-first-run) walk through it, including
+how to narrow the XO root from Setup if the installer landed somewhere busy.
+
 ### Check the API directly
 
 ```bash

--- a/space_ui/css/wiki.css
+++ b/space_ui/css/wiki.css
@@ -52,6 +52,9 @@
 .wiki-callout{margin-top:38px;padding:20px 22px;border:1px solid rgba(168,217,79,.28);border-radius:12px;background:rgba(168,217,79,.055)}
 .wiki-callout b{display:block;margin-bottom:7px;font:600 10px var(--mono);letter-spacing:.14em;text-transform:uppercase;color:var(--accent)}
 .wiki-callout p{font-size:13px;line-height:1.65;color:var(--ink-2)}
+/* in-article cross-link to another wiki page or tab: reads as a link, is a button */
+.wiki-link{display:inline;padding:0;border:0;background:none;font:inherit;color:var(--accent);text-decoration:underline;text-underline-offset:2px;cursor:pointer}
+.wiki-link:hover{color:var(--ink)}
 .wiki-tab-callout{display:flex;align-items:center;justify-content:space-between;gap:24px}
 .wiki-tab-callout>div{min-width:0}
 .wiki-tab-callout button{flex:none;border:1px solid rgba(168,217,79,.35);border-radius:999px;padding:8px 13px;font:600 8.5px var(--mono);letter-spacing:.1em;text-transform:uppercase;color:var(--accent)}

--- a/space_ui/index.html
+++ b/space_ui/index.html
@@ -10,7 +10,7 @@
 <link rel="stylesheet" href="css/timeline.css?v=20260825-timeline1">
 <link rel="stylesheet" href="css/chrome.css?v=20260813-timeline2">
 <link rel="stylesheet" href="css/projects.css?v=20260824-treecam1">
-<link rel="stylesheet" href="css/wiki.css?v=20260725-collaboration1">
+<link rel="stylesheet" href="css/wiki.css?v=20260827-firstrun1">
 <link rel="stylesheet" href="css/quirq.css?v=20260816-navswap1">
 <link rel="stylesheet" href="css/secrets.css?v=20260825-installlink1">
 <link rel="stylesheet" href="css/preview.css?v=20260816-preview1">
@@ -152,6 +152,6 @@
   <div class="meta" id="fmeta"></div>
 </footer>
 
-<script type="module" src="js/app.js?v=20260827-restarthint1"></script>
+<script type="module" src="js/app.js?v=20260827-firstrun1"></script>
 
 </body></html>

--- a/space_ui/js/app.js
+++ b/space_ui/js/app.js
@@ -7,11 +7,11 @@ import {initLensSwitch} from './core/lens-switch.js?v=20260817-lens1';
 import {initPreview} from './core/preview.js?v=20260825-rename1';
 import {dashboardView,graphView,timeView} from './views/atlas.js?v=20260825-review1';
 import sessionsView from './views/sessions.js?v=20260825-rename1';
-import projectsView from './views/projects.js?v=20260825-rename1';
+import projectsView from './views/projects.js?v=20260827-firstrun1';
 import treeView from './views/tree.js?v=20260825-rename1';
 /* Chat is deliberately hidden from the tab bar: re-import ./views/chat.js
    and register it below to bring the tab back. */
-import wikiView from './views/wiki.js?v=20260827-restarthint1';
+import wikiView from './views/wiki.js?v=20260827-firstrun1';
 import quirqView from './views/quirq.js?v=20260817-plural1';
 import secretsView from './views/secrets.js?v=20260825-installlink1';
 

--- a/space_ui/js/views/projects.js
+++ b/space_ui/js/views/projects.js
@@ -288,8 +288,13 @@ function rowsHTML(rows){
         +(items.length?'<b>No project matches “'+esc(filter)+'”</b>'
             +'<p>Clear the filter to see all '+items.length+'.</p>'
           :'<b>No projects in this workspace yet</b>'
-            +'<p>Create one through the xo-space; it appears here as soon as the '
-            +'folder exists under the XO root.</p>')
+            +'<p>A project is any folder directly under your workspace (the XO '
+            +'root — see Setup). Clone or <code>mkdir</code> one there, ask your '
+            +'coding agent to “create an xo-project”, or '
+            +'<code>POST /api/files/mkdir</code> with <code>scaffold:true</code>; '
+            +'it appears here on the watcher’s next tick.</p>'
+            +'<p><button class="sess-refresh" data-first-run>Read: Your first run</button> '
+            +'<button class="sess-refresh" data-open-setup>Open Setup</button></p>')
       +'</div>');
 }
 function bindRows(){
@@ -299,6 +304,15 @@ function bindRows(){
     switchTo('graph');
     dispatchEvent(new CustomEvent('space:focus-project',{detail:b.dataset.map}));
   }));
+  /* empty-state hand-offs: the wiki listens for space:wiki-page once mounted,
+     so switch first and select the page after (same order quirq.js uses) */
+  const fr=root.querySelector('[data-first-run]');
+  if(fr)fr.addEventListener('click',async()=>{
+    await switchTo('wiki');
+    dispatchEvent(new CustomEvent('space:wiki-page',{detail:'first-run'}));
+  });
+  const st=root.querySelector('[data-open-setup]');
+  if(st)st.addEventListener('click',()=>switchTo('secrets'));
 }
 function syncSortUI(){
   root.querySelectorAll('[data-sort]').forEach(b=>{

--- a/space_ui/js/views/wiki.js
+++ b/space_ui/js/views/wiki.js
@@ -18,6 +18,12 @@ const PAGES=[
     summary:'Prerequisites, the one-command native install, configuration, verification, and updates.'
   },
   {
+    id:'first-run',
+    section:'Start here',
+    title:'Your first run',
+    summary:'Why the workspace starts empty, what a project is, three ways to get one, and which tabs light up when.'
+  },
+  {
     id:'watcher',
     section:'Runtime systems',
     title:'How the watcher works',
@@ -100,6 +106,7 @@ const PAGES=[
 const ARTICLES={
   storage:storageArticle,
   installation:installationArticle,
+  'first-run':firstRunArticle,
   watcher:watcherArticle,
   'xo-data':xoDataArticle,
   'quirq-data':quirqDataArticle,
@@ -153,7 +160,10 @@ function renderShell(){
   });
   root.querySelector('#wiki-main').addEventListener('click',event=>{
     const button=event.target.closest('[data-open-tab]');
-    if(button)go(button.dataset.openTab);
+    if(button){go(button.dataset.openTab);return;}
+    /* in-article cross-links between wiki pages */
+    const link=event.target.closest('[data-wiki-link]');
+    if(link)selectPage(link.dataset.wikiLink);
   });
   selectPage(activePage);
 }
@@ -634,6 +644,150 @@ function storageArticle(){
     </article>`;
 }
 
+function firstRunArticle(){
+  return`
+    <article class="wiki-article">
+      <header class="wiki-hero">
+        <div class="wiki-kicker">Start here · Your first run</div>
+        <h1>What you see first depends on where you ran the installer.</h1>
+        <p>Quirq does not create work for you: it watches one directory — the
+        one you ran the installer in, your <b>workspace</b> — and shows what
+        is in it. Run it in an empty directory and the Files tab is empty.
+        Run it in a directory that already holds folders and every one of
+        them is listed as a project on the spot. Both are correct; this page
+        explains what you are looking at either way and how to get a real
+        project in.</p>
+        <div class="wiki-facts">
+          <span>a project is a folder</span>
+          <span>the watcher picks it up</span>
+          <span>three ways to add one</span>
+          <span>tabs fill in stages</span>
+        </div>
+      </header>
+
+      <section class="wiki-section">
+        <h2>What you are looking at</h2>
+        <div class="wiki-decision-list">
+          <div><b>An empty directory</b><p>Files says <i>No projects in this
+          workspace yet</i>. Dashboard, Graph, Tree and Timeline draw the
+          same empty map. Setup and Wiki are fully alive; Sessions lists the
+          runtimes it can read and shows <i>no data</i> until one of them has
+          run a session on this machine.</p></div>
+          <div><b>A directory with things in it</b><p>Every non-hidden folder
+          is listed — your existing repos, scratch folders, and the
+          <code>xo-space</code> checkout the installer just made — each with
+          an <i>unscaffolded</i> badge, browsable but without project
+          metadata. Big repos among them count toward the map's file cap
+          (400 per project, 1,500 across the workspace), so a very full
+          directory shows a trimmed picture. If that is not the collection
+          you meant, point the XO root at a narrower directory from
+          <button class="wiki-link" data-open-tab="secrets">Setup</button>
+          — it changes which folders are listed and never moves files.</p></div>
+        </div>
+        <p class="wiki-note">Either way the tabs read one map: the List, Graph
+        and Tree lenses of Files, the Dashboard and the Timeline all show the
+        same set of folders, and all update within a watcher tick.</p>
+      </section>
+
+      <section class="wiki-section">
+        <h2>What a project is</h2>
+        <p>A project is a <b>direct child folder of the workspace</b>. That is
+        the whole rule: the folder name is the project id, and the watcher
+        lists every non-hidden folder it finds there on its next tick — a few
+        seconds. Two flavours:</p>
+        <div class="wiki-decision-list">
+          <div><b>Unscaffolded</b><p>Any plain folder — one you cloned, copied
+          or <code>mkdir</code>-ed. It appears with an <i>unscaffolded</i>
+          badge: the files are browsable, but there is no
+          <code>.xo/</code> metadata yet, so no todos, timeline or identity.
+          The installer's own <code>xo-space</code> checkout shows up this way
+          too, because it is a folder in your workspace like any other.</p></div>
+          <div><b>Scaffolded</b><p>A folder created through the API. It gets
+          <code>.xo/project.json</code> (owned by the watcher, never edited by
+          hand) and the template docs an agent works from —
+          <code>AGENTS.md</code>, <code>PROJECT.md</code>,
+          <code>OBJECTIVES.md</code>, <code>PLAN.md</code>,
+          <code>PROGRESS.md</code>, <code>memory/</code>. This is the shape
+          the Dashboard, todos and sync features expect.</p></div>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Three ways to get one</h2>
+        <div class="wiki-recipe">
+          <div class="wiki-recipe-step"><small>1</small><b>Drop a folder in</b>
+          <code>git clone &lt;repo&gt; &lt;workspace&gt;/my-app</code>
+          <p>Or <code>mkdir</code>, or copy an existing project. It shows up
+          unscaffolded within a tick. Right for "I already have code and want
+          to see it here".</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>2</small><b>Ask your coding agent</b>
+          <code>"create an xo-project called my-app"</code>
+          <p>Claude Code or Codex running in the workspace carries the
+          <code>xo-projects</code> skill (shipped in the checkout under
+          <code>.agents/skills/</code>, and in the Claude Code plugin). It
+          asks the API to scaffold the folder and then fills in the template
+          docs with you. Right for starting something new.</p></div>
+          <i>→</i>
+          <div class="wiki-recipe-step"><small>3</small><b>Call the API yourself</b>
+          <code>POST /api/files/mkdir</code>
+          <p>Body: <code>{"path": "&lt;XO root&gt;/my-app", "scaffold": true,
+          "display_name": "My App"}</code>. The path must be a direct child
+          of the XO root (400 otherwise, 409 if it exists). Same result as
+          the skill, no agent needed.</p></div>
+        </div>
+        <p class="wiki-note">The XO root is printed by the installer
+        (<i>XO projects:</i>) and shown in <button class="wiki-link"
+        data-open-tab="secrets">Setup</button> under storage roots. Never
+        guess it; <code>GET /api/config/workspace</code> returns it too.</p>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Which tabs light up when</h2>
+        <div class="wiki-table-wrap">
+          <table class="wiki-table">
+            <thead><tr><th>Once you have…</th><th>…this appears</th></tr></thead>
+            <tbody>
+              <tr><td>any folder in the workspace</td><td>Files (List, Graph, Tree), the project drawer's file browser, Dashboard node</td></tr>
+              <tr><td>a scaffolded project</td><td>identity and description from <code>.xo/project.json</code>, todos in the drawer and orbiting on Dashboard</td></tr>
+              <tr><td>a <code>.git</code> inside the project</td><td>Timeline lane with commit history; file dates in Graph and Tree (folders without git are drawn as dark lanes, not dropped)</td></tr>
+              <tr><td>an agent session in the project</td><td>live badge and last activity in Files, events in the drawer, entries in Sessions</td></tr>
+              <tr><td>credentials in Setup or <code>.env</code></td><td>chat through the API, connectors, backup and restore</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="wiki-section">
+        <h2>Before the first chat: a Setup checklist</h2>
+        <ol class="wiki-steps">
+          <li><b>Roots.</b><p>Confirm the XO root is the directory you meant.
+          Changing it selects a different collection of projects; it never
+          moves files.</p></li>
+          <li><b>Runtime.</b><p>The agent CLI must be on the server's PATH —
+          <code>claude</code> or <code>codex</code>. The installer does not
+          install it: <code>npm install -g @anthropic-ai/claude-code</code>.
+          Setup's runtime card says whether it was found.</p></li>
+          <li><b>Credentials.</b><p>Add the runtime's key in Setup (write-only;
+          previews never show the value) or in the checkout's
+          <code>.env</code>. A saved Setup value outranks <code>.env</code>
+          on the next start.</p></li>
+        </ol>
+        <p class="wiki-note">Nothing here is required to browse. A workspace
+        with plain folders and no credentials is already a working file map;
+        the checklist is for the day you want an agent in the loop.</p>
+      </section>
+
+      <aside class="wiki-callout">
+        <b>Why nothing is invented</b>
+        <p>The watcher only ever reads. It materialises what your folders and
+        your runtimes' own logs contain — it does not create projects,
+        sessions or history. An empty workspace is an honest one, and a full
+        one shows exactly what was already there.</p>
+      </aside>
+    </article>`;
+}
+
 function installationArticle(){
   return`
     <article class="wiki-article">
@@ -692,6 +846,11 @@ function installationArticle(){
           and piping that to <code>bash</code> yourself does the same thing.</p></li>
           <li><b>Open the workspace.</b>
           <code>http://localhost:5002/space/</code>
+          <p>It opens on the Files tab: empty if the directory was empty,
+          otherwise listing every folder that was already there as a
+          project. Both are expected — <button class="wiki-link"
+          data-wiki-link="first-run">Your first run</button> explains what
+          you are looking at and how to get a real project in.</p>
           <p>Press Ctrl-C to stop the server. To start it again without
           updating, run <code>./xo-space/install.sh</code> from the same
           directory; re-run the installer command whenever you want to update
@@ -747,6 +906,12 @@ function installationArticle(){
         state root later; it saves them to <code>roots.env</code> in the state
         root and the server reads that file at startup, so the change lands on
         the next start and shows as a restart reason until then.</p>
+        <p class="wiki-note">The environment is made by <code>uv</code> and has
+        no <code>pip</code>. To add packages (the test suite, say), use uv
+        against it: <code>~/.local/bin/uv pip install --python
+        ./xo-space/venv/bin/python -r &lt;file&gt;</code>. The installer put uv in
+        <code>~/.local/bin</code>, which is not on your shell's PATH unless you
+        add it.</p>
       </section>
 
       <section class="wiki-section">

--- a/tests/test_space_wiki.py
+++ b/tests/test_space_wiki.py
@@ -165,8 +165,11 @@ class SpaceWikiTests(unittest.TestCase):
         self.assertIn("Liveblocks + Yjs", wiki)
         self.assertIn("docs.yjs.dev/api/document-updates", wiki)
         self.assertIn("support.google.com/docs/answer/190843", wiki)
+        # The stylesheet must be cache-busted, but pinning the literal stamp
+        # turns every legitimate bump into a red test (see the app.js stamp
+        # test above for the same reasoning): assert the shape, not the value.
         index = (ROOT / "space_ui" / "index.html").read_text(encoding="utf-8")
-        self.assertIn("css/wiki.css?v=20260725-collaboration1", index)
+        self.assertRegex(index, r"css/wiki\.css\?v=\d{8}-[a-z0-9]+")
 
     def test_wiki_documents_space_walk_session_replay(self) -> None:
         wiki = (ROOT / "space_ui" / "js" / "views" / "wiki.js").read_text(
@@ -549,6 +552,43 @@ class SpaceWikiTests(unittest.TestCase):
         self.assertIn("prepare_state_root", code)
         # Nothing may be installed beyond requirements.txt.
         self.assertIn("QUIRQ_SKIP_BOOT_INSTALL", code)
+
+    def test_first_run_is_explained_in_wiki_docs_and_the_empty_state(self) -> None:
+        """A fresh install opens on an empty Files tab. The wiki page, the two
+        docs and the empty state itself must all say what a project is and
+        the three ways to get one — and agree on the API call."""
+
+        wiki = (ROOT / "space_ui" / "js" / "views" / "wiki.js").read_text(encoding="utf-8")
+        self.assertIn("id:'first-run'", wiki)
+        self.assertIn("'first-run':firstRunArticle", wiki)
+        self.assertIn("Your first run", wiki)
+        self.assertIn("direct child folder of the workspace", wiki)
+        self.assertIn("POST /api/files/mkdir", wiki)
+        self.assertIn("xo-projects", wiki)
+        # In-article cross-link from the install guide to the first-run page.
+        self.assertIn('data-wiki-link="first-run"', wiki)
+        self.assertIn("data-wiki-link", wiki.split("function pageButton")[0])
+
+        projects = (ROOT / "space_ui" / "js" / "views" / "projects.js").read_text(encoding="utf-8")
+        self.assertIn("data-first-run", projects)
+        self.assertIn("'first-run'", projects)
+        self.assertIn("scaffold:true", projects)
+        self.assertNotIn("Create one through the xo-space", projects)
+
+        guide = (ROOT / "INSTALLATION.md").read_text(encoding="utf-8")
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        for doc in (guide, readme, wiki):
+            self.assertIn("Your first run", doc)
+            self.assertIn("/api/files/mkdir", doc)
+            # The first run is only empty if the directory was: a busy
+            # directory lists every folder as an unscaffolded project, and
+            # all three tellings must say so.
+            self.assertIn("unscaffolded", doc)
+        self.assertIn("## Your first run", guide)
+        self.assertIn("uv pip install --python", guide)
+        # The cross-link buttons need a rule, or they render as stock buttons.
+        css = (ROOT / "space_ui" / "css" / "wiki.css").read_text(encoding="utf-8")
+        self.assertIn(".wiki-link{", css)
 
     def test_installer_tells_you_how_to_come_back_and_never_nests(self) -> None:
         """Ctrl-C hands back a bare prompt; the banner must have said how to


### PR DESCRIPTION
## Summary

A fresh install opens on the Files tab and nothing on the page says what a project is or how to make one. Two cases, both undocumented:

- **Empty directory:** Files says "No projects in this workspace yet", and the map tabs are empty. The old empty state said "Create one through the xo-space", which is not actionable.
- **Directory that already holds folders:** every folder is listed as an *unscaffolded* project on the spot — the `xo-space` checkout included — which is at least as confusing, and big repos among them eat into the map's file cap (#36).

This PR documents the first run in the three places a user actually looks, and makes them agree.

### Wiki — new *Start here* page "Your first run" (`space_ui/js/views/wiki.js`)
- What you are looking at, empty vs busy directory — and how to narrow the XO root from Setup (jump button).
- What a project is: a direct child folder; *unscaffolded* (any folder) vs *scaffolded* (`.xo/project.json` + the template docs).
- Three ways to get one: drop a folder in; ask the coding agent (the `xo-projects` skill, shipped in `.agents/skills/` and the Claude Code plugin); `POST /api/files/mkdir` with `scaffold:true` (body, 400/409 rules, where the XO root is shown).
- Which tabs light up when (table), a Setup checklist before the first chat, and why nothing is invented.
- The install guide's "Open the workspace" step says both cases are expected and cross-links to the page — new `data-wiki-link` handling in `renderShell` and a `.wiki-link` rule in `wiki.css` — and gains the "uv-made venv has no pip" note.

### Files empty state (`space_ui/js/views/projects.js`)
One paragraph with the same facts, plus **Read: Your first run** (switches to Wiki and selects the page via `space:wiki-page`) and **Open Setup**.

### Docs
- `INSTALLATION.md`: "Your first run" section (same two-case framing, the API call as curl, tab stages, checklist); venv/pip note in the local-data table.
- `README.md` quick start: a paragraph pointing at both.

### Cache stamps
`wiki.js`, `projects.js` and `app.js` (`?v=20260827-firstrun1`), `wiki.css`.

### Tests
`tests/test_space_wiki.py::test_first_run_is_explained_in_wiki_docs_and_the_empty_state` pins the shared facts across wiki, README, INSTALLATION.md, `projects.js` and the CSS rule — including "unscaffolded" in all three tellings so the busy-directory case cannot be dropped from one. The literal `wiki.css?v=…` pin in the collaboration test is now a shape check, so stamp bumps stop breaking an unrelated test.

## Verification
- `node --check` clean on `wiki.js`, `projects.js`, `app.js`.
- `tests.test_space_wiki` + `tests.test_install_sh`: 24 passed, 1 skipped (Windows).
- **Not verified in a browser.** The page uses existing wiki classes plus the one new `.wiki-link` rule, and the empty-state buttons reuse `sess-refresh` — please open `/space/` → Wiki → *Your first run*, and the Files tab in an empty root, once.

## Related
- #36 (the leaf cap that hides non-git projects) is the next PR; this page already names the 400/1,500 caps so its empty-state wording can build on it.
- No backend changes (`space_ui/` is a pure static consumer).
