### PR TITLE
chore: add issue templates (bug report, feature request, new runtime)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,107 @@
+name: Bug report
+description: Something in XO Space is broken or behaving unexpectedly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Please fill in the fields below so the bug can be reproduced.
+        Before opening, search [open and closed issues](https://github.com/quirq-ai/xo-space/issues) for a twin.
+
+        > **Security:** if this is a vulnerability (credentials, a path escape, one user reaching another's data),
+        > do **not** describe it here. Open a blank issue titled **"Security: request for a private channel"**
+        > with no details, and a maintainer will reply with a private channel.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Area
+      description: Which part of XO Space is affected?
+      options:
+        - Server / API
+        - Watcher / .xo data
+        - Space UI (browser)
+        - Chat (a specific runtime)
+        - Sessions / usage / cost telemetry
+        - Installer / update / restart
+        - Connector (gdrive / onedrive / github / vercel / manus)
+        - xo-projects sync / backup
+        - Docs / Wiki
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How did you install / run it?
+      options:
+        - curl -fsSL https://quirq.ai/install | sh
+        - ./install.sh from a clone
+        - ./cowork-api.sh dev
+        - ./quirq (Docker / compose.local.yml)
+        - Hosted / managed workspace
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        OS and version (Windows means WSL), Python version
+        (`./venv/bin/python --version`), and the checkout commit
+        (`git rev-parse --short HEAD`, or the *Installed* line on the Setup tab).
+      placeholder: "macOS 14 · Python 3.12.4 · commit 105eeb0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Active runtime (AGENT_NAME)
+      description: Which agent backend was active? Not needed if the bug is UI-only.
+      options:
+        - claude_code
+        - codex
+        - openclaw
+        - hermes
+        - antigravity
+        - cursor (telemetry only)
+        - Other / none
+    validations:
+      required: false
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: What happened?
+      description: "What you did, what you expected, and what actually happened. Include exact commands and the exact text of any error."
+      placeholder: |
+        1. Ran ...
+        2. Expected ...
+        3. Instead saw ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: |
+        `curl -s localhost:5002/health` and the tail of the server log —
+        `<state root>/quirq.log` (installer path) or `/tmp/xo-space.log` (`cowork-api.sh`).
+
+        **Redact tokens and keys before pasting** — `/health` reports presence, not values,
+        on purpose; logs may not.
+      placeholder: "Paste redacted evidence here."
+    validations:
+      required: false
+
+  - type: textarea
+    id: ui
+    attributes:
+      label: UI-only details
+      description: If this is a Space UI bug — browser and version, a screenshot, and the Wiki tab page for that view if it contradicts what you saw.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+# Issue template config — see CONTRIBUTING.md "Reporting a bug" and "Security".
+#
+# blank_issues_enabled stays TRUE on purpose: CONTRIBUTING.md asks people to
+# report a vulnerability by opening a BLANK issue titled
+# "Security: request for a private channel" with no details. Disabling blank
+# issues would remove that path.
+blank_issues_enabled: true
+
+contact_links:
+  - name: XO Space documentation
+    url: https://docs.xo.builders
+    about: Product docs, architecture, installing Space, and the UI walkthrough.
+  - name: Contributing guide
+    url: https://github.com/quirq-ai/xo-space/blob/main/CONTRIBUTING.md
+    about: Ground rules, dev setup, and the PR process before you open an issue.
+  - name: Security
+    url: https://github.com/quirq-ai/xo-space/issues/new
+    about: 'Do NOT describe a vulnerability in a public issue. Open a blank issue titled "Security: request for a private channel" with no details, and a maintainer will reply with a private channel.'

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,79 @@
+name: Feature / capability request
+description: A capability you want XO Space to add or improve — measuring, attributing, or guarding agent work.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        XO Space measures and attributes what coding agents deliver. Tell us what you want to
+        see, measure, or guard. The more concrete the better — say which surface it touches and
+        which runtimes it must work with.
+
+  - type: dropdown
+    id: theme
+    attributes:
+      label: What does this improve?
+      description: Pick the closest theme (choose the best fit).
+      options:
+        - Cost of tool calling (compute / tokens / latency per agent-to-tool interaction)
+        - Attribution (token spend mapped to agent / model / provider / workflow / human)
+        - Codebase drift (detecting silent file changes or refactors without review)
+        - Engineer performance (separating agent output from human validation)
+        - Security / runtime auditing (what the agent touched, who saw it, on untrusted hardware)
+        - Something else
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface?
+      options:
+        - Server API (/api/*)
+        - Watcher / .xo data model
+        - Space UI (browser)
+        - Sessions / usage / cost telemetry
+        - xo-projects sync
+        - New connector
+        - New runtime
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Which runtimes must it work with?
+      options:
+        - All supported
+        - A specific one (name it below)
+        - Doesn't matter
+    validations:
+      required: false
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem / outcome you're after
+      description: What are you trying to know or control that XO Space doesn't do today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: >
+        What should XO Space do? A new endpoint, a new .xo field, a new UI view, a watcher change?
+        Note anything that must stay backward compatible (existing endpoints / .xo shape) or that
+        must work in both local and hosted (cloud) deployments.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, links, the workflow this is part of, or a rough sense of how much it matters to you.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/new_runtime.yml
+++ b/.github/ISSUE_TEMPLATE/new_runtime.yml
@@ -1,0 +1,63 @@
+name: New runtime
+description: Add support for a new coding-agent runtime.
+labels: ["new-runtime"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Adding a runtime is designed to be **two folders and zero core edits** (DEVELOPING.md §4):
+        `config/agents/<name>/` and `services/cowork_agent/adapters/<name>/`. Say what the runtime
+        is and what you can provide; we'll help shape the two folders.
+
+  - type: input
+    id: name
+    attributes:
+      label: Runtime name
+      description: The AGENT_NAME you'd use, e.g. `claude_code`, `hermes`.
+    validations:
+      required: true
+
+  - type: input
+    id: binary
+    attributes:
+      label: Binary / CLI or gateway
+      description: How is it invoked — a CLI subprocess, or an HTTP gateway + port?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: chat
+    attributes:
+      label: Chat support
+      options:
+        - Yes — can run a turn via CLI / gateway
+        - No — read-only telemetry only
+    validations:
+      required: true
+
+  - type: dropdown
+    id: telemetry
+    attributes:
+      label: Session / usage telemetry
+      options:
+        - Yes — exposes sessions, tokens, cost
+        - Partial — sessions only
+        - No
+    validations:
+      required: true
+
+  - type: textarea
+    id: storage
+    attributes:
+      label: Where does it store sessions?
+      description: On-disk session store location and format (JSONL, DB, files), so the watcher can read it.
+    validations:
+      required: false
+
+  - type: textarea
+    id: plan
+    attributes:
+      label: Your plan / what you can provide
+      description: Which capabilities you intend to add (adapter, usage, models, sessions, routes, ...) and whether you'll implement it yourself.
+    validations:
+      required: false


### PR DESCRIPTION
Adds structured GitHub issue templates under .github/ISSUE_TEMPLATE/: bug report, feature/capability request, and new-runtime forms, plus a config.yml with helpful links. No application code touched.