### PR TITLE
fix: surface expired Claude sessions for recovery

### DIFF
--- a/routers/auth/claude_setup_token.py
+++ b/routers/auth/claude_setup_token.py
@@ -67,6 +67,7 @@ except ImportError:
     _HAS_PTY = False
 
 from fastapi import APIRouter, HTTPException
+from services.cowork_agent.adapters.claude_code.auth_state import clear_auth_failure
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -815,6 +816,7 @@ async def claude_setup_token(force: bool = False):
                     clear_session()
                     if returncode == 0:
                         print("[setup-token] login successful (exit 0)")
+                        clear_auth_failure()
                         # Compat shim for the currently-deployed frontend, which
                         # detects success by scraping stdout for the legacy
                         # `claude setup-token` string and ignores this `done`

--- a/services/cowork_agent/adapters/claude_code/adapter.py
+++ b/services/cowork_agent/adapters/claude_code/adapter.py
@@ -9,6 +9,10 @@ from pathlib import Path
 from typing import Any, AsyncIterator
 
 from services.cowork_agent.adapters.base import BaseAgentAdapter
+from services.cowork_agent.adapters.claude_code.auth_state import (
+    clear_auth_failure,
+    record_auth_failure,
+)
 from services.cowork_agent.helpers import iso_now
 from services.cowork_agent.project_layout import (
     project_dir as _xo_project_dir,
@@ -379,9 +383,13 @@ class ClaudeCodeAdapter(BaseAgentAdapter):
             raise RuntimeError(f"ClaudeCodeAdapter.run timed out after {timeout}s")
 
         if proc.returncode != 0:
+            detail = stderr.decode(errors="replace")
+            record_auth_failure(detail)
             raise RuntimeError(
-                f"Claude CLI exited with code {proc.returncode}: {stderr.decode()[:500]}"
+                f"Claude CLI exited with code {proc.returncode}: {detail[:500]}"
             )
+
+        clear_auth_failure()
 
         try:
             data = json.loads(stdout)
@@ -455,6 +463,7 @@ class ClaudeCodeAdapter(BaseAgentAdapter):
             )
 
             native_session_id: str | None = None
+            saw_auth_failure = False
             response_parts: list[str] = []
             result_text: str = ""
             usage: dict = {}
@@ -464,6 +473,9 @@ class ClaudeCodeAdapter(BaseAgentAdapter):
                 event = parse_stream_line(raw_line)
                 if event is None:
                     continue
+
+                if event.get("type") == "error":
+                    saw_auth_failure = record_auth_failure(event.get("error")) is not None
 
                 if event.get("type") == "session_id":
                     # Early ``system``/``init`` event — claude emits this on the
@@ -494,6 +506,11 @@ class ClaudeCodeAdapter(BaseAgentAdapter):
                 yield event
 
             await proc.wait()
+            if proc.returncode != 0:
+                detail = (await proc.stderr.read()).decode(errors="replace")
+                saw_auth_failure = record_auth_failure(detail) is not None or saw_auth_failure
+            if proc.returncode == 0 and not saw_auth_failure:
+                clear_auth_failure()
 
             # Fall back to result event text when no token events were captured.
             if not response_parts and result_text:

