### PR TITLE
fix: close issue #37 reliability gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,9 @@
 
 - Broker design: core code never names a specific agent. The active backend is
   resolved from `AGENT_NAME` through one seam, the capability loader
-  `services/cowork_agent/adapters/loader.py`. A missing capability degrades to an
-  empty/501 shape, never a crash.
+  `services/cowork_agent/adapters/loader.py`. A missing capability module
+  degrades to an empty/501 shape; an import error inside an existing module
+  fails loudly so a broken installation is not misreported as unsupported.
 - Agent-specific code lives only in three trees:
   `services/cowork_agent/adapters/<name>/`, `config/agents/<name>/`, and
   `config/models/<name>/` (legacy Plane-A model clients). No other file may name

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,8 @@
   backend is resolved from `AGENT_NAME` through one seam — the capability loader
   `services/cowork_agent/adapters/loader.py` (`load_capability` /
   `try_load_capability`). A capability is a module `adapters/<name>/<cap>.py`; a
-  missing one means the router returns its empty/501 shape, never a crash.
+  missing module means the router returns its empty/501 shape, while an import
+  error inside an existing module fails loudly instead of hiding a broken install.
 - **Agent-specific code lives in exactly three trees:**
   `services/cowork_agent/adapters/<name>/`, `config/agents/<name>/`, and
   `config/models/<name>/` (legacy Plane-A model clients). Nowhere else may name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,8 +173,8 @@ review, and some by tests.
    else — endpoints, the UI, agents — reads. Anything else written there is
    overwritten on the next tick.
 5. **Backward compatibility.** Endpoint paths, request schemas, and response
-   shapes are contracts. A missing capability degrades to an empty/501 shape,
-   never a crash.
+   shapes are contracts. A missing capability module degrades to an empty/501
+   shape; an import error inside an existing module fails loudly.
 6. **Never log secrets.** No tokens, keys, cookies, or prompt text in logs or
    error messages. `/health` reports whether a credential is present, never
    its value; keep it that way.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -101,7 +101,9 @@ mod = load_capability("usage", agent="hermes")   # target a specific agent
 
 A **capability** is just a module `adapters/<name>/<capability>.py`. A core
 router asks for a capability and forwards to it; it never branches on the agent
-name. A missing capability is normal — the router returns its empty/501 shape.
+name. A missing capability module is normal — the router returns its empty/501
+shape. An import error inside an existing capability is an implementation error
+and is raised rather than being misreported as unsupported.
 
 Capabilities in use today:
 

--- a/routers/cowork_agent/bff/xo_projects.py
+++ b/routers/cowork_agent/bff/xo_projects.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timezone
-from pathlib import PurePosixPath
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException
@@ -31,6 +30,7 @@ from services.cowork_agent.project_layout import (
     list_projects,
     list_unscaffolded_dirs,
     project_dir_exists,
+    relative_path_suffix,
     read_project_file,
 )
 
