### PR TITLE
fix(tests): stop uninstall harness deleting real ~/.quirq (sandbox root env vars)

### DIFF
--- a/tests/uninstall_sh_harness.sh
+++ b/tests/uninstall_sh_harness.sh
@@ -128,7 +128,9 @@ cp "$SRC" "$W/ws5/xo-space/uninstall.sh"
 mkdir -p "$W/home5/.argus" "$W/home5/.xo-cowork"
 echo db > "$W/home5/.argus/argus.db"
 mkdir -p "$W/tmp5"
-full="$( cd "$W/ws5" && HOME="$W/home5" PORT=59999 QUIRQ_DAEMON_TMPDIR="$W/tmp5" bash ./xo-space/uninstall.sh --yes 2>&1 )" || {
+full="$( cd "$W/ws5" && HOME="$W/home5" PORT=59999 QUIRQ_DAEMON_TMPDIR="$W/tmp5" \
+        XO_PROJECTS_ROOT="$W/ws5" QUIRQ_STATE_ROOT="$W/ws5/.quirq" \
+        bash ./xo-space/uninstall.sh --yes 2>&1 )" || {
     bad "full --yes run exits 0" "$full"; }
 state5="$([ -d "$W/ws5/projectA" ] && echo projects || echo lost)"
 state5="$state5|$([ -e "$W/ws5/xo-space" ] && echo checkout || echo nocheckout)"
@@ -139,7 +141,9 @@ check "full run: projects kept; checkout, .quirq, .xo, ~/.argus removed" \
       "$state5" "projects|nocheckout|noquirq|noxo|noargus"
 
 cp "$SRC" "$W/ws5/uninstall-copy.sh"
-again="$( cd "$W/ws5" && HOME="$W/home5" QUIRQ_DAEMON_TMPDIR="$W/tmp5" bash ./uninstall-copy.sh --yes >/dev/null 2>&1 && echo ok || echo err )"
+again="$( cd "$W/ws5" && HOME="$W/home5" QUIRQ_DAEMON_TMPDIR="$W/tmp5" \
+         XO_PROJECTS_ROOT="$W/ws5" QUIRQ_STATE_ROOT="$W/ws5/.quirq" \
+         bash ./uninstall-copy.sh --yes >/dev/null 2>&1 && echo ok || echo err )"
 check "second run is graceful (idempotent)" "$again" "ok"
 
 # ---- summary ---------------------------------------------------------------


### PR DESCRIPTION
Fixes #60.

## Problem

Running the test suite on a real install deletes the developer's live `~/.quirq` state root (and `<projects>/.xo`). The uninstall harness's two full `uninstall.sh --yes` runs override `HOME`, `PORT`, and `QUIRQ_DAEMON_TMPDIR` but not `XO_PROJECTS_ROOT` / `QUIRQ_STATE_ROOT`. On a real install those are exported, so `uninstall.sh` resolves the real state root and `rm -rf`s it. (The resolve-roots unit tests in the same harness already sandbox these; the full-run invocations were missing it.)

`uninstall.sh` itself is correct — it removes the configured state root; the test just pointed it at the real one.

## Change

Pin `XO_PROJECTS_ROOT` / `QUIRQ_STATE_ROOT` to the `ws5` sandbox for both full-run invocations in `tests/uninstall_sh_harness.sh`.

## Verification

With both vars exported to sentinel paths (simulating a real box where the leak occurs):

- Patched harness: **14/14 pass**, and the sentinel `.quirq/state.json` **survives**.
- Without the patch, the same setup deletes the sentinel (matches the reported real-world behavior).

## Note

Impact was limited to the state root and the regenerable `<projects>/.xo`; project folders (purge needs `--purge-projects`), `~/.claude`, and `~/.argus` were not affected. Anyone who ran the suite on a real box should restart the server to regenerate `.quirq` defaults and re-enter any credentials that were saved through the UI.
