### PR TITLE
fix(tests): two suite tests fail on a clean macOS checkout (#46)

### DIFF
--- a/tests/test_workspace_document.py
+++ b/tests/test_workspace_document.py
@@ -94,10 +94,25 @@ class WorkspaceViewFileTests(unittest.TestCase):
 
     def test_the_expensive_sink_self_throttles(self) -> None:
         """The watcher ticks every second; these views walk every mapped file
-        in the workspace, so they must not rebuild on every tick."""
+        in the workspace, so they must not rebuild on every tick.
+
+        The window is pinned wide and HOME is pointed at the temp dir:
+        ``apply()`` stamps ``_last_build`` before it builds, and the sessions
+        view scans the session stores under the real ``$HOME``, so on a
+        developer machine with a large ``~/.claude`` the first build could
+        outlast the default 30 s window and make the second call due again —
+        a wall-clock flake, and a hermeticity leak besides."""
         with tempfile.TemporaryDirectory() as tmp:
             root = _workspace(tmp)
-            with patch.dict(os.environ, {"XO_PROJECTS_ROOT": str(root)}, clear=False):
+            with patch.dict(
+                os.environ,
+                {
+                    "XO_PROJECTS_ROOT": str(root),
+                    "XO_VIEWS_REFRESH_S": "3600",
+                    "HOME": tmp,
+                },
+                clear=False,
+            ):
                 views._last_build = 0.0
                 self.assertTrue(views.apply())     # first tick builds
                 self.assertFalse(views.apply())    # second is not due

--- a/tests/test_xo_root_identity.py
+++ b/tests/test_xo_root_identity.py
@@ -131,7 +131,10 @@ class MixedCaseFolderTests(unittest.TestCase):
 
     def test_traversal_still_collapses_to_a_safe_leaf(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
+            # Resolved: xo_projects_root() resolves what it returns, and on
+            # macOS $TMPDIR sits behind the /var -> /private/var symlink, so
+            # comparing against the unresolved tmp path can never succeed.
+            root = Path(tmp).resolve()
             with patch.dict(os.environ, {"XO_PROJECTS_ROOT": str(root)}, clear=False):
                 for hostile in ("../etc", "..", ".", "", "a/b", ".hidden"):
                     resolved = project_layout.project_dir(hostile)


### PR DESCRIPTION
Fixes #46 — both failures reproduce on a clean `development` checkout on macOS with no local changes; neither is code behaviour, both are test-environment assumptions.

## What & why

**`test_xo_root_identity.test_traversal_still_collapses_to_a_safe_leaf`** — compared `project_dir()`'s parent (resolved, because `xo_projects_root()` resolves) against the *unresolved* tempdir. On macOS `$TMPDIR` lives behind the `/var → /private/var` symlink, so the equality could never hold: deterministic failure on every Mac, invisible on Linux. The test now resolves its root the same way the code under test does.

**`test_workspace_document.test_the_expensive_sink_self_throttles`** — assumed `apply()` + the second call fit inside the default 30 s window. But `apply()` stamps `_last_build` *before* building, and the sessions view scans the session stores under the real `$HOME` — on a developer machine with a large `~/.claude` the first build outlasts the window, the second call is legitimately due, and the assertion flips under load. The test now pins the window wide (`XO_VIEWS_REFRESH_S=3600`, using the sink's own knob) and points `HOME` at the temp dir — which also closes a hermeticity leak: the suite was walking the developer's real session stores (CONTRIBUTING: tests are hermetic, temp dirs only).

No production code touched; the throttle behaviour itself is still exercised (build once, second call inside the window refused).

## How verified

macOS (Darwin 25.6), Python 3.14.6: both modules previously failed on clean `development` (tracebacks in #46); with this PR `venv/bin/python -m unittest tests.test_xo_root_identity tests.test_workspace_document` → Ran 19, OK. The `HOME` redirect is visible in the telemetry providers' own log lines, which now probe the temp dir instead of the real home. Not run: Linux (the resolve() change is a no-op where tmp paths contain no symlink; the env pins are platform-neutral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)