### PR TITLE
Fix the three imported-suite gaps: tarball '..' members, BFF pathlib import, loader fail-loud docs (#37)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@
 - Broker design: core code never names a specific agent. The active backend is
   resolved from `AGENT_NAME` through one seam, the capability loader
   `services/cowork_agent/adapters/loader.py`. A missing capability degrades to an
-  empty/501 shape, never a crash.
+  empty/501 shape, never a crash; a present-but-broken one (its own dependency
+  missing) fails loud at startup rather than being disguised as unsupported.
 - Agent-specific code lives only in three trees:
   `services/cowork_agent/adapters/<name>/`, `config/agents/<name>/`, and
   `config/models/<name>/` (legacy Plane-A model clients). No other file may name

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,10 @@
   backend is resolved from `AGENT_NAME` through one seam — the capability loader
   `services/cowork_agent/adapters/loader.py` (`load_capability` /
   `try_load_capability`). A capability is a module `adapters/<name>/<cap>.py`; a
-  missing one means the router returns its empty/501 shape, never a crash.
+  missing one means the router returns its empty/501 shape, never a crash. A
+  *broken* one — present, but failing to import because a dependency of its own
+  is missing — fails loud at startup instead: a real implementation error must
+  not be disguised as "unsupported" (see `try_load_capability`).
 - **Agent-specific code lives in exactly three trees:**
   `services/cowork_agent/adapters/<name>/`, `config/agents/<name>/`, and
   `config/models/<name>/` (legacy Plane-A model clients). Nowhere else may name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,9 @@ review, and some by tests.
    overwritten on the next tick.
 5. **Backward compatibility.** Endpoint paths, request schemas, and response
    shapes are contracts. A missing capability degrades to an empty/501 shape,
-   never a crash.
+   never a crash — but a capability that exists and fails to import (a missing
+   dependency inside it) fails loud at startup rather than silently dropping
+   routes.
 6. **Never log secrets.** No tokens, keys, cookies, or prompt text in logs or
    error messages. `/health` reports whether a credential is present, never
    its value; keep it that way.

--- a/routers/cowork_agent/bff/xo_projects.py
+++ b/routers/cowork_agent/bff/xo_projects.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timezone
-from pathlib import PurePosixPath
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException
@@ -31,6 +30,7 @@ from services.cowork_agent.project_layout import (
     list_unscaffolded_dirs,
     project_dir_exists,
     read_project_file,
+    relative_path_suffix,
 )
 
 router = APIRouter()
@@ -338,7 +338,7 @@ def project_file(project_id: str, relative_path: str) -> FilePreviewResponse:
             status_code=404,
             detail={"code": "project_not_found", "message": "Project not found."},
         )
-    suffix = PurePosixPath(relative_path or "").suffix.lower()
+    suffix = relative_path_suffix(relative_path)
     if suffix not in PREVIEW_SUFFIXES:
         raise HTTPException(
             status_code=415,

--- a/services/cowork_agent/project_layout.py
+++ b/services/cowork_agent/project_layout.py
@@ -510,6 +510,23 @@ def read_project_file(name: str, relative_path: str, *, max_bytes: int) -> dict 
     }
 
 
+def relative_path_suffix(relative_path: str) -> str:
+    """Lower-cased extension of ``relative_path``'s final segment (``".md"``).
+
+    Empty when there is none. Pure string work, but it is path work all the
+    same, and path work belongs in this module — BFF route modules compare
+    the result against their allowlists instead of importing ``pathlib``
+    themselves (design rule P2).
+    """
+    name = (relative_path or "").replace("\\", "/").rsplit("/", 1)[-1]
+    dot = name.rfind(".")
+    # No dot, a dotfile like ".env" (its name is not a suffix), or a bare
+    # trailing dot — the same cases pathlib's ``suffix`` treats as none.
+    if not 0 < dot < len(name) - 1:
+        return ""
+    return name[dot:].lower()
+
+
 def list_unscaffolded_dirs() -> list[dict]:
     """Directories under xo-projects/ that lack ``.xo/project.json``.
 

--- a/services/cowork_agent/xo_projects_sync/tarball.py
+++ b/services/cowork_agent/xo_projects_sync/tarball.py
@@ -143,14 +143,26 @@ async def build_tarball(project_dir: Path, output_path: Path) -> int:
 def extract_tarball(tarball_path: Path, target_dir: Path) -> None:
     """Extract ``tarball_path`` into ``target_dir``.
 