--- a/services/cowork_agent/adapters/claude_code/auth_state.py
+++ b/services/cowork_agent/adapters/claude_code/auth_state.py
@@ -1,0 +1,65 @@
+"""Persist the last observed Claude native-login failure without storing CLI output."""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+AUTH_FAILURE_FILE = Path("/tmp/xo-claude-auth-failure.json")
+
+
+def auth_failure_reason(detail: str | None) -> str | None:
+    """Classify CLI output that conclusively shows native authentication failed."""
+    message = (detail or "").lower()
+    if "oauth session expired" in message:
+        return "session_expired"
+    if any(marker in message for marker in (
+        "failed to authenticate",
+        "authentication required",
+        "not logged in",
+    )):
+        return "authentication_failed"
+    return None
+
+
+def record_auth_failure(detail: str | None) -> str | None:
+    """Record a classified failure, returning its reason; ignore unrelated errors."""
+    reason = auth_failure_reason(detail)
+    if reason is None:
+        return None
+    try:
+        AUTH_FAILURE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            "w", dir=AUTH_FAILURE_FILE.parent, delete=False,
+            prefix=f".{AUTH_FAILURE_FILE.name}.", suffix=".tmp",
+        ) as tmp:
+            json.dump({"reason": reason}, tmp)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp.name, AUTH_FAILURE_FILE)
+    except OSError:
+        # The auth result must never depend on whether this diagnostic state can
+        # be persisted (for example, in a read-only temporary filesystem).
+        return None
+    return reason
+
+
+def last_auth_failure_reason() -> str | None:
+    """Return the last recorded native-login failure reason, if any."""
+    try:
+        data = json.loads(AUTH_FAILURE_FILE.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    reason = data.get("reason") if isinstance(data, dict) else None
+    return reason if reason in {"session_expired", "authentication_failed"} else None
+
+
+def clear_auth_failure() -> None:
+    """Forget a previous failure after a successful login or authenticated call."""
+    try:
+        AUTH_FAILURE_FILE.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass

--- a/services/cowork_agent/adapters/claude_code/providers_status.py
+++ b/services/cowork_agent/adapters/claude_code/providers_status.py
@@ -16,8 +16,9 @@ Crucially the probe runs with the **same environment the chat subprocess uses**
 ``ANTHROPIC_API_KEY`` when a usable native login is present, so a subscription
 login wins; if we probed the raw env instead, the tile would advertise a key the
 CLI never actually uses. The tiles therefore reflect what chat will *actually*
-resolve to, not everything configured. This stays presence-not-validity: a
-logged-in-but-invalid credential still reads connected.
+resolve to, not everything configured. A recent authentication failure from Remote Control or chat is authoritative:
+the tile stays disconnected until a successful authenticated call or login clears
+that observed failure.
 
 OpenAI is read from the process environment. OpenRouter is different: it is
 configured by merging an ``env`` block into the CLI's own ``settings.json`` (see
@@ -32,6 +33,7 @@ import os
 from typing import Any
 
 from services.cowork_agent.adapters.claude_code.adapter import ClaudeCodeAdapter
+from services.cowork_agent.adapters.claude_code.auth_state import last_auth_failure_reason
 from services.cowork_agent.providers_status_lib import (
     build_providers_status,
     claude_auth_status,
@@ -53,13 +55,17 @@ async def get_providers_status() -> dict[str, Any]:
     logged_in = bool(auth.get("loggedIn"))
     via_api_key = (auth.get("apiKeySource") or "") == "ANTHROPIC_API_KEY"
 
-    return await build_providers_status(
+    failure_reason = None if via_api_key else last_auth_failure_reason()
+    result = await build_providers_status(
         "claude_code",
         anthropic_key_present=lambda: logged_in and via_api_key,
         openai_key_present=lambda: bool((os.environ.get("OPENAI_API_KEY") or "").strip()),
         openrouter_key_present=_openrouter_configured,
-        claude_oauth_present=lambda: logged_in and not via_api_key,
+        claude_oauth_present=lambda: logged_in and not via_api_key and not failure_reason,
     )
+    if failure_reason and "claude_code" in result["oauth"]:
+        result["oauth"]["claude_code"]["reason"] = failure_reason
+    return result
 
 
 __all__ = ["get_providers_status"]

--- a/services/cowork_agent/adapters/claude_code/remote_control.py
+++ b/services/cowork_agent/adapters/claude_code/remote_control.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from typing import Any, Iterator, Optional
 
 from services.cowork_agent.adapters.cli_status import resolve_binary
+from services.cowork_agent.adapters.claude_code.auth_state import record_auth_failure
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,8 @@ URL_FILE = Path("/tmp/xo-rc.url")   # single line: the current connect link
 ERR_FILE = Path("/tmp/xo-rc.err")   # small: the CLI's stderr, for debugging a failed start
 NAME_FILE = Path("/tmp/xo-rc.name")  # the label the session was launched with
 LOCK_FILE = Path("/tmp/xo-rc.lock")  # serializes start/stop
+_STARTUP_WAIT_SECONDS = 2.0
+_STARTUP_POLL_SECONDS = 0.1
 # Files removed on stop / a failed start (LOCK_FILE is persistent).
 _STATE_FILES = (PID_FILE, URL_FILE, ERR_FILE, NAME_FILE)
 
@@ -145,8 +148,35 @@ def _session_url() -> Optional[str]:
     return url or None
 
 
-def _cleanup_state() -> None:
+def _last_error() -> Optional[str]:
+    """The final CLI error, if Remote Control failed to start or later stopped."""
+    try:
+        detail = ERR_FILE.read_text(errors="replace").strip()
+    except OSError:
+        return None
+    return detail or None
+
+
+def _wait_for_start() -> bool:
+    """Wait briefly for a link or an early launcher exit.
+
+    A live process without a link is still a successful asynchronous launch: the
+    CLI may need longer than this small window to render its first dashboard.
+    """
+    deadline = time.monotonic() + _STARTUP_WAIT_SECONDS
+    while time.monotonic() < deadline:
+        if _session_url() is not None:
+            return True
+        if _running_pid() is None:
+            return False
+        time.sleep(_STARTUP_POLL_SECONDS)
+    return _running_pid() is not None
+
+
+def _cleanup_state(*, keep_error: bool = False) -> None:
     for f in _STATE_FILES:
+        if keep_error and f == ERR_FILE:
+            continue
         try:
             f.unlink()
         except OSError:
@@ -243,7 +273,15 @@ def status() -> dict[str, Any]:
     login = native_login_present()
     pid = _running_pid()
     if pid is None:
-        return {"running": False, "login_present": login, "session_url": None}
+        detail = _last_error()
+        if detail:
+            record_auth_failure(detail)
+        return {
+            "running": False,
+            "login_present": login,
+            "session_url": None,
+            "last_error": detail,
+        }
     return {
         "running": True,
         "login_present": login,
@@ -310,6 +348,18 @@ def start(name: Optional[str] = None) -> dict[str, Any]:
                 "running": False,
                 "error": "start_failed",
                 "detail": str(exc),
+            }
+
+        if not _wait_for_start():
+            detail = _last_error() or "Remote Control exited before it became ready."
+            record_auth_failure(detail)
+            _cleanup_state(keep_error=True)
+            return {
+                "ok": False,
+                "running": False,
+                "login_present": native_login_present(),
+                "error": "start_failed",
+                "detail": detail,
             }
 
         logger.info("Remote Control started: pid=%s dir=%s name=%r",

--- a/tests/test_claude_session_recovery.py
+++ b/tests/test_claude_session_recovery.py
@@ -1,0 +1,109 @@
+"""Regression coverage for expired Claude native-session recovery (issue #56)."""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from contextlib import nullcontext
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from services.cowork_agent.adapters.claude_code import auth_state, remote_control
+from services.cowork_agent.adapters.claude_code import providers_status
+
+
+class AuthStateTests(unittest.TestCase):
+    def test_records_only_classified_failures_without_cli_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, patch.object(
+            auth_state, "AUTH_FAILURE_FILE", Path(tmp) / "auth.json"
+        ):
+            detail = "Failed to authenticate: OAuth session expired and could not be refreshed"
+            self.assertEqual(auth_state.record_auth_failure(detail), "session_expired")
+            self.assertEqual(auth_state.last_auth_failure_reason(), "session_expired")
+            self.assertNotIn(detail, auth_state.AUTH_FAILURE_FILE.read_text())
+
+            auth_state.clear_auth_failure()
+            self.assertIsNone(auth_state.last_auth_failure_reason())
+            self.assertIsNone(auth_state.record_auth_failure("network timeout"))
+
+
+class ProviderStatusTests(unittest.IsolatedAsyncioTestCase):
+    async def test_recent_session_expiry_overrides_logged_in_presence(self) -> None:
+        async def build_status(*_args, **kwargs):
+            return {
+                "agent": "claude_code",
+                "oauth": {"claude_code": {"connected": kwargs["claude_oauth_present"]()}},
+                "api_keys": {},
+            }
+
+        with patch.object(
+            providers_status, "claude_auth_status", new=AsyncMock(return_value={"loggedIn": True})
+        ), patch.object(
+            providers_status, "last_auth_failure_reason", return_value="session_expired"
+        ), patch.object(
+            providers_status, "build_providers_status", side_effect=build_status
+        ):
+            result = await providers_status.get_providers_status()
+
+        self.assertEqual(
+            result["oauth"]["claude_code"],
+            {"connected": False, "reason": "session_expired"},
+        )
+
+
+class RemoteControlTests(unittest.TestCase):
+    def _state_paths(self, root: Path):
+        return patch.multiple(
+            remote_control,
+            PID_FILE=root / "pid",
+            URL_FILE=root / "url",
+            ERR_FILE=root / "err",
+            NAME_FILE=root / "name",
+            _STATE_FILES=(root / "pid", root / "url", root / "err", root / "name"),
+        )
+
+    def test_status_exposes_dead_launcher_error_and_records_expiry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, self._state_paths(Path(tmp)), patch.object(
+            auth_state, "AUTH_FAILURE_FILE", Path(tmp) / "auth.json"
+        ), patch.object(remote_control, "native_login_present", return_value=True), patch.object(
+            remote_control, "_running_pid", return_value=None
+        ):
+            remote_control.ERR_FILE.write_text(
+                "Failed to authenticate: OAuth session expired and could not be refreshed"
+            )
+            result = remote_control.status()
+            recorded_reason = auth_state.last_auth_failure_reason()
+
+        self.assertFalse(result["running"])
+        self.assertIn("OAuth session expired", result["last_error"])
+        self.assertEqual(recorded_reason, "session_expired")
+
+    def test_failed_start_returns_early_exit_error_and_keeps_it_for_status(self) -> None:
+        class Proc:
+            pid = 123
+
+        def fail_to_start(*_args, **kwargs):
+            Path(kwargs["env"]["RC_ERR"]).write_text(
+                "OAuth session expired and could not be refreshed"
+            )
+            return Proc()
+
+        with tempfile.TemporaryDirectory() as tmp, self._state_paths(Path(tmp)), patch.object(
+            auth_state, "AUTH_FAILURE_FILE", Path(tmp) / "auth.json"
+        ), patch.object(remote_control, "_lock", return_value=nullcontext()
+        ), patch.object(remote_control, "native_login_present", return_value=True), patch.object(
+            remote_control, "ensure_gates_seeded"
+        ), patch.object(remote_control, "resolve_binary", return_value="claude"), patch.object(
+            remote_control, "_launch_dir", return_value=Path(tmp)
+        ), patch.object(remote_control.subprocess, "Popen", side_effect=fail_to_start), patch.object(
+            remote_control, "_running_pid", return_value=None
+        ), patch.object(remote_control, "_wait_for_start", return_value=False):
+            result = remote_control.start()
+
+            self.assertEqual(result["error"], "start_failed")
+            self.assertIn("OAuth session expired", result["detail"])
+            self.assertTrue(remote_control.ERR_FILE.exists())
+            self.assertEqual(auth_state.last_auth_failure_reason(), "session_expired")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
`claude auth status --json` reports whether stored credentials exist, not whether the native Claude session can still authenticate. An expired refresh session could therefore remain green while chat and Remote Control immediately failed, leaving the user without an accurate state or actionable failure detail.

## What changed
- Record only classified authentication failures from Claude chat and Remote Control; the persisted state contains a reason, never CLI output or credentials.
- Make `/providers/status` demote the Claude OAuth tile after an observed failure and add the backward-compatible `reason` (`session_expired` or `authentication_failed`). A successful native login or authenticated chat clears that state.
- Poll briefly after Remote Control spawn, return its early-exit stderr instead of a false successful start, and expose the last error through its status response.
- Add regressions for expiry classification, provider status, and dead-on-start Remote Control behavior.

## Verification
- `venv/bin/python -m unittest tests.test_claude_session_recovery -v`
- `AGENT_NAME=claude_code venv/bin/python -c 'import server'`
- `AGENT_NAME=openclaw venv/bin/python -c 'import server'`
- `AGENT_NAME=hermes venv/bin/python -c 'import server'`
- `venv/bin/python -m unittest discover -s tests -v` — 147 tests passed; one existing unrelated failure remains: `test_workspace_document.WorkspaceViewFileTests.test_the_expensive_sink_self_throttles` (`views.apply()` returned `False`).

The repository's checked-in Space UI does not contain the Claude connect/reconnect control described in the issue, so this PR intentionally does not invent a separate UI flow. The existing Connect Claude endpoint clears the observed failure on successful login, and the additive status/error fields let its frontend surface the reconnect path and explanation.