@@ -408,7 +408,7 @@ def project_file(
     # The gate judges the name the content will carry: the historical
     # name when a version is asked for, today's name otherwise.
     gate_name = commit_path if (commit and commit_path) else relative_path
-    suffix = PurePosixPath(gate_name or "").suffix.lower()
+    suffix = relative_path_suffix(gate_name or "").lower()
     if suffix not in PREVIEW_SUFFIXES:
         raise HTTPException(
             status_code=415,

--- a/services/cowork_agent/project_layout.py
+++ b/services/cowork_agent/project_layout.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import json
 import os
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from services.cowork_agent.helpers import normalize_agent_id
 
@@ -365,6 +365,11 @@ def list_projects() -> list[dict]:
 def project_dir_exists(name: str) -> bool:
     """True iff the project root directory exists (scaffolded or not)."""
     return project_dir(name).is_dir()
+
+
+def relative_path_suffix(relative_path: str) -> str:
+    """Return a project-relative path's final suffix without filesystem access."""
+    return PurePosixPath(relative_path).suffix
 
 
 def list_project_tree(name: str, relative_path: str = "") -> dict | None:

--- a/services/cowork_agent/xo_projects_sync/tarball.py
+++ b/services/cowork_agent/xo_projects_sync/tarball.py
@@ -140,21 +140,58 @@ async def build_tarball(project_dir: Path, output_path: Path) -> int:
     return output_path.stat().st_size
 
 
+def _member_path_parts(value: str, *, label: str) -> tuple[str, ...]:
+    """Return safe archive-relative path parts for a member or hard-link target."""
+    normalized = value.replace("\\", "/")
+    if normalized.startswith("/"):
+        raise RuntimeError(f"tarball {label} {value!r} is absolute — refusing")
+    parts = tuple(part for part in normalized.split("/") if part not in {"", "."})
+    if not parts:
+        raise RuntimeError(f"tarball {label} {value!r} is empty — refusing")
+    if ".." in parts:
+        raise RuntimeError(f"tarball {label} {value!r} contains '..' — refusing")
+    return parts
+
+
+def _is_descendant_of(parts: tuple[str, ...], parent: tuple[str, ...]) -> bool:
+    return parts[:len(parent)] == parent
+
+
 def extract_tarball(tarball_path: Path, target_dir: Path) -> None:
     """Extract ``tarball_path`` into ``target_dir``.
 
-    Refuses any member with a ``..`` path component or whose resolved
-    destination escapes ``target_dir`` (tar-slip defence). Member permissions
-    are preserved; ownership is not (running process owns everything).
+    Refuses unsafe member paths and hard-link targets before writing anything.
+    Symlink targets are preserved verbatim because project snapshots can
+    legitimately contain both relative and absolute links; no later member may
+    write through a symlink in the archive. Extraction explicitly uses
+    tarfile's ``tar`` filter so this policy does not change with Python's
+    default extraction filter.
     """
     target_dir.mkdir(parents=True, exist_ok=True)
     target_resolved = target_dir.resolve()
     with tarfile.open(tarball_path, "r:gz") as tar:
+        symlink_paths: list[tuple[str, ...]] = []
         for member in tar.getmembers():
-            if ".." in member.name.replace("\\", "/").split("/"):
+            member_parts = _member_path_parts(member.name, label="member")
+            if any(_is_descendant_of(member_parts, link) for link in symlink_paths):
                 raise RuntimeError(
-                    f"tarball member {member.name!r} contains '..' — refusing"
+                    f"tarball member {member.name!r} writes through a symlink — refusing"
                 )
+
+            if member.islnk():
+                link_parts = _member_path_parts(member.linkname, label="hard-link target")
+                if any(_is_descendant_of(link_parts, link) for link in symlink_paths):
+                    raise RuntimeError(
+                        f"tarball hard-link target {member.linkname!r} crosses a symlink — refusing"
+                    )
+
+            # A symbolic link's target is intentionally not constrained to
+            # target_dir: tracked project links and virtualenv links may point
+            # outside it. The member-path check above prevents later archive
+            # entries from using such a link to write outside target_dir.
+            if member.issym():
+                symlink_paths.append(member_parts)
+
             dest = (target_dir / member.name).resolve()
             try:
                 dest.relative_to(target_resolved)
@@ -162,4 +199,8 @@ def extract_tarball(tarball_path: Path, target_dir: Path) -> None:
                 raise RuntimeError(
                     f"tarball member {member.name!r} would extract outside {target_dir} — refusing"
                 )
-        tar.extractall(target_dir)
+
+        try:
+            tar.extractall(target_dir, filter="tar")
+        except tarfile.FilterError as exc:
+            raise RuntimeError(f"tarball member rejected during extraction: {exc}") from exc

--- a/services/cowork_agent/xo_projects_sync/tarball.py
+++ b/services/cowork_agent/xo_projects_sync/tarball.py
@@ -143,14 +143,18 @@ async def build_tarball(project_dir: Path, output_path: Path) -> int:
 def extract_tarball(tarball_path: Path, target_dir: Path) -> None:
     """Extract ``tarball_path`` into ``target_dir``.
 
-    Refuses any member whose resolved destination escapes ``target_dir``
-    (tar-slip defence). Member permissions are preserved; ownership is
-    not (running process owns everything).
+    Refuses any member with a ``..`` path component or whose resolved
+    destination escapes ``target_dir`` (tar-slip defence). Member permissions
+    are preserved; ownership is not (running process owns everything).
     """
     target_dir.mkdir(parents=True, exist_ok=True)
     target_resolved = target_dir.resolve()
     with tarfile.open(tarball_path, "r:gz") as tar:
         for member in tar.getmembers():
+            if ".." in member.name.replace("\\", "/").split("/"):
+                raise RuntimeError(
+                    f"tarball member {member.name!r} contains '..' — refusing"
+                )
             dest = (target_dir / member.name).resolve()
             try:
                 dest.relative_to(target_resolved)

--- a/tests/test_issue_37_gaps.py
+++ b/tests/test_issue_37_gaps.py
@@ -1,0 +1,59 @@
+"""Regression coverage for the contracts clarified in issue #37."""
+from __future__ import annotations
+
+import io
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from services.cowork_agent.adapters import loader
+from services.cowork_agent.project_layout import relative_path_suffix
+from services.cowork_agent.xo_projects_sync.tarball import extract_tarball
+
+
+class RelativePathSuffixTests(unittest.TestCase):
+    def test_preserves_posix_path_suffix_rules(self) -> None:
+        self.assertEqual(relative_path_suffix("docs/guide.MD"), ".MD")
+        self.assertEqual(relative_path_suffix(".env"), "")
+
+
+class CapabilityLoaderTests(unittest.TestCase):
+    def test_existing_capability_with_missing_dependency_fails_loudly(self) -> None:
+        missing = ModuleNotFoundError("No module named 'fcntl'")
+        missing.name = "fcntl"
+
+        with patch.object(loader.importlib, "import_module", side_effect=missing):
+            with self.assertRaisesRegex(ModuleNotFoundError, "fcntl"):
+                loader.try_load_capability("routes", agent="demo")
+
+    def test_missing_capability_module_remains_optional(self) -> None:
+        expected = "services.cowork_agent.adapters.demo.routes"
+        missing = ModuleNotFoundError(f"No module named '{expected}'")
+        missing.name = expected
+
+        with patch.object(loader.importlib, "import_module", side_effect=missing):
+            self.assertIsNone(loader.try_load_capability("routes", agent="demo"))
+
+
+class TarballExtractionTests(unittest.TestCase):
+    def test_refuses_an_internal_dotdot_member_before_extracting(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tarball = root / "snapshot.tar.gz"
+            target = root / "target"
+            payload = b"must not be written"
+            member = tarfile.TarInfo("a/../b.txt")
+            member.size = len(payload)
+            with tarfile.open(tarball, "w:gz") as tar:
+                tar.addfile(member, io.BytesIO(payload))
+
+            with self.assertRaisesRegex(RuntimeError, "contains '..'"):
+                extract_tarball(tarball, target)
+
+            self.assertFalse((target / "b.txt").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue_37_gaps.py
+++ b/tests/test_issue_37_gaps.py
@@ -2,15 +2,33 @@
 from __future__ import annotations
 
 import io
+import os
 import tarfile
 import tempfile
 import unittest
+import warnings
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+from fastapi import HTTPException
+
+from routers.cowork_agent import xo_projects_sync as sync_router
 from services.cowork_agent.adapters import loader
 from services.cowork_agent.project_layout import relative_path_suffix
 from services.cowork_agent.xo_projects_sync.tarball import extract_tarball
+
+
+def _add_file(tar: tarfile.TarFile, name: str, payload: bytes) -> None:
+    member = tarfile.TarInfo(name)
+    member.size = len(payload)
+    tar.addfile(member, io.BytesIO(payload))
+
+
+def _add_symlink(tar: tarfile.TarFile, name: str, target: str) -> None:
+    member = tarfile.TarInfo(name)
+    member.type = tarfile.SYMTYPE
+    member.linkname = target
+    tar.addfile(member)
 
 
 class RelativePathSuffixTests(unittest.TestCase):
@@ -38,21 +56,116 @@ class CapabilityLoaderTests(unittest.TestCase):
 
 
 class TarballExtractionTests(unittest.TestCase):
+    def test_preserves_relative_and_absolute_symlinks_without_a_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tarball = root / "snapshot.tar.gz"
+            target = root / "target"
+            with tarfile.open(tarball, "w:gz") as tar:
+                _add_symlink(tar, "shared", "../common")
+                _add_symlink(tar, "venv/bin/python", "/usr/bin/python3")
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", DeprecationWarning)
+                extract_tarball(tarball, target)
+
+            self.assertEqual(os.readlink(target / "shared"), "../common")
+            self.assertEqual(os.readlink(target / "venv/bin/python"), "/usr/bin/python3")
+
     def test_refuses_an_internal_dotdot_member_before_extracting(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             tarball = root / "snapshot.tar.gz"
             target = root / "target"
-            payload = b"must not be written"
-            member = tarfile.TarInfo("a/../b.txt")
-            member.size = len(payload)
             with tarfile.open(tarball, "w:gz") as tar:
-                tar.addfile(member, io.BytesIO(payload))
+                _add_file(tar, "a/../b.txt", b"must not be written")
 
             with self.assertRaisesRegex(RuntimeError, "contains '..'"):
                 extract_tarball(tarball, target)
 
             self.assertFalse((target / "b.txt").exists())
+
+    def test_refuses_an_absolute_member_name_before_extracting(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tarball = root / "snapshot.tar.gz"
+            target = root / "target"
+            with tarfile.open(tarball, "w:gz") as tar:
+                _add_file(tar, "/outside.txt", b"must not be written")
+
+            with self.assertRaisesRegex(RuntimeError, "is absolute"):
+                extract_tarball(tarball, target)
+
+            self.assertFalse((root / "outside.txt").exists())
+
+    def test_refuses_a_hard_link_target_outside_the_archive_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tarball = root / "snapshot.tar.gz"
+            target = root / "target"
+            with tarfile.open(tarball, "w:gz") as tar:
+                member = tarfile.TarInfo("linked.txt")
+                member.type = tarfile.LNKTYPE
+                member.linkname = "../outside.txt"
+                tar.addfile(member)
+
+            with self.assertRaisesRegex(RuntimeError, "hard-link target.*contains '..'"):
+                extract_tarball(tarball, target)
+
+            self.assertFalse((root / "outside.txt").exists())
+
+    def test_refuses_a_member_that_writes_through_a_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tarball = root / "snapshot.tar.gz"
+            target = root / "target"
+            outside = root / "outside"
+            with tarfile.open(tarball, "w:gz") as tar:
+                _add_symlink(tar, "linked", "../outside")
+                _add_file(tar, "linked/payload.txt", b"must not be written")
+
+            with self.assertRaisesRegex(RuntimeError, "writes through a symlink"):
+                extract_tarball(tarball, target)
+
+            self.assertFalse((outside / "payload.txt").exists())
+            self.assertFalse((target / "linked").exists())
+
+    def test_converts_tarfile_filter_errors_to_runtime_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tarball = root / "snapshot.tar.gz"
+            target = root / "target"
+            with tarfile.open(tarball, "w:gz") as tar:
+                _add_file(tar, "safe.txt", b"safe")
+
+            with patch.object(
+                tarfile.TarFile,
+                "extractall",
+                side_effect=tarfile.FilterError("blocked by filter"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "blocked by filter"):
+                    extract_tarball(tarball, target)
+
+
+class RestoreRouteTests(unittest.IsolatedAsyncioTestCase):
+    async def test_runtime_errors_use_the_restore_failed_shape(self) -> None:
+        with patch.object(
+            sync_router,
+            "_require_config_and_auth",
+            new=AsyncMock(return_value=(object(), object(), "owner")),
+        ), patch.object(
+            sync_router.restore_mod,
+            "restore_one",
+            new=AsyncMock(side_effect=RuntimeError("unsafe tarball")),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await sync_router.restore_project("demo")
+
+        self.assertEqual(raised.exception.status_code, 500)
+        self.assertEqual(
+            raised.exception.detail,
+            {"error": "restore_failed", "detail": "unsafe tarball"},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- moves the BFF preview suffix operation into the project-layout service, keeping filesystem/path utilities out of the route module
- documents and regression-tests the fail-loud contract for missing dependencies inside an existing optional capability, while preserving graceful handling for an absent capability module
- makes snapshot extraction explicit and version-stable with `filter="tar"`, while preserving legitimate relative and absolute symlinks
- rejects unsafe member paths, unsafe hard-link targets, and archive entries that would write through an earlier symlink; filter rejections are converted to the restore route's `RuntimeError` error contract

## Verification
- `AGENT_NAME=openclaw QUIRQ_SKIP_BOOT_INSTALL=1 venv/bin/python -m unittest discover -s tests -t . -v` (134 tests)
- `AGENT_NAME=openclaw QUIRQ_SKIP_BOOT_INSTALL=1 venv/bin/python -m compileall -q routers services`
- `AGENT_NAME=openclaw QUIRQ_SKIP_BOOT_INSTALL=1 venv/bin/python -c 'import server; print("server import passed")'`

Fixes #37.