### PR TITLE
fix(openclaw): set gateway.trustedProxies in generated config (#57)

### DIFF
--- a/config/agents/openclaw/agent.sh
+++ b/config/agents/openclaw/agent.sh
@@ -282,6 +282,7 @@ enable_channels() {
             '{
                 gateway: {
                     mode: "local",
+                    trustedProxies: ["127.0.0.1"],
                     controlUi: {
                         dangerouslyDisableDeviceAuth: true
                     },
@@ -375,6 +376,7 @@ enable_channels() {
 {
   "gateway": {
     "mode": "local",
+    "trustedProxies": ["127.0.0.1"],
     "controlUi": {
       "allowedOrigins": ["${control_ui_origin}"],
       "dangerouslyDisableDeviceAuth": true
@@ -415,6 +417,7 @@ EOJSON
 {
   "gateway": {
     "mode": "local",
+    "trustedProxies": ["127.0.0.1"],
     "controlUi": {
       "dangerouslyDisableDeviceAuth": true
     },


### PR DESCRIPTION
Fixes #57.

## Why

Newer OpenClaw gateway versions refuse every request unless `gateway.trustedProxies` is configured:

```json
{"error":{"message":"Proxy client attribution is required. Configure gateway.trustedProxies narrowly and make the proxy overwrite or safely rebuild forwarded client headers.","type":"proxy_attribution_required"}}
```

The `openclaw.json` that `config/agents/openclaw/agent.sh` generates never set the field, so a fresh `AGENT_NAME=openclaw` install started the gateway but failed on the first request through it.

## What changed

Added `"trustedProxies": ["127.0.0.1"]` to the `gateway` block in **all three** config builders in `agent.sh` — the field was missing from every path:

- the `jq -n` builder (primary path when `jq` is present)
- the no-`jq` heredoc fallback **with** a control-UI origin
- the no-`jq` heredoc fallback **without** one

`127.0.0.1` matches the local-mode setup where xo-space fronts the gateway on loopback.

## Scope / follow-ups (deliberately not in this PR)

- **Existing installs are not migrated.** `enable_channels()` returns early when `openclaw.json` already exists, so this change only affects newly generated configs. Existing installs still need a manual edit (add the field under `gateway`) or a separate migration — worth a follow-up decision.
- **Compose/Docker path:** if a non-loopback proxy hop fronts the gateway there, `127.0.0.1` may need to be the actual proxy address instead — the upstream change wants the trusted set configured *narrowly*, so confirm the correct value for that path.
- **Version pin:** worth recording which OpenClaw version made `trustedProxies` mandatory, alongside the CLI-version guidance the repo already keeps, so the template and pinned CLI stay in sync.

## Verification

- `bash -n config/agents/openclaw/agent.sh` — parses.
- `jq -n '{gateway:{mode:"local",trustedProxies:["127.0.0.1"],controlUi:{dangerouslyDisableDeviceAuth:true}}}'` — valid jq, emits the field.
- Diff is 3 inserted lines, no other changes.
- Not run: a live gateway start against the new OpenClaw version (no gateway on the dev box); the fix mirrors the exact field/value confirmed working in the issue repro.