-    Refuses any member whose resolved destination escapes ``target_dir``
-    (tar-slip defence). Member permissions are preserved; ownership is
+    Refuses any member with an absolute name or a ``..`` path component,
+    and any member whose resolved destination escapes ``target_dir``
+    (tar-slip defence). A ``..`` that still resolves inside the target
+    (``a/../b.txt``) is refused too: our own archives never contain one
+    (build_tarball feeds ``git ls-files`` / walk output), and CPython
+    3.12.14+ refuses to materialise the ``a/..`` intermediate anyway, so
+    such an archive would otherwise die mid-extract with a confusing
+    ``FileExistsError``. Member permissions are preserved (modulo the
+    ``data`` filter clamping setuid/setgid/sticky bits); ownership is
     not (running process owns everything).
     """
     target_dir.mkdir(parents=True, exist_ok=True)
     target_resolved = target_dir.resolve()
     with tarfile.open(tarball_path, "r:gz") as tar:
         for member in tar.getmembers():
+            parts = member.name.split("/")
+            if member.name.startswith("/") or ".." in parts:
+                raise RuntimeError(
+                    f"tarball member {member.name!r} has an absolute or '..' path — refusing"
+                )
             dest = (target_dir / member.name).resolve()
             try:
                 dest.relative_to(target_resolved)
@@ -158,4 +170,6 @@ def extract_tarball(tarball_path: Path, target_dir: Path) -> None:
                 raise RuntimeError(
                     f"tarball member {member.name!r} would extract outside {target_dir} — refusing"
                 )
-        tar.extractall(target_dir)
+        # Explicit filter: the default flipped to "data" in 3.14 and warns on
+        # 3.12/3.13 — pinning it keeps extraction identical across versions.
+        tar.extractall(target_dir, filter="data")

--- a/tests/test_adapters_loader.py
+++ b/tests/test_adapters_loader.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib
+import shutil
+import unittest
+from pathlib import Path
+
+import services.cowork_agent.adapters as adapters_pkg
+from services.cowork_agent.adapters.loader import try_load_capability
+
+# A throwaway adapter package created inside the real adapters directory —
+# the loader resolves capabilities by import path, so there is no other seam
+# to point it at. Underscore-prefixed and removed again in addCleanup; no
+# config/agents manifest exists for it, so discovery never sees it as a real
+# runtime.
+_AGENT = "_loader_contract_test"
+
+
+class TryLoadCapabilityContractTests(unittest.TestCase):
+    """Pin the fail-loud contract of try_load_capability.
+
+    A capability file that simply is not there is "unsupported" and degrades
+    to None. A capability file that exists but cannot import (one of its OWN
+    dependencies is missing) is an implementation error and must re-raise —
+    silently dropping its routes would disguise a broken install as an
+    unsupported feature.
+    """
+
+    def setUp(self) -> None:
+        adapters_dir = Path(adapters_pkg.__file__).resolve().parent
+        self.agent_dir = adapters_dir / _AGENT
+        self.agent_dir.mkdir()
+        self.addCleanup(shutil.rmtree, self.agent_dir, True)
+        self.addCleanup(importlib.invalidate_caches)
+        (self.agent_dir / "__init__.py").write_text("")
+        (self.agent_dir / "working.py").write_text("VALUE = 42\n")
+        (self.agent_dir / "broken.py").write_text(
+            "import a_module_that_does_not_exist_anywhere\n"
+        )
+        importlib.invalidate_caches()
+
+    def test_present_capability_loads(self) -> None:
+        module = try_load_capability("working", agent=_AGENT)
+        self.assertIsNotNone(module)
+        self.assertEqual(module.VALUE, 42)
+
+    def test_missing_capability_degrades_to_none(self) -> None:
+        self.assertIsNone(try_load_capability("absent", agent=_AGENT))
+
+    def test_missing_agent_package_degrades_to_none(self) -> None:
+        self.assertIsNone(try_load_capability("working", agent="_no_such_agent"))
+
+    def test_broken_capability_fails_loud(self) -> None:
+        with self.assertRaises(ModuleNotFoundError) as ctx:
+            try_load_capability("broken", agent=_AGENT)
+        # The error names the actual missing dependency, not the capability.
+        self.assertEqual(
+            ctx.exception.name, "a_module_that_does_not_exist_anywhere"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_layout.py
+++ b/tests/test_project_layout.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import unittest
+
+from services.cowork_agent.project_layout import relative_path_suffix
+
+
+class RelativePathSuffixTests(unittest.TestCase):
+    """The helper mirrors pathlib's ``suffix`` semantics, lower-cased, so the
+    BFF preview allowlist keeps matching exactly what it matched before the
+    path work moved out of the router (design rule P2)."""
+
+    def test_plain_and_nested_paths(self) -> None:
+        self.assertEqual(relative_path_suffix("README.md"), ".md")
+        self.assertEqual(relative_path_suffix("docs/guide/INDEX.HTML"), ".html")
+
+    def test_multi_dot_names_keep_only_the_last_suffix(self) -> None:
+        self.assertEqual(relative_path_suffix("archive.tar.gz"), ".gz")
+
+    def test_no_suffix_cases(self) -> None:
+        self.assertEqual(relative_path_suffix(""), "")
+        self.assertEqual(relative_path_suffix("Makefile"), "")
+        self.assertEqual(relative_path_suffix("dir.d/file"), "")
+        # A dotfile's whole name is its name, not a suffix — and a trailing
+        # dot is not one either. Same as pathlib.
+        self.assertEqual(relative_path_suffix(".env"), "")
+        self.assertEqual(relative_path_suffix("notes/.hidden"), "")
+        self.assertEqual(relative_path_suffix("odd."), "")
+
+    def test_backslashes_separate_like_forward_slashes(self) -> None:
+        self.assertEqual(relative_path_suffix("docs\\guide.md"), ".md")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tarball.py
+++ b/tests/test_tarball.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from services.cowork_agent.xo_projects_sync.tarball import extract_tarball
+
+
+def _write_tar(path: Path, members: dict[str, bytes]) -> None:
+    """Hand-build a tar.gz with exact member names, bypassing build_tarball
+    (which can never emit an unsafe name — that is the point of the test)."""
+    with tarfile.open(path, "w:gz") as tar:
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+
+
+class ExtractTarballTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+        self.target = self.tmp / "restored"
+
+    def test_normal_members_extract(self) -> None:
+        archive = self.tmp / "ok.tar.gz"
+        _write_tar(archive, {"a.txt": b"one", "sub/b.txt": b"two"})
+
+        extract_tarball(archive, self.target)
+
+        self.assertEqual((self.target / "a.txt").read_bytes(), b"one")
+        self.assertEqual((self.target / "sub" / "b.txt").read_bytes(), b"two")
+
+    def test_dotdot_member_is_refused_even_when_it_resolves_inside(self) -> None:
+        # "a/../b.txt" lands inside the target, so the resolve() check alone
+        # allows it — but CPython 3.12.14+ refuses to create the "a/.."
+        # intermediate and the extract dies mid-flight. Refuse it outright.
+        archive = self.tmp / "dotdot.tar.gz"
+        _write_tar(archive, {"a/../b.txt": b"sneaky"})
+
+        with self.assertRaisesRegex(RuntimeError, r"'\.\.'"):
+            extract_tarball(archive, self.target)
+        self.assertFalse((self.target / "b.txt").exists())
+
+    def test_escaping_member_is_refused(self) -> None:
+        archive = self.tmp / "escape.tar.gz"
+        _write_tar(archive, {"../evil.txt": b"outside"})
+
+        with self.assertRaises(RuntimeError):
+            extract_tarball(archive, self.target)
+        self.assertFalse((self.tmp / "evil.txt").exists())
+
+    def test_absolute_member_is_refused(self) -> None:
+        archive = self.tmp / "absolute.tar.gz"
+        _write_tar(archive, {"/tmp/abs.txt": b"outside"})
+
+        with self.assertRaisesRegex(RuntimeError, "absolute"):
+            extract_tarball(archive, self.target)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #37 — all three gaps from the imported suite, one commit per gap.

## What & why

**1. tarball: refuse `..` and absolute members outright** (`services/cowork_agent/xo_projects_sync/tarball.py`)
A member like `a/../b.txt` resolves inside the target, so the `resolve()` tar-slip check allowed it — but CPython ≥ 3.12.14 refuses to create the `a/..` intermediate and `extractall` dies mid-restore with an uncaught `FileExistsError` (a 500). Our own archives can never contain such names (`build_tarball` feeds `git ls-files` / a directory walk), so refusing outright is safer than normalising — exactly what the issue recommends. Also pins `extractall(filter="data")`, which 3.14 already defaults to, so 3.12 and 3.14 extract identically (and the 3.12/3.13 `DeprecationWarning` goes away).

**2. BFF pathlib import** (`routers/cowork_agent/bff/xo_projects.py` → `services/cowork_agent/project_layout.py`)
The one path operation in a BFF route module (design rule P2) — `PurePosixPath(...).suffix.lower()` for the preview allowlist — moved into `project_layout.relative_path_suffix()`, with pathlib-equivalent semantics pinned by tests (multi-dot, dotfile, trailing dot, no dot). No behaviour change.

**3. loader contract: decided fail-loud, docs aligned** (`CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, new test)
Kept the current code — `try_load_capability` swallows only "capability file missing" and re-raises a transitive `ModuleNotFoundError`, so a broken install is not disguised as an unsupported feature (the issue's recommendation). The three docs still described the old cowork-api behaviour ("never a crash", unqualified); they now state both halves. `tests/test_adapters_loader.py` pins the contract executable-ly, so the decision can't silently drift back.

## Contract changes

- `extract_tarball` now raises `RuntimeError` for `..`/absolute members that previously either extracted (`a/../b.txt`, pre-3.12.14) or died with `FileExistsError` (3.12.14+); it also no longer preserves setuid/setgid/sticky bits (the `data` filter), which Python 3.14 already enforced. Only foreign/hand-made archives are affected — restore of xo-space's own backups is unchanged.
- `project_layout.relative_path_suffix()` is a new public service helper; no endpoint shape changed.

## How verified

macOS (Darwin 25.6), Python 3.14.6, bash — `./cowork-api.sh install`-equivalent venv:

- `venv/bin/python -m unittest discover -s tests -t .` — every test added or touched by this PR passes; the only failures are two pre-existing macOS-environment ones that fail identically on a clean `development` checkout (`test_xo_root_identity` trips over macOS's `/var` → `/private/var` symlink when comparing an unresolved tmpdir, and `test_workspace_document.test_the_expensive_sink_self_throttles` is wall-clock-sensitive under load). Filed separately.
- Import gate: `AGENT_NAME=<a> venv/bin/python -c "import server"` for claude_code / codex / openclaw / hermes / antigravity — all import with the documented route counts (claude_code 164, codex 161, openclaw 164, hermes 188, antigravity 163).
- Not run: Windows/WSL, and the private `tests2/` imported suite (not in the repo) — the `xfail(strict=True)` markers there should now flip on all three and want removing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
