### PR TITLE
Add CONTRIBUTING.md: the contributor guide (#31)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,9 +94,11 @@ reporter in the fix's notes unless you prefer otherwise.
 
 ## Set up a dev environment
 
-Linux or macOS. Prerequisites: `git`, Python 3.12+ (the installer downloads
-one via uv if you have none), and — only for chat — an agent CLI such as
-`npm install -g @anthropic-ai/claude-code`.
+**Linux or macOS. On Windows, use WSL** (Ubuntu is fine) and do everything
+below — clone, run, test — inside it; the server does not run on native
+Windows (see [Windows](#windows)). Prerequisites: `git`, Python 3.12+ (the
+installer downloads one via uv if you have none), and — only for chat — an
+agent CLI such as `npm install -g @anthropic-ai/claude-code`.
 
 ```bash
 git clone https://github.com/quirq-ai/xo-space.git
@@ -296,9 +298,10 @@ run yet, so "how you verified it" in the description carries real weight.
 
 ## Windows
 
-The server does not run on native Windows: the watcher imports `fcntl`, the
-boot hooks are bash, and the installer needs bash. Use WSL for running and
-testing. From a Windows checkout you can still edit and do static checks
+**Use WSL.** The server does not run on native Windows: the watcher imports
+`fcntl`, the boot hooks are bash, and the installer needs bash. Clone and work
+inside a WSL distribution (Ubuntu), and run the validation there. From a
+Windows-side checkout you can still edit and do static checks
 (`python -m compileall`, `node --check`, the text-level tests). Two things bite:
 `core.autocrlf` makes working copies CRLF, so judge a shell script's line
 endings on the blob (`git ls-files --eol <file>` must say `i/lf`) and strip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,29 @@ projects. This guide is the short path from "I found something" to "it's
 merged". The engineering detail lives in [DEVELOPING.md](DEVELOPING.md); this
 file tells you how to work with us.
 
-**Contents:** [What we're looking for](#what-were-looking-for) ·
-[Before you start](#before-you-start) · [Reporting a bug](#reporting-a-bug) ·
-[Security](#security) · [Set up a dev environment](#set-up-a-dev-environment) ·
-[Ground rules](#ground-rules) · [Where things live](#where-things-live) ·
-[Testing and validation](#testing-and-validation) · [Docs move with code](#docs-move-with-code) ·
-[Branches, commits, pull requests](#branches-commits-pull-requests) ·
-[Review](#review) · [Windows](#windows) · [Community and licence](#community-and-licence)
+## Contents
+
+**Getting involved**
+
+1. [What we're looking for](#what-were-looking-for) — what helps most, and what we'll push back on
+2. [Before you start](#before-you-start) — search first; when to open an issue before a PR
+3. [Reporting a bug](#reporting-a-bug) — what to include so it can be reproduced
+4. [Security](#security) — how to report a vulnerability without publishing it
+
+**Working on the code**
+
+5. [Set up a dev environment](#set-up-a-dev-environment) — clone, two ways to run, WSL on Windows
+6. [Ground rules](#ground-rules) — the seven invariants every change must keep
+7. [Where things live](#where-things-live) — the map, adding a runtime, changing the Space UI
+8. [Testing and validation](#testing-and-validation) — the commands to run before a PR
+9. [Docs move with code](#docs-move-with-code) — which docs change with which code
+
+**Getting it merged**
+
+10. [Branches, commits, pull requests](#branches-commits-pull-requests) — `development` vs `main`, what a PR must say
+11. [Review](#review) — what we look at, in what order, and how fast
+12. [Windows](#windows) — what works natively and what needs WSL
+13. [Community and licence](#community-and-licence) — where to ask, MIT
 
 ---
 
@@ -86,9 +102,10 @@ If you are not sure it is a bug, open the issue anyway and say so.
 
 ## Security
 
-Do **not** open a public issue for a vulnerability — credentials, path escapes,
-anything that would let one user reach another's data. Use GitHub's private
-reporting: [Security → Report a vulnerability](https://github.com/quirq-ai/xo-space/security/advisories/new).
+Do **not** describe a vulnerability in a public issue — credentials, path
+escapes, anything that would let one user reach another's data. Instead, open
+an issue titled **"Security: request for a private channel"** with no details
+in it, and a maintainer will reply with a way to send the report privately.
 Give us a reasonable window to fix it before disclosing. Credit goes to the
 reporter in the fix's notes unless you prefer otherwise.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,319 @@
+# Contributing to xo-space
+
+Thanks for helping. `xo-space` is the open-source local control plane for AI
+coding agents — Claude Code, Codex, OpenClaw, Hermes, Antigravity, and Cursor
+for telemetry — plus the Space UI that shows what those agents did to your
+projects. This guide is the short path from "I found something" to "it's
+merged". The engineering detail lives in [DEVELOPING.md](DEVELOPING.md); this
+file tells you how to work with us.
+
+**Contents:** [What we're looking for](#what-were-looking-for) ·
+[Before you start](#before-you-start) · [Reporting a bug](#reporting-a-bug) ·
+[Security](#security) · [Set up a dev environment](#set-up-a-dev-environment) ·
+[Ground rules](#ground-rules) · [Where things live](#where-things-live) ·
+[Testing and validation](#testing-and-validation) · [Docs move with code](#docs-move-with-code) ·
+[Branches, commits, pull requests](#branches-commits-pull-requests) ·
+[Review](#review) · [Windows](#windows) · [Community and licence](#community-and-licence)
+
+---
+
+## What we're looking for
+
+Welcome, in rough order of how much they help:
+
+- **Bug reports with a reproduction.** Even without a fix. See
+  [Reporting a bug](#reporting-a-bug).
+- **New runtimes.** Adding a coding agent is designed to be "drop two folders"
+  with zero core edits (below, and DEVELOPING.md §4).
+- **Fixes and small improvements** to the server, the watcher, the Space UI,
+  the installer, and the docs. Anything labelled
+  [`good first issue`](https://github.com/quirq-ai/xo-space/labels/good%20first%20issue)
+  or [`help wanted`](https://github.com/quirq-ai/xo-space/labels/help%20wanted)
+  is a safe place to start.
+- **Docs and wiki corrections** where a page says something the code no
+  longer does.
+- **Connectors** (Google Drive, OneDrive, GitHub, Vercel, Manus live in
+  `routers/cowork_agent/connectors/` + `services/cowork_agent/connectors/`).
+
+Things we will push back on, so you don't spend time on them first:
+
+- Code that names a specific agent outside the agent-owned trees (the
+  modularity invariant, below). This is the one rule that gets a PR sent back
+  on sight.
+- Writing anything into a user's project folder or `.xo/` from outside the
+  watcher.
+- A build step, framework, or bundled dependency for `space_ui/` — it is
+  deliberately plain ES modules served as files.
+- Changing an existing endpoint's path, request, or response shape without an
+  issue agreeing to it first. Other clients depend on them.
+- Cloud-only behaviour. The same tree runs on a laptop and in a hosted
+  workspace (DEVELOPING.md §9); a change must make sense for both.
+
+## Before you start
+
+1. **Search [the issues](https://github.com/quirq-ai/xo-space/issues)** —
+   open and closed. Add to an existing thread rather than opening a twin.
+2. **Typos, broken links, obvious one-line fixes:** just open the PR.
+3. **Anything larger — a feature, a new endpoint, a change to what `.xo/`
+   contains, a new runtime — open an issue first** and say what you plan to
+   do. A five-minute conversation beats a rewritten PR. Say if you intend to
+   implement it yourself so nobody duplicates the work.
+4. Comment on the issue when you start, so it is visibly taken.
+
+## Reporting a bug
+
+Open an issue with:
+
+- **How you installed:** the one-liner (`curl -fsSL https://quirq.ai/install | sh`),
+  `./install.sh` from a clone, `./cowork-api.sh dev`, `./quirq` (compose), or
+  a hosted workspace.
+- **Where it runs:** OS and version (Windows means WSL — see
+  [Windows](#windows)), Python version (`./venv/bin/python --version`), and
+  the checkout's commit (`git rev-parse --short HEAD`, or the *Installed*
+  line on the Setup tab).
+- **Which runtime:** `AGENT_NAME` (and, for chat bugs, whether the CLI works
+  on its own in a terminal).
+- **What you did, what you expected, what happened.** Exact commands and the
+  exact text of any error.
+- **Evidence:** `curl -s localhost:5002/health`, and the tail of the server
+  log — `<state root>/quirq.log` for the installer path, `/tmp/xo-space.log`
+  for `cowork-api.sh`. **Redact tokens and keys before pasting** (`/health`
+  reports presence, not values, on purpose; logs may not).
+- For UI bugs: the browser, a screenshot, and the Wiki tab's page for that view
+  if it contradicts what you saw.
+
+If you are not sure it is a bug, open the issue anyway and say so.
+
+## Security
+
+Do **not** open a public issue for a vulnerability — credentials, path escapes,
+anything that would let one user reach another's data. Use GitHub's private
+reporting: [Security → Report a vulnerability](https://github.com/quirq-ai/xo-space/security/advisories/new).
+Give us a reasonable window to fix it before disclosing. Credit goes to the
+reporter in the fix's notes unless you prefer otherwise.
+
+## Set up a dev environment
+
+Linux or macOS. Prerequisites: `git`, Python 3.12+ (the installer downloads
+one via uv if you have none), and — only for chat — an agent CLI such as
+`npm install -g @anthropic-ai/claude-code`.
+
+```bash
+git clone https://github.com/quirq-ai/xo-space.git
+cd xo-space
+git checkout development          # where work lands; see Branches below
+```
+
+Two equivalent ways to run it; pick one:
+
+```bash
+# A. Contributor mode: system python3 (3.12+), venv/ + pip, auto-reload.
+./cowork-api.sh install           # venv + requirements.txt
+./cowork-api.sh dev               # http://localhost:5002/space/ (5003 if busy)
+
+# B. Exactly what users run: uv-managed Python 3.12, foreground server.
+./install.sh                      # in-place mode — never runs git on your clone
+```
+
+Both create `./venv`. The uv-made one (B) has **no `pip`**; add packages with
+`~/.local/bin/uv pip install --python ./venv/bin/python …`. In-place mode makes
+the clone itself your workspace and puts state in `./.quirq` — both are
+gitignored. To boot a specific backend:
+
+```bash
+AGENT_NAME=claude_code venv/bin/python server.py   # or codex, openclaw, hermes, antigravity
+```
+
+The server runs its boot hooks (`config/agents/<name>/setup.sh`,
+`scripts/install_shared_deps.sh`) on every start; set
+`QUIRQ_SKIP_BOOT_INSTALL=1` if you do not want them installing anything on a
+dev box (the installer sets it by default).
+
+## Ground rules
+
+These are the invariants the architecture depends on. They are enforced in
+review, and some by tests.
+
+1. **The modularity invariant.** Core code never names a specific agent
+   (`claude_code`, `codex`, `openclaw`, `hermes`, `antigravity`). Agent-specific
+   code lives in exactly three trees: `services/cowork_agent/adapters/<name>/`,
+   `config/agents/<name>/`, and `config/models/<name>/`. Everything else
+   resolves the active agent from `AGENT_NAME` through one seam,
+   `services/cowork_agent/adapters/loader.py`. The only sanctioned core
+   literal is the `openclaw` safe-boot default in `registry/agent_registry.py`
+   (plus the short frozen allowlist in DEVELOPING.md §6).
+2. **Thin routers, logic in services.** Endpoints in `routers/` are HTTP
+   handlers; behaviour lives in `services/`. Routers import services, never
+   the reverse. BFF route modules do no path work at all.
+3. **The project folder is sacred.** Nothing goes into `<XO root>/<project>/`
+   that would not survive a `git push`: no transcripts, prompts, credentials.
+   Conversations stay in each runtime's own home (`~/.claude/`, `~/.codex/`,
+   `~/.openclaw/`, `~/.hermes/`, …).
+4. **`.xo/` belongs to the watcher.** Only
+   `services/cowork_agent/visualizer/{sinks,workspace}/` write it; everything
+   else — endpoints, the UI, agents — reads. Anything else written there is
+   overwritten on the next tick.
+5. **Backward compatibility.** Endpoint paths, request schemas, and response
+   shapes are contracts. A missing capability degrades to an empty/501 shape,
+   never a crash.
+6. **Never log secrets.** No tokens, keys, cookies, or prompt text in logs or
+   error messages. `/health` reports whether a credential is present, never
+   its value; keep it that way.
+7. **Async** for network and subprocess work; actionable error messages;
+   clear code over clever code.
+
+## Where things live
+
+```
+server.py                      app wiring, lifespan, both planes
+routers/                       HTTP only — cowork_agent/ (Plane B /api/*), auth/, status/, space.py, xo_data.py
+services/cowork_agent/         the broker: engine, adapters/, registry/, connectors/, visualizer/, xo_projects_sync/
+config/agents/<name>/          per-runtime manifest, capabilities, settings, setup.sh
+space_ui/                      the Space UI — plain ES modules, no build; js/views/wiki.js is the in-app manual
+install.sh · cowork-api.sh · quirq   the three ways to run it
+tests/                         xo-space's own unittest suite
+plugin/ · .agents/             the Claude Code / Codex plugin bundles (kept in sync by a script)
+```
+
+DEVELOPING.md §2 has the full map; the README's "Project structure" section
+has the annotated tree.
+
+### Adding a runtime ("drop two folders")
+
+No core edits. `config/agents/<name>/manifest.json` + `capabilities.json`, and
+`services/cowork_agent/adapters/<name>/adapter.py` with a `BaseAgentAdapter`
+subclass implementing `run`, `stream`, `adapter_name`. Add only the optional
+capability modules you need (`usage.py`, `models.py`, `sessions.py`,
+`routes.py`); the rest degrade to empty/501. Boot it with
+`AGENT_NAME=<name>` and run the validation below. Walkthrough: DEVELOPING.md §4.
+
+### Changing the Space UI
+
+- One file per view under `space_ui/js/views/`; views never import each
+  other — cross-view jumps go through `ctx.switchTo()`. All backend calls go
+  through `js/core/api.js`.
+- Bump the `?v=` cache stamp of every module you touch in `js/app.js` (and
+  the `app.js` stamp in `index.html` if a view stamp moves; CSS stamps live in
+  `index.html`). Otherwise browsers keep the old file.
+- Update the view's tab guide in `js/views/wiki.js` in the same PR. The wiki
+  is the manual for the exact build the user runs; stale pages are bugs.
+- `node --check` each module you edit.
+
+## Testing and validation
+
+Run these before opening a PR. They need Linux/macOS (the watcher uses
+`fcntl`); on Windows only the text-level tests run.
+
+```bash
+# 1. xo-space's own suite (prints its own count — do not quote a number in docs)
+venv/bin/python -m unittest discover -s tests -t .
+
+# 2. Import gate: the app must build under every runtime, and route counts
+#    differ by design — read them, don't assert them.
+for a in claude_code codex openclaw hermes antigravity; do
+  AGENT_NAME=$a venv/bin/python -c "import server; print('$a', len(server.app.openapi()['paths']))"
+done
+
+# 3. Modularity invariant — grep core for an agent name you may have leaked
+#    (DEVELOPING.md §6 lists the frozen exceptions).
+
+# 4. If you touched install.sh: the harness runs its real functions in /tmp,
+#    no network, no venv, no server.
+bash tests/install_sh_harness.sh
+
+# 5. If you touched plugin/ or .agents/: the two bundles must match.
+./scripts/check_plugin_sync.sh
+```
+
+Add a test with every behaviour change. `tests/` is a flat `unittest` suite,
+one `TestCase` per module, hermetic (temp dirs; never a real `~/.quirq` or
+`.env`). Docs and wiki text are pinned by `tests/test_space_wiki.py` — when a
+rename breaks a pin, update the pin to the new name rather than reinstating the
+old one.
+
+## Docs move with code
+
+The docs are part of the product, and several are pinned by tests. When you
+change… update in the same PR:
+
+| Change | Also update |
+|---|---|
+| the adapter contract, session model, `.xo` layout, `/xo/*.json` views | `DEVELOPING.md` and the relevant page of `space_ui/js/views/wiki.js` |
+| any view's behaviour | its tab guide in `wiki.js` |
+| `install.sh`, roots, `.env` handling | `INSTALLATION.md` and the wiki's *Install & run locally* / *Your first run* pages |
+| what a first-time user sees | the three places must agree: `INSTALLATION.md` "Your first run", the README quick start, the wiki `first-run` page |
+| what leaves the machine | README "What leaves your machine" — keep the heading verbatim; `install.sh` prints a pointer to it |
+
+The README only references files that exist on `main`; it states the repo's
+contract, not observations from one machine, and re-measures any number it
+quotes (route counts, test counts).
+
+## Branches, commits, pull requests
+
+**Branch from `development`, target `development`.** `main` is the release
+branch: it is what the public one-liner installs, what the container image is
+built from (`.github/workflows/publish-container.yml` runs on push to `main`),
+and what `install.sh` fast-forwards a managed checkout to. `development` is
+merged into `main` by the maintainers in "Merge Dev to Main" pull requests;
+nothing lands on `main` directly.
+
+Name branches by intent: `fix/…`, `feat/…`, `docs/…`, `chore/…`.
+
+**Commits** — one concern per commit; validate before each. The first line is
+`type(scope): what changed` in the imperative (`fix(install.sh): keep the exec
+in start_server`, `docs: explain the first run`); the body says *why* and what
+you verified. Commit messages are read by people debugging a year from now —
+write them for that reader.
+
+**Pull requests** — the description should let a reviewer understand the
+change without reading the diff first:
+
+- what it does and why (link the issue: `Fixes #N` — note that a PR into
+  `development` does not auto-close the issue; a maintainer closes it after
+  the merge);
+- how you verified it, precisely — which commands, on which platform. Say
+  plainly what you did *not* run;
+- any behaviour change a user could notice, and any contract you touched;
+- screenshots for UI changes.
+
+Keep PRs focused: a rename, a fix, and a feature are three PRs. Allow edits
+from maintainers so small review fixes don't need a round trip. Keep your
+branch rebased on `development` if it falls behind; we merge with a merge
+commit, so no need to squash yourself.
+
+Contributions do not need a CLA. By submitting a PR you agree your change is
+licensed under the repository's [MIT licence](LICENSE), like the rest of the
+code.
+
+## Review
+
+A maintainer reviews every PR. We look at, in this order: does it break an
+invariant; is it verified the way it claims; does it change a contract; are
+the docs and tests in the same PR; then style. Expect questions rather than
+silent edits. We try to respond within a few days; nudge the thread if a week
+passes. Approval plus green checks is the bar to merge — there is no CI test
+run yet, so "how you verified it" in the description carries real weight.
+
+## Windows
+
+The server does not run on native Windows: the watcher imports `fcntl`, the
+boot hooks are bash, and the installer needs bash. Use WSL for running and
+testing. From a Windows checkout you can still edit and do static checks
+(`python -m compileall`, `node --check`, the text-level tests). Two things bite:
+`core.autocrlf` makes working copies CRLF, so judge a shell script's line
+endings on the blob (`git ls-files --eol <file>` must say `i/lf`) and strip
+`\r` before running a working-copy script under WSL; and Git-Bash's `grep`
+hides CRs, so don't trust it for that check.
+
+## Community and licence
+
+- **Issues** — bugs, features, questions:
+  <https://github.com/quirq-ai/xo-space/issues>.
+- **The in-app Wiki** — `http://localhost:5002/space/` → Wiki. Sixteen
+  version-matched pages; the maintained manual (the GitHub wiki is empty on
+  purpose).
+- **Docs site** — <https://docs.quirq.ai/docs/space/>.
+- **Licence** — MIT, see [LICENSE](LICENSE).
+
+Be kind and specific. Assume the other person is doing their best with the
+information they have, and give them more of it.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -186,8 +186,9 @@ local deployments — the environment contract that selects behavior — is §9.
 **Validation playbook — run before every commit:**
 
 ```bash
-# 1. Import gate + route parity under each agent (expect 146 / 149 / 173 / 148)
-for a in claude_code openclaw hermes antigravity; do
+# 1. Import gate + route parity under each agent. Counts differ per agent by
+#    design and drift with every route added — read them, don't assert a number.
+for a in claude_code codex openclaw hermes antigravity; do
   AGENT_NAME=$a venv/bin/python -c "import server; \
     print('$a', len(server.app.openapi()['paths']))"
 done

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Cursor shows up as session telemetry.
 [![Python](https://img.shields.io/badge/Python-3.12%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.109%2B-009688?style=flat-square&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
 [![License](https://img.shields.io/github/license/quirq-ai/xo-space?style=flat-square)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-100%20unittest-2C2C2C?style=flat-square)](tests/)
+[![Tests](https://img.shields.io/badge/tests-unittest-2C2C2C?style=flat-square)](tests/)
 
 </div>
 
@@ -491,7 +491,7 @@ xo-space/
 │                                     projects, tree, sessions, wiki, secrets, quirq, chat)
 ├── plugin/  .claude-plugin/        Claude Code plugin + marketplace manifest
 ├── .agents/                        the same plugin for Codex, plus this repo's agent skills
-├── tests/                          14 unittest modules, 100 tests
+├── tests/                          flat unittest suite (one TestCase per module)
 ├── scripts/                        install_shared_deps.sh, check_plugin_sync.sh, list_runtime_mounts.py
 ├── utils/                          commands.py, local_port.py
 ├── docs/                           openclaw-usage-sync-flow.md
@@ -546,10 +546,10 @@ Issues and PRs welcome — [CONTRIBUTING.md](CONTRIBUTING.md) is the guide: how 
 
 Changes that touch the adapter contract, the session model, the `.xo` layout, or the `/xo/*.json` views need their documentation in the same PR: `DEVELOPING.md` for architecture, `space_ui/js/views/wiki.js` for the in-app manual.
 
-Before opening a PR:
+Before opening a PR (Linux/macOS, or WSL on Windows):
 
 ```bash
-venv/bin/python -m unittest discover -s tests -t .        # 100 tests
+venv/bin/python -m unittest discover -s tests -t .        # the suite prints its own count
 AGENT_NAME=claude_code venv/bin/python -c "import server" # import gate; repeat per agent
 ./scripts/check_plugin_sync.sh                            # if you touched plugin/ or .agents/
 ```

--- a/README.md
+++ b/README.md
@@ -518,12 +518,13 @@ Per-agent lifecycle scripts live at `config/agents/<name>/agent.sh` (formerly ro
 
 | Where | What |
 |---|---|
-| **In-app Wiki** — `http://localhost:5002/space/#/wiki` | The operating manual, version-matched to the checkout: fifteen sections covering the storage map, installation, watcher internals, complete `.xo` and `.quirq` data catalogs, collaboration, one section per UI tab, and flow-building recipes |
+| **In-app Wiki** — `http://localhost:5002/space/#/wiki` | The operating manual, version-matched to the checkout: sixteen pages covering the storage map, installation, your first run, watcher internals, complete `.xo` and `.quirq` data catalogs, collaboration, one section per UI tab, and flow-building recipes |
 | **`/docs` · `/redoc` · `/openapi.json`** on a running server | The canonical API reference. The shape changes with the active runtime, so a generated page is the only page that can be right |
 | [DEVELOPING.md](DEVELOPING.md) | Engineering guide: broker/adapter architecture, the two planes, the capability loader, adding a new agent, the modularity invariant, the validation playbook |
 | [INSTALLATION.md](INSTALLATION.md) | Prerequisites, the agent CLI, where local data goes, running from a clone, configuration, Windows |
 | [space_ui/README.md](space_ui/README.md) | The Space UI: every module, the view contract, how the folder is served |
 | [plugin/README.md](plugin/README.md) | The Claude Code plugin (`/quirq:status`, `/quirq:install`, `/quirq:start`) and its Codex twin |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute: reporting bugs, dev setup, the ground rules, testing, branches and PRs, review |
 | [AGENTS.md](AGENTS.md) / [CLAUDE.md](CLAUDE.md) | The rules an agent editing this repo has to follow |
 | [docs/openclaw-usage-sync-flow.md](docs/openclaw-usage-sync-flow.md) | How OpenClaw usage reaches the daily sync |
 
@@ -533,7 +534,7 @@ The GitHub wiki has no pages; the in-app Wiki is the maintained one.
 
 ## Contributing
 
-Issues and PRs welcome. `main` is the default branch and where work lands — branch from it and target it. The codebase is ~45k lines of Python across 228 modules plus a build-free ~9k-line front end in `space_ui/`.
+Issues and PRs welcome — [CONTRIBUTING.md](CONTRIBUTING.md) is the guide: how to report a bug, set up a dev environment, the ground rules, and the PR process. Branch from and target **`development`**; `main` is the release branch the one-liner installs from, and maintainers merge `development` into it. The codebase is ~45k lines of Python across 228 modules plus a build-free ~9k-line front end in `space_ui/`.
 
 | Want to… | Start at |
 |---|---|

--- a/tests/test_space_wiki.py
+++ b/tests/test_space_wiki.py
@@ -610,11 +610,17 @@ class SpaceWikiTests(unittest.TestCase):
             "./scripts/check_plugin_sync.sh",
         ):
             self.assertIn(command, guide)
-        # No hard-coded test count: it drifts every week.
-        self.assertNotRegex(guide, r"\b\d{2,3} tests\b")
-        self.assertIn("security/advisories/new", guide)
-
+        # No hard-coded test count anywhere contributors read: it drifts with
+        # every PR, and a stale number is worse than none.
         readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        developing = (ROOT / "DEVELOPING.md").read_text(encoding="utf-8")
+        for doc in (guide, readme, developing):
+            self.assertNotRegex(doc, r"\b\d{2,3} tests\b")
+        self.assertNotIn("expect 146", developing)
+        self.assertIn("security/advisories/new", guide)
+        # Windows contributors are told, up front, to use WSL.
+        self.assertIn("On Windows, use WSL", guide)
+
         self.assertIn("[CONTRIBUTING.md](CONTRIBUTING.md)", readme)
         self.assertNotIn("branch from it and target it", readme)
 

--- a/tests/test_space_wiki.py
+++ b/tests/test_space_wiki.py
@@ -617,7 +617,10 @@ class SpaceWikiTests(unittest.TestCase):
         for doc in (guide, readme, developing):
             self.assertNotRegex(doc, r"\b\d{2,3} tests\b")
         self.assertNotIn("expect 146", developing)
-        self.assertIn("security/advisories/new", guide)
+        # Security reports must never be steered into a public issue body, and
+        # the guide must not link GitHub private reporting until it is enabled.
+        self.assertIn("request for a private channel", guide)
+        self.assertNotIn("security/advisories/new", guide)
         # Windows contributors are told, up front, to use WSL.
         self.assertIn("On Windows, use WSL", guide)
 

--- a/tests/test_space_wiki.py
+++ b/tests/test_space_wiki.py
@@ -590,6 +590,34 @@ class SpaceWikiTests(unittest.TestCase):
         css = (ROOT / "space_ui" / "css" / "wiki.css").read_text(encoding="utf-8")
         self.assertIn(".wiki-link{", css)
 
+    def test_contributing_guide_matches_how_the_repo_actually_works(self) -> None:
+        """CONTRIBUTING.md is the front door for outside contributors. The
+        facts most likely to rot are pinned: the branch model, the four
+        invariants, the validation commands, and the README pointing at it."""
+        guide = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+        # Work lands on development; main is the release branch.
+        self.assertIn("target `development`", guide)
+        self.assertIn("publish-container.yml", guide)
+        self.assertNotIn("Branch from and target **`main`**", guide)
+        for invariant in (
+            "modularity invariant", "Thin routers", "project folder is sacred",
+            "belongs to the watcher",
+        ):
+            self.assertIn(invariant, guide)
+        for command in (
+            "unittest discover -s tests -t .",
+            "bash tests/install_sh_harness.sh",
+            "./scripts/check_plugin_sync.sh",
+        ):
+            self.assertIn(command, guide)
+        # No hard-coded test count: it drifts every week.
+        self.assertNotRegex(guide, r"\b\d{2,3} tests\b")
+        self.assertIn("security/advisories/new", guide)
+
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("[CONTRIBUTING.md](CONTRIBUTING.md)", readme)
+        self.assertNotIn("branch from it and target it", readme)
+
     def test_installer_tells_you_how_to_come_back_and_never_nests(self) -> None:
         """Ctrl-C hands back a bare prompt; the banner must have said how to
         start again. And the one-liner run from inside ./xo-space must reuse


### PR DESCRIPTION
Fixes #31

## Summary

Adds `CONTRIBUTING.md` — the front door for outside contributors — built from the draft in #31, checked line by line against the repo, and shaped after how established projects do it: uv's *ways to help → setup → testing → docs → releases* skeleton; the GitHub docs guide's etiquette (search issues first, what a PR must say, allow maintainer edits, a Windows section); and the widely used contributing template's *ground rules / security first / review process*. GitHub links the file automatically from every new issue and PR once it is on the default branch.

## What changed from the #31 draft

| Draft said | Guide says | Why |
|---|---|---|
| branch from and target `main` | branch from and target **`development`**; `main` is the release branch the one-liner installs from and the container is built from; maintainers merge dev → main | that is how every PR here actually lands — **please confirm this is the intended model** |
| "94 tests" (README said 100; the tree has 103 today) | no number anywhere; "the suite prints its own count" | counts drift weekly; the pin test forbids an `NN tests` literal in README, DEVELOPING.md and CONTRIBUTING.md, and README's badge/tree/comment and DEVELOPING's route-count "expect 146 / 149 / 173 / 148" were removed too |
| "fifteen versioned chapters" | sixteen pages | #38 added *Your first run* |
| security: nothing | a **Security** section: do not describe a vulnerability publicly; open a details-free issue titled "Security: request for a private channel" and a maintainer replies privately | private vulnerability reporting is deliberately not enabled yet, so the guide must not link it (the pin test forbids the advisories URL until it is switched on) |

## What the draft lacked and the guide adds

- What we will push back on, up front, so nobody spends a weekend on it (agent names in core, writes into project folders/`.xo/`, a build step for `space_ui/`, contract changes without an issue, cloud-only behaviour).
- A bug-report checklist specific to this app: install mode, OS/Python/commit, `AGENT_NAME`, exact commands, `/health`, which log to tail, **redact secrets**.
- Both dev-setup paths (`cowork-api.sh` vs in-place `install.sh`), the uv-venv-has-no-pip trap, and **"On Windows, use WSL" as the first sentence of setup**.
- The seven ground rules, a "where things live" map, adding a runtime, and the Space UI rules (cache stamps, wiki in the same PR, `node --check`).
- The real validation commands including `tests/install_sh_harness.sh` and `check_plugin_sync.sh`; a docs-move-with-code table; commit and PR expectations; review order and response expectations; Windows limits; no CLA, inbound = outbound MIT.
- A grouped table of contents (getting involved / working on the code / getting it merged).

## Also in this PR

- README: the Contributing paragraph links to the guide and states the same branch model; the Documentation table lists it and the wiki page count is current; the `# 100 tests` comment, the `tests-100` badge and the tree's "14 modules, 100 tests" are gone.
- DEVELOPING.md: the import-gate loop no longer asserts route counts and now includes `codex`.
- `tests/test_space_wiki.py::test_contributing_guide_matches_how_the_repo_actually_works` pins the branch model, the four invariants, the validation commands, the no-count rule across three docs, the WSL line, the security wording, and the README link.

## Verification

- `tests.test_space_wiki` 23/23; all 13 table-of-contents anchors resolve (script-checked).
- Not verified: rendering on GitHub beyond standard Markdown (lists, tables, anchors).

## Follow-ups, deliberately not here

`.github/ISSUE_TEMPLATE/bug_report.md` and `.github/PULL_REQUEST_TEMPLATE.md` (so reporters fill the checklist by default), a `CODE_OF_CONDUCT.md` if wanted, and — when private vulnerability reporting is enabled — switching the Security section to link it.
