### PR TITLE
fix(tests): suite is red on clean development — re-pin first-run docs after the README rewrite

### DIFF
--- a/tests/test_space_wiki.py
+++ b/tests/test_space_wiki.py
@@ -583,13 +583,19 @@ class SpaceWikiTests(unittest.TestCase):
 
         guide = (ROOT / "INSTALLATION.md").read_text(encoding="utf-8")
         readme = (ROOT / "README.md").read_text(encoding="utf-8")
-        for doc in (guide, readme, wiki):
+        for doc in (guide, wiki):
             self.assertIn("Your first run", doc)
             self.assertIn("/api/files/mkdir", doc)
             # The first run is only empty if the directory was: a busy
             # directory lists every folder as an unscaffolded project, and
-            # all three tellings must say so.
+            # both full tellings must say so.
             self.assertIn("unscaffolded", doc)
+        # The 2026-08-29 README rewrite tells the short version on purpose
+        # and hands off to the guide: pin the empty state, the "First run"
+        # paragraph, and the hand-off link instead of the full walkthrough.
+        self.assertIn("First run", readme)
+        self.assertIn("No projects in this workspace yet", readme)
+        self.assertIn("INSTALLATION.md", readme)
         self.assertIn("## Your first run", guide)
         self.assertIn("uv pip install --python", guide)
         # The cross-link buttons need a rule, or they render as stock buttons.


### PR DESCRIPTION
The suite currently fails on a clean `development` checkout: the README rewrite in 105eeb0 replaced the full **Your first run** walkthrough with a short **First run** paragraph that hands off to INSTALLATION.md, and `test_first_run_is_explained_in_wiki_docs_and_the_empty_state` still pins the old wording (`Your first run` / `/api/files/mkdir` / `unscaffolded` in the README).

Per the repo's own rule — *when a rename breaks a pin, update the pin to the new name rather than reinstating the old one* — the full pins now apply to INSTALLATION.md and the wiki only, and the README is pinned on what it now promises: the **First run** paragraph, the *No projects in this workspace yet* empty state, and the hand-off link to the guide. No production code or docs touched.

## How verified

macOS (Darwin 25.6), Python 3.14.6: `tests.test_space_wiki` was `FAILED (failures=1)` on clean `development` (`'Your first run' not found in …`), now `Ran 23, OK`. Grepped `tests/` for other README readers — `test_space_dashboard` and `test_workspace_document` only use fixture READMEs and pass.

Worth merging early: every contributor who clones `development` today starts from a red suite, which CONTRIBUTING's 'how you verified it' flow depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)