### PR TITLE
Feat/telemetry harnesses expansion

### DIFF
--- a/config/agents/deepseek_harness/manifest.json
+++ b/config/agents/deepseek_harness/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "deepseek_harness",
+  "binary": "dsh",
+  "install_url": "https://deepseek.com",
+  "home_dir": "~/.dsh",
+  "env_file": "~/.dsh/.env",
+  "config_file": "~/.dsh/config.json",
+  "agents_dir": "~/.dsh/sessions",
+  "workspace_dir": "~/xo-projects",
+  "provisioning_log": "~/.dsh/provisioning.log",
+  "cwd": "~",
+  "cli_timeout_seconds": 300,
+  "api": {
+    "session_header": ""
+  },
+  "model_prefix": "deepseek",
+  "models": {
+    "default": "deepseek-reasoner",
+    "catalog": ["deepseek-reasoner", "deepseek-coder", "deepseek-chat"]
+  },
+  "runtime_setup": {
+    "installs_cli": false,
+    "session_globs": ["sessions/*.json", "sessions/*.jsonl", "logs/*.json", "logs/*.jsonl"],
+    "secrets": []
+  }
+}

--- a/config/agents/deepseek_harness/manifest.json
+++ b/config/agents/deepseek_harness/manifest.json
@@ -14,9 +14,25 @@
     "session_header": ""
   },
   "model_prefix": "deepseek",
+  "model_capabilities": {
+    "function_calling": true,
+    "vision": true,
+    "reasoning": true,
+    "json_output": true,
+    "max_context": 128000,
+    "max_output": 16384
+  },
   "models": {
     "default": "deepseek-reasoner",
-    "catalog": ["deepseek-reasoner", "deepseek-coder", "deepseek-chat"]
+    "catalog": [
+      "deepseek-reasoner",
+      "deepseek-coder",
+      "deepseek-chat",
+      "deepseek-v4-flash-free",
+      "local/ollama-deepseek-r1",
+      "local/vllm-deepseek-v3",
+      "custom/openai-compatible"
+    ]
   },
   "runtime_setup": {
     "installs_cli": false,

--- a/config/agents/grok_build/manifest.json
+++ b/config/agents/grok_build/manifest.json
@@ -14,9 +14,24 @@
     "session_header": ""
   },
   "model_prefix": "grok",
+  "model_capabilities": {
+    "function_calling": true,
+    "vision": true,
+    "reasoning": true,
+    "json_output": true,
+    "max_context": 128000,
+    "max_output": 16384
+  },
   "models": {
     "default": "grok-code",
-    "catalog": ["grok-code", "grok-2", "grok-beta"]
+    "catalog": [
+      "grok-code",
+      "grok-2",
+      "grok-2-vision",
+      "grok-beta",
+      "local/ollama",
+      "custom/openai-compatible"
+    ]
   },
   "runtime_setup": {
     "installs_cli": false,

--- a/config/agents/grok_build/manifest.json
+++ b/config/agents/grok_build/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "grok_build",
+  "binary": "grok",
+  "install_url": "https://x.ai",
+  "home_dir": "~/.grok",
+  "env_file": "~/.grok/.env",
+  "config_file": "~/.grok/config.json",
+  "agents_dir": "~/.grok/sessions",
+  "workspace_dir": "~/xo-projects",
+  "provisioning_log": "~/.grok/provisioning.log",
+  "cwd": "~",
+  "cli_timeout_seconds": 300,
+  "api": {
+    "session_header": ""
+  },
+  "model_prefix": "grok",
+  "models": {
+    "default": "grok-code",
+    "catalog": ["grok-code", "grok-2", "grok-beta"]
+  },
+  "runtime_setup": {
+    "installs_cli": false,
+    "session_globs": ["sessions/*.json", "sessions/*.jsonl", "traces/*.json", "traces/*.jsonl"],
+    "secrets": []
+  }
+}

--- a/config/agents/kimi_code/manifest.json
+++ b/config/agents/kimi_code/manifest.json
@@ -23,10 +23,11 @@
     "max_output": 16384
   },
   "models": {
-    "default": "kimi-k1.5",
+    "default": "kimi-k3",
     "catalog": [
-      "kimi-k1.5",
+      "kimi-k3",
       "kimi-k2.5",
+      "kimi-k1.5",
       "kimi-latest",
       "moonshot-v1-8k",
       "moonshot-v1-32k",

--- a/config/agents/kimi_code/manifest.json
+++ b/config/agents/kimi_code/manifest.json
@@ -14,9 +14,26 @@
     "session_header": ""
   },
   "model_prefix": "kimi",
+  "model_capabilities": {
+    "function_calling": true,
+    "vision": true,
+    "reasoning": true,
+    "json_output": true,
+    "max_context": 2000000,
+    "max_output": 16384
+  },
   "models": {
     "default": "kimi-k1.5",
-    "catalog": ["kimi-k1.5", "kimi-latest"]
+    "catalog": [
+      "kimi-k1.5",
+      "kimi-k2.5",
+      "kimi-latest",
+      "moonshot-v1-8k",
+      "moonshot-v1-32k",
+      "moonshot-v1-128k",
+      "local/ollama",
+      "custom/openai-compatible"
+    ]
   },
   "runtime_setup": {
     "installs_cli": false,

--- a/config/agents/kimi_code/manifest.json
+++ b/config/agents/kimi_code/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "kimi_code",
+  "binary": "kimi",
+  "install_url": "https://kimi.moonshot.cn",
+  "home_dir": "~/.kimi-code",
+  "env_file": "~/.kimi-code/.env",
+  "config_file": "~/.kimi-code/config.json",
+  "agents_dir": "~/.kimi-code/sessions",
+  "workspace_dir": "~/xo-projects",
+  "provisioning_log": "~/.kimi-code/provisioning.log",
+  "cwd": "~",
+  "cli_timeout_seconds": 300,
+  "api": {
+    "session_header": ""
+  },
+  "model_prefix": "kimi",
+  "models": {
+    "default": "kimi-k1.5",
+    "catalog": ["kimi-k1.5", "kimi-latest"]
+  },
+  "runtime_setup": {
+    "installs_cli": false,
+    "session_globs": ["sessions/*.json", "sessions/*.jsonl", "logs/*.json", "logs/*.jsonl"],
+    "secrets": []
+  }
+}

--- a/config/agents/omp/manifest.json
+++ b/config/agents/omp/manifest.json
@@ -14,9 +14,23 @@
     "session_header": ""
   },
   "model_prefix": "omp",
+  "model_capabilities": {
+    "function_calling": true,
+    "vision": true,
+    "reasoning": true,
+    "json_output": true,
+    "max_context": 200000,
+    "max_output": 16384
+  },
   "models": {
     "default": "omp-agent-v1",
-    "catalog": ["omp-agent-v1"]
+    "catalog": [
+      "omp-agent-v1",
+      "omp-coder-large",
+      "local/ollama",
+      "local/vllm",
+      "custom/openai-compatible"
+    ]
   },
   "runtime_setup": {
     "installs_cli": false,

--- a/config/agents/omp/manifest.json
+++ b/config/agents/omp/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "omp",
+  "binary": "omp",
+  "install_url": "https://github.com/omp-ai/omp",
+  "home_dir": "~/.omp",
+  "env_file": "~/.omp/.env",
+  "config_file": "~/.omp/config.json",
+  "agents_dir": "~/.omp/agent/sessions",
+  "workspace_dir": "~/xo-projects",
+  "provisioning_log": "~/.omp/provisioning.log",
+  "cwd": "~",
+  "cli_timeout_seconds": 300,
+  "api": {
+    "session_header": ""
+  },
+  "model_prefix": "omp",
+  "models": {
+    "default": "omp-agent-v1",
+    "catalog": ["omp-agent-v1"]
+  },
+  "runtime_setup": {
+    "installs_cli": false,
+    "session_globs": ["agent/sessions/*.json", "agent/sessions/*.jsonl", "*.json"],
+    "secrets": []
+  }
+}

--- a/config/agents/opencode/manifest.json
+++ b/config/agents/opencode/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "opencode",
+  "binary": "opencode",
+  "install_url": "https://github.com/opencode-ai/opencode",
+  "home_dir": "~/.local/share/opencode",
+  "env_file": "~/.config/opencode/.env",
+  "config_file": "~/.config/opencode/config.json",
+  "agents_dir": "~/.local/share/opencode/sessions",
+  "workspace_dir": "~/xo-projects",
+  "provisioning_log": "~/.local/share/opencode/provisioning.log",
+  "cwd": "~",
+  "cli_timeout_seconds": 300,
+  "api": {
+    "session_header": ""
+  },
+  "model_prefix": "opencode",
+  "models": {
+    "default": "opencode-v1",
+    "catalog": ["opencode-v1"]
+  },
+  "runtime_setup": {
+    "installs_cli": false,
+    "session_globs": ["*.json", "*.jsonl", "sessions/*.json", "sessions/*.jsonl"],
+    "secrets": []
+  }
+}

--- a/config/agents/opencode/manifest.json
+++ b/config/agents/opencode/manifest.json
@@ -14,13 +14,38 @@
     "session_header": ""
   },
   "model_prefix": "opencode",
+  "model_capabilities": {
+    "function_calling": true,
+    "vision": true,
+    "reasoning": true,
+    "json_output": true,
+    "max_context": 200000,
+    "max_output": 16384
+  },
   "models": {
-    "default": "opencode-v1",
-    "catalog": ["opencode-v1"]
+    "default": "deepseek-v4-flash-free",
+    "catalog": [
+      "deepseek-v4-flash-free",
+      "deepseek-reasoner",
+      "deepseek-coder",
+      "openai/gpt-oss-20b",
+      "qwen/qwen3-coder-30b",
+      "claude-sonnet-4-5",
+      "claude-haiku-4-5",
+      "gpt-5.1-codex",
+      "gpt-5.2",
+      "glm-4.7",
+      "ornith-1.0-35b",
+      "hy3-free",
+      "north-mini-code-free",
+      "local/ollama",
+      "local/vllm",
+      "custom/openai-compatible"
+    ]
   },
   "runtime_setup": {
     "installs_cli": false,
-    "session_globs": ["*.json", "*.jsonl", "sessions/*.json", "sessions/*.jsonl"],
+    "session_globs": ["*.json", "*.jsonl", "sessions/*.json", "sessions/*.jsonl", "opencode.db"],
     "secrets": []
   }
 }

--- a/config/agents/pi_agent/manifest.json
+++ b/config/agents/pi_agent/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "pi_agent",
+  "binary": "pi",
+  "install_url": "https://pi.ai",
+  "home_dir": "~/.pi/agent",
+  "env_file": "~/.pi/agent/.env",
+  "config_file": "~/.pi/agent/config.json",
+  "agents_dir": "~/.pi/agent/sessions",
+  "workspace_dir": "~/xo-projects",
+  "provisioning_log": "~/.pi/agent/provisioning.log",
+  "cwd": "~",
+  "cli_timeout_seconds": 300,
+  "api": {
+    "session_header": ""
+  },
+  "model_prefix": "pi",
+  "models": {
+    "default": "pi-agent-v1",
+    "catalog": ["pi-agent-v1"]
+  },
+  "runtime_setup": {
+    "installs_cli": false,
+    "session_globs": ["sessions/*.json", "sessions/*.jsonl", "telemetry/**/*.json"],
+    "secrets": []
+  }
+}

--- a/config/agents/pi_agent/manifest.json
+++ b/config/agents/pi_agent/manifest.json
@@ -14,9 +14,22 @@
     "session_header": ""
   },
   "model_prefix": "pi",
+  "model_capabilities": {
+    "function_calling": true,
+    "vision": true,
+    "reasoning": true,
+    "json_output": true,
+    "max_context": 128000,
+    "max_output": 16384
+  },
   "models": {
     "default": "pi-agent-v1",
-    "catalog": ["pi-agent-v1"]
+    "catalog": [
+      "pi-agent-v1",
+      "pi-coder",
+      "local/ollama",
+      "custom/openai-compatible"
+    ]
   },
   "runtime_setup": {
     "installs_cli": false,

--- a/services/cowork_agent/adapters/deepseek_harness/session_telemetry.py
+++ b/services/cowork_agent/adapters/deepseek_harness/session_telemetry.py
@@ -1,0 +1,242 @@
+"""Read-only Space session telemetry for local DeepSeek Harness agent sessions.
+
+DeepSeek Harness stores session metadata and transcripts under:
+  macOS/Linux: ~/.dsh/sessions/ and ~/.dsh/logs/
+  Windows: %USERPROFILE%\.dsh\sessions\ and %USERPROFILE%\.dsh\logs\
+
+This read-only capability scans JSON/JSONL session logs and calculates token
+totals, session counts, models, and daily rollups.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SOURCE_ID = "deepseek_harness"
+SOURCE_LABEL = "DeepSeek Harness"
+META_PRIORITY = 35
+COST_STATUS = "unavailable"
+
+MAX_SESSIONS = 500
+
+
+def _dsh_home() -> Path:
+    configured = (os.getenv("DSH_HOME") or os.getenv("DEEPSEEK_HOME") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".dsh"
+
+
+def runtime_mounts() -> list[Path]:
+    """Native directories the managed Docker runtime may read if present."""
+    return [_dsh_home()]
+
+
+def _parse_timestamp(val: Any) -> str | None:
+    if not val:
+        return None
+    if isinstance(val, (int, float)):
+        ms = float(val)
+        if ms < 1_000_000_000_000:
+            ms *= 1000
+        try:
+            return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    if isinstance(val, str):
+        try:
+            norm = val.replace("Z", "+00:00")
+            return datetime.fromisoformat(norm).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    return None
+
+
+def collect_session_telemetry() -> dict:
+    root = _dsh_home()
+    sessions_dir = root / "sessions"
+    logs_dir = root / "logs"
+
+    if not root.is_dir() and not sessions_dir.is_dir() and not logs_dir.is_dir():
+        raise FileNotFoundError(f"DeepSeek Harness directory not found at {root}")
+
+    session_files: list[Path] = []
+    for d in (sessions_dir, logs_dir, root):
+        if d.is_dir():
+            session_files.extend(list(d.glob("*.json")) + list(d.glob("*.jsonl")))
+
+    if not session_files:
+        raise ValueError(f"DeepSeek Harness directory {root} contains no log or session files")
+
+    sessions: list[dict] = []
+    seen_ids: set[str] = set()
+    project_keys: set[str] = set()
+
+    daily_models: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_sessions: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_tools: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+
+    for file_path in sorted(session_files, key=lambda p: p.stat().st_mtime, reverse=True)[:MAX_SESSIONS]:
+        try:
+            stat = file_path.stat()
+            file_mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            file_day = file_mtime[:10]
+
+            sid = file_path.stem
+            if sid in seen_ids:
+                continue
+            seen_ids.add(sid)
+
+            project_path = ""
+            model = "deepseek-reasoner"
+            started_at = file_mtime
+            ended_at = file_mtime
+            total_tokens = 0
+            unclassified = 0
+            fresh_tokens = 0
+            output_tokens = 0
+
+            # Inspect file content
+            if file_path.suffix == ".json":
+                try:
+                    data = json.loads(file_path.read_text(encoding="utf-8"))
+                    if isinstance(data, dict):
+                        sid = str(data.get("id") or data.get("session_id") or sid)
+                        project_path = str(data.get("project_path") or data.get("cwd") or "")
+                        model = str(data.get("model") or model)
+                        started_at = _parse_timestamp(data.get("created_at") or data.get("started_at")) or file_mtime
+                        ended_at = _parse_timestamp(data.get("updated_at") or data.get("ended_at")) or file_mtime
+                        usage = data.get("usage") or {}
+                        fresh_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                        output_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                        total_tokens = int(usage.get("total_tokens") or (fresh_tokens + output_tokens))
+                except Exception:
+                    pass
+            elif file_path.suffix == ".jsonl":
+                try:
+                    lines = file_path.read_text(encoding="utf-8").splitlines()
+                    for line in lines:
+                        if not line.strip():
+                            continue
+                        rec = json.loads(line)
+                        if isinstance(rec, dict):
+                            if rec.get("model"):
+                                model = str(rec["model"])
+                            if rec.get("cwd") or rec.get("project_path"):
+                                project_path = str(rec.get("cwd") or rec.get("project_path"))
+                            ts = _parse_timestamp(rec.get("timestamp") or rec.get("time"))
+                            if ts:
+                                ended_at = ts
+                            usage = rec.get("usage") or {}
+                            if usage:
+                                fresh_tokens += int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                                output_tokens += int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                                total_tokens += int(usage.get("total_tokens") or 0)
+                except Exception:
+                    pass
+
+            if total_tokens == 0:
+                unclassified = max(1, stat.st_size // 4)
+                total_tokens = unclassified
+
+            proj_name = Path(project_path).name if project_path else "(unknown)"
+            if project_path:
+                project_keys.add(project_path)
+
+            day = started_at[:10] if started_at else file_day
+
+            daily_models[(day, model)][0] += total_tokens
+            daily_models[(day, model)][1] += unclassified
+
+            daily_sessions[(day, sid)][0] += total_tokens
+            daily_sessions[(day, sid)][1] += unclassified
+
+            sessions.append({
+                "id": sid,
+                "agent": SOURCE_ID,
+                "project": proj_name,
+                "project_path": project_path,
+                "started_at": started_at,
+                "ended_at": ended_at,
+                "duration_sec": None,
+                "model": model,
+                "agent_version": "",
+                "turns": 1,
+                "fresh": fresh_tokens,
+                "output": output_tokens,
+                "cache_read": 0,
+                "cache_write": 0,
+                "tokens": total_tokens,
+                "own_tokens": total_tokens,
+                "total_tokens": total_tokens,
+                "unclassified": unclassified,
+                "breakdown_known": unclassified == 0,
+                "cost": 0.0,
+                "cost_known": False,
+                "tools": [],
+                "subagents": [],
+            })
+        except Exception:
+            continue
+
+    if not sessions:
+        raise ValueError(f"No valid DeepSeek Harness sessions found under {root}")
+
+    sessions.sort(key=lambda r: r.get("started_at") or "", reverse=True)
+    all_tokens = sum(r["tokens"] for r in sessions)
+    kept_ids = {r["id"] for r in sessions}
+
+    return {
+        "source": {
+            "id": SOURCE_ID,
+            "label": SOURCE_LABEL,
+            "cost_status": COST_STATUS,
+        },
+        "meta_priority": META_PRIORITY,
+        "meta": {
+            "db_path": str(root),
+            "schema_version": None,
+            "pricing_version": None,
+        },
+        "totals": {
+            "sessions": len(sessions),
+            "tokens": all_tokens,
+            "cost_usd": 0.0,
+            "projects": len(project_keys),
+            "sessions_by_agent": {SOURCE_ID: len(sessions)},
+        },
+        "project_keys": sorted(project_keys),
+        "sessions": sessions,
+        "daily_models": [
+            {
+                "day": day, "agent": SOURCE_ID, "model": model,
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, model), values in sorted(daily_models.items())
+        ],
+        "daily_sessions": [
+            {
+                "day": day, "agent": SOURCE_ID, "session_id": session_id,
+                "session_key": f"{SOURCE_ID}:{session_id}",
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, session_id), values in sorted(daily_sessions.items())
+            if session_id in kept_ids
+        ],
+        "daily_tools": [
+            {
+                "day": day, "agent": SOURCE_ID, "name": name,
+                "calls": values[0], "errors": values[1],
+            }
+            for (day, name), values in sorted(daily_tools.items())
+        ],
+    }

--- a/services/cowork_agent/adapters/grok_build/session_telemetry.py
+++ b/services/cowork_agent/adapters/grok_build/session_telemetry.py
@@ -1,0 +1,242 @@
+"""Read-only Space session telemetry for local Grok Build agent sessions.
+
+Grok Build stores session metadata and transcripts under:
+  macOS/Linux: ~/.grok/sessions/ and ~/.grok/traces/
+  Windows: %USERPROFILE%\.grok\sessions\ and %USERPROFILE%\.grok\traces\
+
+This read-only capability scans JSON/JSONL session logs and calculates token
+totals, session counts, models, and daily rollups.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SOURCE_ID = "grok_build"
+SOURCE_LABEL = "Grok Build"
+META_PRIORITY = 55
+COST_STATUS = "unavailable"
+
+MAX_SESSIONS = 500
+
+
+def _grok_home() -> Path:
+    configured = (os.getenv("GROK_HOME") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".grok"
+
+
+def runtime_mounts() -> list[Path]:
+    """Native directories the managed Docker runtime may read if present."""
+    return [_grok_home()]
+
+
+def _parse_timestamp(val: Any) -> str | None:
+    if not val:
+        return None
+    if isinstance(val, (int, float)):
+        ms = float(val)
+        if ms < 1_000_000_000_000:
+            ms *= 1000
+        try:
+            return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    if isinstance(val, str):
+        try:
+            norm = val.replace("Z", "+00:00")
+            return datetime.fromisoformat(norm).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    return None
+
+
+def collect_session_telemetry() -> dict:
+    root = _grok_home()
+    sessions_dir = root / "sessions"
+    traces_dir = root / "traces"
+
+    if not root.is_dir() and not sessions_dir.is_dir() and not traces_dir.is_dir():
+        raise FileNotFoundError(f"Grok Build directory not found at {root}")
+
+    session_files: list[Path] = []
+    for d in (sessions_dir, traces_dir, root):
+        if d.is_dir():
+            session_files.extend(list(d.glob("*.json")) + list(d.glob("*.jsonl")))
+
+    if not session_files:
+        raise ValueError(f"Grok Build directory {root} contains no log or session files")
+
+    sessions: list[dict] = []
+    seen_ids: set[str] = set()
+    project_keys: set[str] = set()
+
+    daily_models: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_sessions: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_tools: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+
+    for file_path in sorted(session_files, key=lambda p: p.stat().st_mtime, reverse=True)[:MAX_SESSIONS]:
+        try:
+            stat = file_path.stat()
+            file_mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            file_day = file_mtime[:10]
+
+            sid = file_path.stem
+            if sid in seen_ids:
+                continue
+            seen_ids.add(sid)
+
+            project_path = ""
+            model = "grok-code"
+            started_at = file_mtime
+            ended_at = file_mtime
+            total_tokens = 0
+            unclassified = 0
+            fresh_tokens = 0
+            output_tokens = 0
+
+            # Inspect file content
+            if file_path.suffix == ".json":
+                try:
+                    data = json.loads(file_path.read_text(encoding="utf-8"))
+                    if isinstance(data, dict):
+                        sid = str(data.get("id") or data.get("session_id") or sid)
+                        project_path = str(data.get("project_path") or data.get("cwd") or "")
+                        model = str(data.get("model") or model)
+                        started_at = _parse_timestamp(data.get("created_at") or data.get("started_at")) or file_mtime
+                        ended_at = _parse_timestamp(data.get("updated_at") or data.get("ended_at")) or file_mtime
+                        usage = data.get("usage") or {}
+                        fresh_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                        output_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                        total_tokens = int(usage.get("total_tokens") or (fresh_tokens + output_tokens))
+                except Exception:
+                    pass
+            elif file_path.suffix == ".jsonl":
+                try:
+                    lines = file_path.read_text(encoding="utf-8").splitlines()
+                    for line in lines:
+                        if not line.strip():
+                            continue
+                        rec = json.loads(line)
+                        if isinstance(rec, dict):
+                            if rec.get("model"):
+                                model = str(rec["model"])
+                            if rec.get("cwd") or rec.get("project_path"):
+                                project_path = str(rec.get("cwd") or rec.get("project_path"))
+                            ts = _parse_timestamp(rec.get("timestamp") or rec.get("time"))
+                            if ts:
+                                ended_at = ts
+                            usage = rec.get("usage") or {}
+                            if usage:
+                                fresh_tokens += int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                                output_tokens += int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                                total_tokens += int(usage.get("total_tokens") or 0)
+                except Exception:
+                    pass
+
+            if total_tokens == 0:
+                unclassified = max(1, stat.st_size // 4)
+                total_tokens = unclassified
+
+            proj_name = Path(project_path).name if project_path else "(unknown)"
+            if project_path:
+                project_keys.add(project_path)
+
+            day = started_at[:10] if started_at else file_day
+
+            daily_models[(day, model)][0] += total_tokens
+            daily_models[(day, model)][1] += unclassified
+
+            daily_sessions[(day, sid)][0] += total_tokens
+            daily_sessions[(day, sid)][1] += unclassified
+
+            sessions.append({
+                "id": sid,
+                "agent": SOURCE_ID,
+                "project": proj_name,
+                "project_path": project_path,
+                "started_at": started_at,
+                "ended_at": ended_at,
+                "duration_sec": None,
+                "model": model,
+                "agent_version": "",
+                "turns": 1,
+                "fresh": fresh_tokens,
+                "output": output_tokens,
+                "cache_read": 0,
+                "cache_write": 0,
+                "tokens": total_tokens,
+                "own_tokens": total_tokens,
+                "total_tokens": total_tokens,
+                "unclassified": unclassified,
+                "breakdown_known": unclassified == 0,
+                "cost": 0.0,
+                "cost_known": False,
+                "tools": [],
+                "subagents": [],
+            })
+        except Exception:
+            continue
+
+    if not sessions:
+        raise ValueError(f"No valid Grok Build sessions found under {root}")
+
+    sessions.sort(key=lambda r: r.get("started_at") or "", reverse=True)
+    all_tokens = sum(r["tokens"] for r in sessions)
+    kept_ids = {r["id"] for r in sessions}
+
+    return {
+        "source": {
+            "id": SOURCE_ID,
+            "label": SOURCE_LABEL,
+            "cost_status": COST_STATUS,
+        },
+        "meta_priority": META_PRIORITY,
+        "meta": {
+            "db_path": str(root),
+            "schema_version": None,
+            "pricing_version": None,
+        },
+        "totals": {
+            "sessions": len(sessions),
+            "tokens": all_tokens,
+            "cost_usd": 0.0,
+            "projects": len(project_keys),
+            "sessions_by_agent": {SOURCE_ID: len(sessions)},
+        },
+        "project_keys": sorted(project_keys),
+        "sessions": sessions,
+        "daily_models": [
+            {
+                "day": day, "agent": SOURCE_ID, "model": model,
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, model), values in sorted(daily_models.items())
+        ],
+        "daily_sessions": [
+            {
+                "day": day, "agent": SOURCE_ID, "session_id": session_id,
+                "session_key": f"{SOURCE_ID}:{session_id}",
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, session_id), values in sorted(daily_sessions.items())
+            if session_id in kept_ids
+        ],
+        "daily_tools": [
+            {
+                "day": day, "agent": SOURCE_ID, "name": name,
+                "calls": values[0], "errors": values[1],
+            }
+            for (day, name), values in sorted(daily_tools.items())
+        ],
+    }

--- a/services/cowork_agent/adapters/kimi_code/session_telemetry.py
+++ b/services/cowork_agent/adapters/kimi_code/session_telemetry.py
@@ -1,0 +1,245 @@
+"""Read-only Space session telemetry for local Kimi Code agent sessions.
+
+Kimi Code stores session metadata and transcripts under:
+  macOS/Linux: ~/.kimi-code/sessions/ and ~/.kimi-code/logs/
+  Windows: %USERPROFILE%\.kimi-code\sessions\ and %USERPROFILE%\.kimi-code\logs\
+
+This read-only capability scans JSON/JSONL session logs and calculates token
+totals, session counts, models, and daily rollups.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SOURCE_ID = "kimi_code"
+SOURCE_LABEL = "Kimi Code"
+META_PRIORITY = 30
+COST_STATUS = "unavailable"
+
+MAX_SESSIONS = 500
+MAX_TOOLS_PER_SESSION = 10
+
+
+def _kimi_home() -> Path:
+    configured = (os.getenv("KIMI_HOME") or os.getenv("KIMI_CODE_HOME") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".kimi-code"
+
+
+def runtime_mounts() -> list[Path]:
+    """Native directories the managed Docker runtime may read if present."""
+    return [_kimi_home()]
+
+
+def _parse_timestamp(val: Any) -> str | None:
+    if not val:
+        return None
+    if isinstance(val, (int, float)):
+        ms = float(val)
+        if ms < 1_000_000_000_000:
+            ms *= 1000
+        try:
+            return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    if isinstance(val, str):
+        try:
+            norm = val.replace("Z", "+00:00")
+            return datetime.fromisoformat(norm).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    return None
+
+
+def collect_session_telemetry() -> dict:
+    root = _kimi_home()
+    sessions_dir = root / "sessions"
+    logs_dir = root / "logs"
+
+    if not root.is_dir() and not sessions_dir.is_dir() and not logs_dir.is_dir():
+        raise FileNotFoundError(f"Kimi Code directory not found at {root}")
+
+    session_files: list[Path] = []
+    for d in (sessions_dir, logs_dir, root):
+        if d.is_dir():
+            session_files.extend(list(d.glob("*.json")) + list(d.glob("*.jsonl")))
+
+    if not session_files:
+        raise ValueError(f"Kimi Code directory {root} contains no log or session files")
+
+    sessions: list[dict] = []
+    seen_ids: set[str] = set()
+    project_keys: set[str] = set()
+
+    daily_models: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_sessions: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_tools: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+
+    for file_path in sorted(session_files, key=lambda p: p.stat().st_mtime, reverse=True)[:MAX_SESSIONS]:
+        try:
+            stat = file_path.stat()
+            file_mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            file_day = file_mtime[:10]
+
+            sid = file_path.stem
+            if sid in seen_ids:
+                continue
+            seen_ids.add(sid)
+
+            project_path = ""
+            model = "kimi-k1.5"
+            started_at = file_mtime
+            ended_at = file_mtime
+            total_tokens = 0
+            unclassified = 0
+            fresh_tokens = 0
+            output_tokens = 0
+            tool_calls = 0
+
+            # Inspect file content
+            if file_path.suffix == ".json":
+                try:
+                    data = json.loads(file_path.read_text(encoding="utf-8"))
+                    if isinstance(data, dict):
+                        sid = str(data.get("id") or data.get("session_id") or sid)
+                        project_path = str(data.get("project_path") or data.get("cwd") or "")
+                        model = str(data.get("model") or model)
+                        started_at = _parse_timestamp(data.get("created_at") or data.get("started_at")) or file_mtime
+                        ended_at = _parse_timestamp(data.get("updated_at") or data.get("ended_at")) or file_mtime
+                        usage = data.get("usage") or {}
+                        fresh_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                        output_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                        total_tokens = int(usage.get("total_tokens") or (fresh_tokens + output_tokens))
+                except Exception:
+                    pass
+            elif file_path.suffix == ".jsonl":
+                try:
+                    lines = file_path.read_text(encoding="utf-8").splitlines()
+                    for line in lines:
+                        if not line.strip():
+                            continue
+                        rec = json.loads(line)
+                        if isinstance(rec, dict):
+                            if rec.get("model"):
+                                model = str(rec["model"])
+                            if rec.get("cwd") or rec.get("project_path"):
+                                project_path = str(rec.get("cwd") or rec.get("project_path"))
+                            ts = _parse_timestamp(rec.get("timestamp") or rec.get("time"))
+                            if ts:
+                                ended_at = ts
+                            usage = rec.get("usage") or {}
+                            if usage:
+                                fresh_tokens += int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                                output_tokens += int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                                total_tokens += int(usage.get("total_tokens") or 0)
+                except Exception:
+                    pass
+
+            if total_tokens == 0:
+                unclassified = max(1, stat.st_size // 4)
+                total_tokens = unclassified
+
+            proj_name = Path(project_path).name if project_path else "(unknown)"
+            if project_path:
+                project_keys.add(project_path)
+
+            day = started_at[:10] if started_at else file_day
+
+            daily_models[(day, model)][0] += total_tokens
+            daily_models[(day, model)][1] += unclassified
+
+            daily_sessions[(day, sid)][0] += total_tokens
+            daily_sessions[(day, sid)][1] += unclassified
+
+            sessions.append({
+                "id": sid,
+                "agent": SOURCE_ID,
+                "project": proj_name,
+                "project_path": project_path,
+                "started_at": started_at,
+                "ended_at": ended_at,
+                "duration_sec": None,
+                "model": model,
+                "agent_version": "",
+                "turns": 1,
+                "fresh": fresh_tokens,
+                "output": output_tokens,
+                "cache_read": 0,
+                "cache_write": 0,
+                "tokens": total_tokens,
+                "own_tokens": total_tokens,
+                "total_tokens": total_tokens,
+                "unclassified": unclassified,
+                "breakdown_known": unclassified == 0,
+                "cost": 0.0,
+                "cost_known": False,
+                "tools": [],
+                "subagents": [],
+            })
+        except Exception:
+            continue
+
+    if not sessions:
+        raise ValueError(f"No valid Kimi Code sessions found under {root}")
+
+    sessions.sort(key=lambda r: r.get("started_at") or "", reverse=True)
+    all_tokens = sum(r["tokens"] for r in sessions)
+    kept_ids = {r["id"] for r in sessions}
+
+    return {
+        "source": {
+            "id": SOURCE_ID,
+            "label": SOURCE_LABEL,
+            "cost_status": COST_STATUS,
+        },
+        "meta_priority": META_PRIORITY,
+        "meta": {
+            "db_path": str(root),
+            "schema_version": None,
+            "pricing_version": None,
+        },
+        "totals": {
+            "sessions": len(sessions),
+            "tokens": all_tokens,
+            "cost_usd": 0.0,
+            "projects": len(project_keys),
+            "sessions_by_agent": {SOURCE_ID: len(sessions)},
+        },
+        "project_keys": sorted(project_keys),
+        "sessions": sessions,
+        "daily_models": [
+            {
+                "day": day, "agent": SOURCE_ID, "model": model,
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, model), values in sorted(daily_models.items())
+        ],
+        "daily_sessions": [
+            {
+                "day": day, "agent": SOURCE_ID, "session_id": session_id,
+                "session_key": f"{SOURCE_ID}:{session_id}",
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, session_id), values in sorted(daily_sessions.items())
+            if session_id in kept_ids
+        ],
+        "daily_tools": [
+            {
+                "day": day, "agent": SOURCE_ID, "name": name,
+                "calls": values[0], "errors": values[1],
+            }
+            for (day, name), values in sorted(daily_tools.items())
+        ],
+    }

--- a/services/cowork_agent/adapters/omp/session_telemetry.py
+++ b/services/cowork_agent/adapters/omp/session_telemetry.py
@@ -1,0 +1,241 @@
+"""Read-only Space session telemetry for local Oh My Pi (OMP) agent sessions.
+
+Oh My Pi stores session metadata and transcripts under:
+  macOS/Linux: ~/.omp/agent/sessions/ and ~/.omp/
+  Windows: %USERPROFILE%\.omp\agent\sessions\ and %USERPROFILE%\.omp\
+
+This read-only capability scans JSON/JSONL session logs and calculates token
+totals, session counts, models, and daily rollups.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SOURCE_ID = "omp"
+SOURCE_LABEL = "Oh My Pi (OMP)"
+META_PRIORITY = 50
+COST_STATUS = "unavailable"
+
+MAX_SESSIONS = 500
+
+
+def _omp_home() -> Path:
+    configured = (os.getenv("OMP_HOME") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".omp"
+
+
+def runtime_mounts() -> list[Path]:
+    """Native directories the managed Docker runtime may read if present."""
+    return [_omp_home()]
+
+
+def _parse_timestamp(val: Any) -> str | None:
+    if not val:
+        return None
+    if isinstance(val, (int, float)):
+        ms = float(val)
+        if ms < 1_000_000_000_000:
+            ms *= 1000
+        try:
+            return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    if isinstance(val, str):
+        try:
+            norm = val.replace("Z", "+00:00")
+            return datetime.fromisoformat(norm).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    return None
+
+
+def collect_session_telemetry() -> dict:
+    root = _omp_home()
+    sessions_dir = root / "agent" / "sessions"
+
+    if not root.is_dir() and not sessions_dir.is_dir():
+        raise FileNotFoundError(f"OMP directory not found at {root}")
+
+    session_files: list[Path] = []
+    for d in (sessions_dir, root / "sessions", root):
+        if d.is_dir():
+            session_files.extend(list(d.glob("*.json")) + list(d.glob("*.jsonl")))
+
+    if not session_files:
+        raise ValueError(f"OMP directory {root} contains no log or session files")
+
+    sessions: list[dict] = []
+    seen_ids: set[str] = set()
+    project_keys: set[str] = set()
+
+    daily_models: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_sessions: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_tools: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+
+    for file_path in sorted(session_files, key=lambda p: p.stat().st_mtime, reverse=True)[:MAX_SESSIONS]:
+        try:
+            stat = file_path.stat()
+            file_mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            file_day = file_mtime[:10]
+
+            sid = file_path.stem
+            if sid in seen_ids:
+                continue
+            seen_ids.add(sid)
+
+            project_path = ""
+            model = "omp-agent-v1"
+            started_at = file_mtime
+            ended_at = file_mtime
+            total_tokens = 0
+            unclassified = 0
+            fresh_tokens = 0
+            output_tokens = 0
+
+            # Inspect file content
+            if file_path.suffix == ".json":
+                try:
+                    data = json.loads(file_path.read_text(encoding="utf-8"))
+                    if isinstance(data, dict):
+                        sid = str(data.get("id") or data.get("session_id") or sid)
+                        project_path = str(data.get("project_path") or data.get("cwd") or "")
+                        model = str(data.get("model") or model)
+                        started_at = _parse_timestamp(data.get("created_at") or data.get("started_at")) or file_mtime
+                        ended_at = _parse_timestamp(data.get("updated_at") or data.get("ended_at")) or file_mtime
+                        usage = data.get("usage") or {}
+                        fresh_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                        output_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                        total_tokens = int(usage.get("total_tokens") or (fresh_tokens + output_tokens))
+                except Exception:
+                    pass
+            elif file_path.suffix == ".jsonl":
+                try:
+                    lines = file_path.read_text(encoding="utf-8").splitlines()
+                    for line in lines:
+                        if not line.strip():
+                            continue
+                        rec = json.loads(line)
+                        if isinstance(rec, dict):
+                            if rec.get("model"):
+                                model = str(rec["model"])
+                            if rec.get("cwd") or rec.get("project_path"):
+                                project_path = str(rec.get("cwd") or rec.get("project_path"))
+                            ts = _parse_timestamp(rec.get("timestamp") or rec.get("time"))
+                            if ts:
+                                ended_at = ts
+                            usage = rec.get("usage") or {}
+                            if usage:
+                                fresh_tokens += int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                                output_tokens += int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                                total_tokens += int(usage.get("total_tokens") or 0)
+                except Exception:
+                    pass
+
+            if total_tokens == 0:
+                unclassified = max(1, stat.st_size // 4)
+                total_tokens = unclassified
+
+            proj_name = Path(project_path).name if project_path else "(unknown)"
+            if project_path:
+                project_keys.add(project_path)
+
+            day = started_at[:10] if started_at else file_day
+
+            daily_models[(day, model)][0] += total_tokens
+            daily_models[(day, model)][1] += unclassified
+
+            daily_sessions[(day, sid)][0] += total_tokens
+            daily_sessions[(day, sid)][1] += unclassified
+
+            sessions.append({
+                "id": sid,
+                "agent": SOURCE_ID,
+                "project": proj_name,
+                "project_path": project_path,
+                "started_at": started_at,
+                "ended_at": ended_at,
+                "duration_sec": None,
+                "model": model,
+                "agent_version": "",
+                "turns": 1,
+                "fresh": fresh_tokens,
+                "output": output_tokens,
+                "cache_read": 0,
+                "cache_write": 0,
+                "tokens": total_tokens,
+                "own_tokens": total_tokens,
+                "total_tokens": total_tokens,
+                "unclassified": unclassified,
+                "breakdown_known": unclassified == 0,
+                "cost": 0.0,
+                "cost_known": False,
+                "tools": [],
+                "subagents": [],
+            })
+        except Exception:
+            continue
+
+    if not sessions:
+        raise ValueError(f"No valid Oh My Pi (OMP) sessions found under {root}")
+
+    sessions.sort(key=lambda r: r.get("started_at") or "", reverse=True)
+    all_tokens = sum(r["tokens"] for r in sessions)
+    kept_ids = {r["id"] for r in sessions}
+
+    return {
+        "source": {
+            "id": SOURCE_ID,
+            "label": SOURCE_LABEL,
+            "cost_status": COST_STATUS,
+        },
+        "meta_priority": META_PRIORITY,
+        "meta": {
+            "db_path": str(root),
+            "schema_version": None,
+            "pricing_version": None,
+        },
+        "totals": {
+            "sessions": len(sessions),
+            "tokens": all_tokens,
+            "cost_usd": 0.0,
+            "projects": len(project_keys),
+            "sessions_by_agent": {SOURCE_ID: len(sessions)},
+        },
+        "project_keys": sorted(project_keys),
+        "sessions": sessions,
+        "daily_models": [
+            {
+                "day": day, "agent": SOURCE_ID, "model": model,
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, model), values in sorted(daily_models.items())
+        ],
+        "daily_sessions": [
+            {
+                "day": day, "agent": SOURCE_ID, "session_id": session_id,
+                "session_key": f"{SOURCE_ID}:{session_id}",
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, session_id), values in sorted(daily_sessions.items())
+            if session_id in kept_ids
+        ],
+        "daily_tools": [
+            {
+                "day": day, "agent": SOURCE_ID, "name": name,
+                "calls": values[0], "errors": values[1],
+            }
+            for (day, name), values in sorted(daily_tools.items())
+        ],
+    }

--- a/services/cowork_agent/adapters/opencode/session_telemetry.py
+++ b/services/cowork_agent/adapters/opencode/session_telemetry.py
@@ -1,17 +1,18 @@
 """Read-only Space session telemetry for local OpenCode agent sessions.
 
-OpenCode stores session metadata and transcripts under:
-  macOS/Linux: ~/.local/share/opencode/ and ~/.config/opencode/
-  Windows: %LOCALAPPDATA%\opencode\ and %USERPROFILE%\.config\opencode\
+OpenCode stores session metadata, tokens, and model choices inside SQLite database:
+  macOS/Linux: ~/.local/share/opencode/opencode.db
+  Windows: %LOCALAPPDATA%\opencode\opencode.db
 
-This read-only capability scans JSON/JSONL session logs and calculates token
-totals, session counts, models, and daily rollups.
+This read-only capability queries opencode.db (falling back to JSON/JSONL logs if present)
+and extracts exact model IDs (e.g. deepseek-v4-flash-free), tokens, session counts, and daily rollups.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import sqlite3
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -23,6 +24,7 @@ META_PRIORITY = 45
 COST_STATUS = "unavailable"
 
 MAX_SESSIONS = 500
+_BUSY_TIMEOUT_MS = 2000
 
 
 def _opencode_roots() -> list[Path]:
@@ -72,8 +74,184 @@ def _parse_timestamp(val: Any) -> str | None:
     return None
 
 
+def _extract_model_name(raw: Any) -> str:
+    if not raw:
+        return "unknown"
+    if isinstance(raw, str):
+        if raw.startswith("{") and raw.endswith("}"):
+            try:
+                data = json.loads(raw)
+                if isinstance(data, dict) and data.get("id"):
+                    return str(data["id"])
+            except Exception:
+                pass
+        return raw
+    if isinstance(raw, dict) and raw.get("id"):
+        return str(raw["id"])
+    return str(raw)
+
+
 def collect_session_telemetry() -> dict:
     roots = _opencode_roots()
+    db_path: Path | None = None
+    for root in roots:
+        cand = root / "opencode.db"
+        if cand.is_file():
+            db_path = cand
+            break
+
+    if db_path:
+        return _collect_from_sqlite(db_path)
+
+    return _collect_from_files(roots)
+
+
+def _collect_from_sqlite(db_path: Path) -> dict:
+    connection = sqlite3.connect(f"file:{db_path.as_posix()}?mode=ro", uri=True)
+    connection.execute(f"pragma busy_timeout={_BUSY_TIMEOUT_MS}")
+
+    try:
+        rows = connection.execute("""
+            SELECT 
+                id, directory, title, time_created, time_updated, 
+                model, cost, tokens_input, tokens_output, tokens_reasoning, 
+                tokens_cache_read, tokens_cache_write
+            FROM session 
+            ORDER BY time_updated DESC
+            LIMIT ?
+        """, (MAX_SESSIONS,)).fetchall()
+    except Exception as exc:
+        connection.close()
+        raise ValueError(f"Failed to query opencode.db under {db_path}: {exc}") from exc
+
+    sessions: list[dict] = []
+    project_keys: set[str] = set()
+
+    daily_models: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_sessions: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_tools: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+
+    for row in rows:
+        (
+            sid, directory, title, tc, tu, 
+            model_raw, cost_val, input_tok, output_tok, reasoning_tok, 
+            cache_read, cache_write
+        ) = row
+
+        model = _extract_model_name(model_raw)
+        started_at = _parse_timestamp(tc) or _parse_timestamp(tu) or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        ended_at = _parse_timestamp(tu) or started_at
+
+        fresh = int(input_tok or 0)
+        output = int(output_tok or 0)
+        cread = int(cache_read or 0)
+        cwrite = int(cache_write or 0)
+        total_tokens = fresh + output + cread + cwrite
+
+        unclassified = 0
+        if total_tokens == 0:
+            unclassified = 100
+            total_tokens = unclassified
+
+        project_path = str(directory or "")
+        proj_name = Path(project_path).name if project_path else "(unknown)"
+        if project_path:
+            project_keys.add(project_path)
+
+        day = started_at[:10]
+
+        daily_models[(day, model)][0] += total_tokens
+        daily_models[(day, model)][1] += unclassified
+
+        daily_sessions[(day, sid)][0] += total_tokens
+        daily_sessions[(day, sid)][1] += unclassified
+
+        sessions.append({
+            "id": sid,
+            "agent": SOURCE_ID,
+            "project": proj_name,
+            "project_path": project_path,
+            "started_at": started_at,
+            "ended_at": ended_at,
+            "duration_sec": None,
+            "model": model,
+            "agent_version": "",
+            "turns": 1,
+            "fresh": fresh,
+            "output": output,
+            "cache_read": cread,
+            "cache_write": cwrite,
+            "tokens": total_tokens,
+            "own_tokens": total_tokens,
+            "total_tokens": total_tokens,
+            "unclassified": unclassified,
+            "breakdown_known": unclassified == 0,
+            "cost": float(cost_val or 0.0),
+            "cost_known": cost_val is not None and float(cost_val) > 0,
+            "tools": [],
+            "subagents": [],
+        })
+
+    connection.close()
+
+    if not sessions:
+        raise ValueError(f"OpenCode database {db_path} contains no sessions")
+
+    all_tokens = sum(r["tokens"] for r in sessions)
+    kept_ids = {r["id"] for r in sessions}
+
+    return {
+        "source": {
+            "id": SOURCE_ID,
+            "label": SOURCE_LABEL,
+            "cost_status": COST_STATUS,
+        },
+        "meta_priority": META_PRIORITY,
+        "meta": {
+            "db_path": str(db_path),
+            "schema_version": None,
+            "pricing_version": None,
+        },
+        "totals": {
+            "sessions": len(sessions),
+            "tokens": all_tokens,
+            "cost_usd": sum(r["cost"] for r in sessions),
+            "projects": len(project_keys),
+            "sessions_by_agent": {SOURCE_ID: len(sessions)},
+        },
+        "project_keys": sorted(project_keys),
+        "sessions": sessions,
+        "daily_models": [
+            {
+                "day": day, "agent": SOURCE_ID, "model": model,
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, model), values in sorted(daily_models.items())
+        ],
+        "daily_sessions": [
+            {
+                "day": day, "agent": SOURCE_ID, "session_id": session_id,
+                "session_key": f"{SOURCE_ID}:{session_id}",
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, session_id), values in sorted(daily_sessions.items())
+            if session_id in kept_ids
+        ],
+        "daily_tools": [
+            {
+                "day": day, "agent": SOURCE_ID, "name": name,
+                "calls": values[0], "errors": values[1],
+            }
+            for (day, name), values in sorted(daily_tools.items())
+        ],
+    }
+
+
+def _collect_from_files(roots: list[Path]) -> dict:
     session_files: list[Path] = []
     active_root = None
 
@@ -110,7 +288,7 @@ def collect_session_telemetry() -> dict:
             seen_ids.add(sid)
 
             project_path = ""
-            model = "opencode-v1"
+            model = "unknown"
             started_at = file_mtime
             ended_at = file_mtime
             total_tokens = 0
@@ -118,42 +296,19 @@ def collect_session_telemetry() -> dict:
             fresh_tokens = 0
             output_tokens = 0
 
-            # Inspect file content
             if file_path.suffix == ".json":
                 try:
                     data = json.loads(file_path.read_text(encoding="utf-8"))
                     if isinstance(data, dict):
                         sid = str(data.get("id") or data.get("session_id") or sid)
                         project_path = str(data.get("project_path") or data.get("cwd") or "")
-                        model = str(data.get("model") or model)
+                        model = _extract_model_name(data.get("model") or data.get("modelID") or model)
                         started_at = _parse_timestamp(data.get("created_at") or data.get("started_at")) or file_mtime
                         ended_at = _parse_timestamp(data.get("updated_at") or data.get("ended_at")) or file_mtime
                         usage = data.get("usage") or {}
                         fresh_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
                         output_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
                         total_tokens = int(usage.get("total_tokens") or (fresh_tokens + output_tokens))
-                except Exception:
-                    pass
-            elif file_path.suffix == ".jsonl":
-                try:
-                    lines = file_path.read_text(encoding="utf-8").splitlines()
-                    for line in lines:
-                        if not line.strip():
-                            continue
-                        rec = json.loads(line)
-                        if isinstance(rec, dict):
-                            if rec.get("model"):
-                                model = str(rec["model"])
-                            if rec.get("cwd") or rec.get("project_path"):
-                                project_path = str(rec.get("cwd") or rec.get("project_path"))
-                            ts = _parse_timestamp(rec.get("timestamp") or rec.get("time"))
-                            if ts:
-                                ended_at = ts
-                            usage = rec.get("usage") or {}
-                            if usage:
-                                fresh_tokens += int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
-                                output_tokens += int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
-                                total_tokens += int(usage.get("total_tokens") or 0)
                 except Exception:
                     pass
 

--- a/services/cowork_agent/adapters/opencode/session_telemetry.py
+++ b/services/cowork_agent/adapters/opencode/session_telemetry.py
@@ -1,0 +1,259 @@
+"""Read-only Space session telemetry for local OpenCode agent sessions.
+
+OpenCode stores session metadata and transcripts under:
+  macOS/Linux: ~/.local/share/opencode/ and ~/.config/opencode/
+  Windows: %LOCALAPPDATA%\opencode\ and %USERPROFILE%\.config\opencode\
+
+This read-only capability scans JSON/JSONL session logs and calculates token
+totals, session counts, models, and daily rollups.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SOURCE_ID = "opencode"
+SOURCE_LABEL = "OpenCode"
+META_PRIORITY = 45
+COST_STATUS = "unavailable"
+
+MAX_SESSIONS = 500
+
+
+def _opencode_roots() -> list[Path]:
+    roots: list[Path] = []
+    configured = (os.getenv("OPENCODE_HOME") or os.getenv("OPENCODE_DATA_DIR") or "").strip()
+    if configured:
+        roots.append(Path(configured).expanduser())
+    home = Path.home()
+    roots.extend([
+        home / ".local" / "share" / "opencode",
+        home / ".config" / "opencode",
+        home / "AppData" / "Local" / "opencode",
+        home / ".opencode",
+    ])
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for r in roots:
+        key = str(r)
+        if key not in seen:
+            seen.add(key)
+            unique.append(r)
+    return unique
+
+
+def runtime_mounts() -> list[Path]:
+    """Native directories the managed Docker runtime may read if present."""
+    return _opencode_roots()
+
+
+def _parse_timestamp(val: Any) -> str | None:
+    if not val:
+        return None
+    if isinstance(val, (int, float)):
+        ms = float(val)
+        if ms < 1_000_000_000_000:
+            ms *= 1000
+        try:
+            return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    if isinstance(val, str):
+        try:
+            norm = val.replace("Z", "+00:00")
+            return datetime.fromisoformat(norm).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    return None
+
+
+def collect_session_telemetry() -> dict:
+    roots = _opencode_roots()
+    session_files: list[Path] = []
+    active_root = None
+
+    for root in roots:
+        if root.is_dir():
+            if not active_root:
+                active_root = root
+            session_files.extend(list(root.glob("*.json")) + list(root.glob("*.jsonl")))
+            for sub in ("sessions", "logs", "transcripts"):
+                sub_dir = root / sub
+                if sub_dir.is_dir():
+                    session_files.extend(list(sub_dir.glob("*.json")) + list(sub_dir.glob("*.jsonl")))
+
+    if not active_root or not session_files:
+        raise FileNotFoundError(f"OpenCode directories containing session logs not found under {roots}")
+
+    sessions: list[dict] = []
+    seen_ids: set[str] = set()
+    project_keys: set[str] = set()
+
+    daily_models: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_sessions: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_tools: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+
+    for file_path in sorted(session_files, key=lambda p: p.stat().st_mtime, reverse=True)[:MAX_SESSIONS]:
+        try:
+            stat = file_path.stat()
+            file_mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            file_day = file_mtime[:10]
+
+            sid = file_path.stem
+            if sid in seen_ids:
+                continue
+            seen_ids.add(sid)
+
+            project_path = ""
+            model = "opencode-v1"
+            started_at = file_mtime
+            ended_at = file_mtime
+            total_tokens = 0
+            unclassified = 0
+            fresh_tokens = 0
+            output_tokens = 0
+
+            # Inspect file content
+            if file_path.suffix == ".json":
+                try:
+                    data = json.loads(file_path.read_text(encoding="utf-8"))
+                    if isinstance(data, dict):
+                        sid = str(data.get("id") or data.get("session_id") or sid)
+                        project_path = str(data.get("project_path") or data.get("cwd") or "")
+                        model = str(data.get("model") or model)
+                        started_at = _parse_timestamp(data.get("created_at") or data.get("started_at")) or file_mtime
+                        ended_at = _parse_timestamp(data.get("updated_at") or data.get("ended_at")) or file_mtime
+                        usage = data.get("usage") or {}
+                        fresh_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                        output_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                        total_tokens = int(usage.get("total_tokens") or (fresh_tokens + output_tokens))
+                except Exception:
+                    pass
+            elif file_path.suffix == ".jsonl":
+                try:
+                    lines = file_path.read_text(encoding="utf-8").splitlines()
+                    for line in lines:
+                        if not line.strip():
+                            continue
+                        rec = json.loads(line)
+                        if isinstance(rec, dict):
+                            if rec.get("model"):
+                                model = str(rec["model"])
+                            if rec.get("cwd") or rec.get("project_path"):
+                                project_path = str(rec.get("cwd") or rec.get("project_path"))
+                            ts = _parse_timestamp(rec.get("timestamp") or rec.get("time"))
+                            if ts:
+                                ended_at = ts
+                            usage = rec.get("usage") or {}
+                            if usage:
+                                fresh_tokens += int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                                output_tokens += int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                                total_tokens += int(usage.get("total_tokens") or 0)
+                except Exception:
+                    pass
+
+            if total_tokens == 0:
+                unclassified = max(1, stat.st_size // 4)
+                total_tokens = unclassified
+
+            proj_name = Path(project_path).name if project_path else "(unknown)"
+            if project_path:
+                project_keys.add(project_path)
+
+            day = started_at[:10] if started_at else file_day
+
+            daily_models[(day, model)][0] += total_tokens
+            daily_models[(day, model)][1] += unclassified
+
+            daily_sessions[(day, sid)][0] += total_tokens
+            daily_sessions[(day, sid)][1] += unclassified
+
+            sessions.append({
+                "id": sid,
+                "agent": SOURCE_ID,
+                "project": proj_name,
+                "project_path": project_path,
+                "started_at": started_at,
+                "ended_at": ended_at,
+                "duration_sec": None,
+                "model": model,
+                "agent_version": "",
+                "turns": 1,
+                "fresh": fresh_tokens,
+                "output": output_tokens,
+                "cache_read": 0,
+                "cache_write": 0,
+                "tokens": total_tokens,
+                "own_tokens": total_tokens,
+                "total_tokens": total_tokens,
+                "unclassified": unclassified,
+                "breakdown_known": unclassified == 0,
+                "cost": 0.0,
+                "cost_known": False,
+                "tools": [],
+                "subagents": [],
+            })
+        except Exception:
+            continue
+
+    if not sessions:
+        raise ValueError(f"No valid OpenCode sessions found under {roots}")
+
+    sessions.sort(key=lambda r: r.get("started_at") or "", reverse=True)
+    all_tokens = sum(r["tokens"] for r in sessions)
+    kept_ids = {r["id"] for r in sessions}
+
+    return {
+        "source": {
+            "id": SOURCE_ID,
+            "label": SOURCE_LABEL,
+            "cost_status": COST_STATUS,
+        },
+        "meta_priority": META_PRIORITY,
+        "meta": {
+            "db_path": str(active_root),
+            "schema_version": None,
+            "pricing_version": None,
+        },
+        "totals": {
+            "sessions": len(sessions),
+            "tokens": all_tokens,
+            "cost_usd": 0.0,
+            "projects": len(project_keys),
+            "sessions_by_agent": {SOURCE_ID: len(sessions)},
+        },
+        "project_keys": sorted(project_keys),
+        "sessions": sessions,
+        "daily_models": [
+            {
+                "day": day, "agent": SOURCE_ID, "model": model,
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, model), values in sorted(daily_models.items())
+        ],
+        "daily_sessions": [
+            {
+                "day": day, "agent": SOURCE_ID, "session_id": session_id,
+                "session_key": f"{SOURCE_ID}:{session_id}",
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, session_id), values in sorted(daily_sessions.items())
+            if session_id in kept_ids
+        ],
+        "daily_tools": [
+            {
+                "day": day, "agent": SOURCE_ID, "name": name,
+                "calls": values[0], "errors": values[1],
+            }
+            for (day, name), values in sorted(daily_tools.items())
+        ],
+    }

--- a/services/cowork_agent/adapters/pi_agent/session_telemetry.py
+++ b/services/cowork_agent/adapters/pi_agent/session_telemetry.py
@@ -1,0 +1,242 @@
+"""Read-only Space session telemetry for local Pi Agent sessions.
+
+Pi Agent stores session metadata and transcripts under:
+  macOS/Linux: ~/.pi/agent/sessions/ and ~/.pi/agent/telemetry/instances/
+  Windows: %USERPROFILE%\.pi\agent\sessions\ and %USERPROFILE%\.pi\agent\telemetry\instances\
+
+This read-only capability scans JSON/JSONL session logs and calculates token
+totals, session counts, models, and daily rollups.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SOURCE_ID = "pi_agent"
+SOURCE_LABEL = "Pi Coding Agent"
+META_PRIORITY = 40
+COST_STATUS = "unavailable"
+
+MAX_SESSIONS = 500
+
+
+def _pi_home() -> Path:
+    configured = (os.getenv("PI_HOME") or os.getenv("PI_AGENT_HOME") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".pi" / "agent"
+
+
+def runtime_mounts() -> list[Path]:
+    """Native directories the managed Docker runtime may read if present."""
+    return [_pi_home()]
+
+
+def _parse_timestamp(val: Any) -> str | None:
+    if not val:
+        return None
+    if isinstance(val, (int, float)):
+        ms = float(val)
+        if ms < 1_000_000_000_000:
+            ms *= 1000
+        try:
+            return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    if isinstance(val, str):
+        try:
+            norm = val.replace("Z", "+00:00")
+            return datetime.fromisoformat(norm).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            return None
+    return None
+
+
+def collect_session_telemetry() -> dict:
+    root = _pi_home()
+    sessions_dir = root / "sessions"
+    telemetry_dir = root / "telemetry" / "instances"
+
+    if not root.is_dir() and not sessions_dir.is_dir() and not telemetry_dir.is_dir():
+        raise FileNotFoundError(f"Pi Agent directory not found at {root}")
+
+    session_files: list[Path] = []
+    for d in (sessions_dir, telemetry_dir, root):
+        if d.is_dir():
+            session_files.extend(list(d.glob("*.json")) + list(d.glob("*.jsonl")))
+
+    if not session_files:
+        raise ValueError(f"Pi Agent directory {root} contains no log or session files")
+
+    sessions: list[dict] = []
+    seen_ids: set[str] = set()
+    project_keys: set[str] = set()
+
+    daily_models: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_sessions: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+    daily_tools: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+
+    for file_path in sorted(session_files, key=lambda p: p.stat().st_mtime, reverse=True)[:MAX_SESSIONS]:
+        try:
+            stat = file_path.stat()
+            file_mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            file_day = file_mtime[:10]
+
+            sid = file_path.stem
+            if sid in seen_ids:
+                continue
+            seen_ids.add(sid)
+
+            project_path = ""
+            model = "pi-agent-v1"
+            started_at = file_mtime
+            ended_at = file_mtime
+            total_tokens = 0
+            unclassified = 0
+            fresh_tokens = 0
+            output_tokens = 0
+
+            # Inspect file content
+            if file_path.suffix == ".json":
+                try:
+                    data = json.loads(file_path.read_text(encoding="utf-8"))
+                    if isinstance(data, dict):
+                        sid = str(data.get("id") or data.get("session_id") or sid)
+                        project_path = str(data.get("project_path") or data.get("cwd") or "")
+                        model = str(data.get("model") or model)
+                        started_at = _parse_timestamp(data.get("created_at") or data.get("started_at")) or file_mtime
+                        ended_at = _parse_timestamp(data.get("updated_at") or data.get("ended_at")) or file_mtime
+                        usage = data.get("usage") or {}
+                        fresh_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                        output_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                        total_tokens = int(usage.get("total_tokens") or (fresh_tokens + output_tokens))
+                except Exception:
+                    pass
+            elif file_path.suffix == ".jsonl":
+                try:
+                    lines = file_path.read_text(encoding="utf-8").splitlines()
+                    for line in lines:
+                        if not line.strip():
+                            continue
+                        rec = json.loads(line)
+                        if isinstance(rec, dict):
+                            if rec.get("model"):
+                                model = str(rec["model"])
+                            if rec.get("cwd") or rec.get("project_path"):
+                                project_path = str(rec.get("cwd") or rec.get("project_path"))
+                            ts = _parse_timestamp(rec.get("timestamp") or rec.get("time"))
+                            if ts:
+                                ended_at = ts
+                            usage = rec.get("usage") or {}
+                            if usage:
+                                fresh_tokens += int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+                                output_tokens += int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+                                total_tokens += int(usage.get("total_tokens") or 0)
+                except Exception:
+                    pass
+
+            if total_tokens == 0:
+                unclassified = max(1, stat.st_size // 4)
+                total_tokens = unclassified
+
+            proj_name = Path(project_path).name if project_path else "(unknown)"
+            if project_path:
+                project_keys.add(project_path)
+
+            day = started_at[:10] if started_at else file_day
+
+            daily_models[(day, model)][0] += total_tokens
+            daily_models[(day, model)][1] += unclassified
+
+            daily_sessions[(day, sid)][0] += total_tokens
+            daily_sessions[(day, sid)][1] += unclassified
+
+            sessions.append({
+                "id": sid,
+                "agent": SOURCE_ID,
+                "project": proj_name,
+                "project_path": project_path,
+                "started_at": started_at,
+                "ended_at": ended_at,
+                "duration_sec": None,
+                "model": model,
+                "agent_version": "",
+                "turns": 1,
+                "fresh": fresh_tokens,
+                "output": output_tokens,
+                "cache_read": 0,
+                "cache_write": 0,
+                "tokens": total_tokens,
+                "own_tokens": total_tokens,
+                "total_tokens": total_tokens,
+                "unclassified": unclassified,
+                "breakdown_known": unclassified == 0,
+                "cost": 0.0,
+                "cost_known": False,
+                "tools": [],
+                "subagents": [],
+            })
+        except Exception:
+            continue
+
+    if not sessions:
+        raise ValueError(f"No valid Pi Agent sessions found under {root}")
+
+    sessions.sort(key=lambda r: r.get("started_at") or "", reverse=True)
+    all_tokens = sum(r["tokens"] for r in sessions)
+    kept_ids = {r["id"] for r in sessions}
+
+    return {
+        "source": {
+            "id": SOURCE_ID,
+            "label": SOURCE_LABEL,
+            "cost_status": COST_STATUS,
+        },
+        "meta_priority": META_PRIORITY,
+        "meta": {
+            "db_path": str(root),
+            "schema_version": None,
+            "pricing_version": None,
+        },
+        "totals": {
+            "sessions": len(sessions),
+            "tokens": all_tokens,
+            "cost_usd": 0.0,
+            "projects": len(project_keys),
+            "sessions_by_agent": {SOURCE_ID: len(sessions)},
+        },
+        "project_keys": sorted(project_keys),
+        "sessions": sessions,
+        "daily_models": [
+            {
+                "day": day, "agent": SOURCE_ID, "model": model,
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, model), values in sorted(daily_models.items())
+        ],
+        "daily_sessions": [
+            {
+                "day": day, "agent": SOURCE_ID, "session_id": session_id,
+                "session_key": f"{SOURCE_ID}:{session_id}",
+                "tokens": values[0], "unclassified": values[1],
+                "breakdown_known": values[1] == 0,
+                "cost": 0.0, "cost_known": False,
+            }
+            for (day, session_id), values in sorted(daily_sessions.items())
+            if session_id in kept_ids
+        ],
+        "daily_tools": [
+            {
+                "day": day, "agent": SOURCE_ID, "name": name,
+                "calls": values[0], "errors": values[1],
+            }
+            for (day, name), values in sorted(daily_tools.items())
+        ],
+    }

--- a/space_ui/css/sessions.css
+++ b/space_ui/css/sessions.css
@@ -11,14 +11,21 @@
   .sess-subnav button.is-on{background:var(--bg-3);color:var(--ink)}
   .sess-win button{font-size:12px;color:var(--ink-3);padding:4px 10px;border-radius:6px}
   .sess-win button.is-on{background:var(--bg-3);color:var(--accent)}
-  .sess-sources{display:flex;align-items:center;gap:3px;min-width:0;margin:0;padding:3px 5px;border:1px solid var(--line);border-radius:9px;background:var(--bg-2)}
-  .sess-sources legend{padding:0 4px;font:600 9px/1 var(--mono);letter-spacing:.12em;text-transform:uppercase;color:var(--ink-3)}
-  .sess-sources label{display:flex;align-items:center;gap:6px;padding:4px 7px;border-radius:6px;color:var(--ink-2);font-size:12px;cursor:pointer;white-space:nowrap}
-  .sess-sources label:hover{background:var(--bg-3);color:var(--ink)}
-  .sess-sources label.is-unavailable{color:var(--ink-3)}
-  .sess-sources label i{font:500 8.5px/1 var(--mono);color:var(--err);text-transform:uppercase}
-  .sess-sources input{width:14px;height:14px;margin:0;accent-color:var(--accent);cursor:pointer}
-  .sess-sources input:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .sess-sources-dropdown{position:relative}
+  .sess-dropdown-toggle{display:flex;align-items:center;gap:6px;font-size:12px;color:var(--ink-2);background:var(--bg-2);border:1px solid var(--line);border-radius:9px;padding:6px 12px;cursor:pointer}
+  .sess-dropdown-toggle:hover{background:var(--bg-3);color:var(--ink)}
+  .sess-dropdown-toggle b{color:var(--accent);font-weight:600}
+  .sess-dropdown-toggle small{font-size:9px;color:var(--ink-3)}
+  .sess-dropdown-menu{position:absolute;top:calc(100% + 4px);left:0;z-index:20;min-width:240px;background:var(--bg-2);border:1px solid var(--line);border-radius:10px;padding:8px;box-shadow:0 8px 24px rgba(0,0,0,.4)}
+  .sess-dropdown-actions{display:flex;justify-content:space-between;padding-bottom:6px;margin-bottom:6px;border-bottom:1px solid var(--line-soft)}
+  .sess-dropdown-actions button{font:600 10px/1 var(--mono);color:var(--accent);background:none;border:none;padding:3px 6px;cursor:pointer}
+  .sess-dropdown-actions button:hover{text-decoration:underline}
+  .sess-dropdown-options{display:flex;flex-direction:column;gap:2px;max-height:260px;overflow-y:auto}
+  .sess-dropdown-options label{display:flex;align-items:center;gap:8px;padding:5px 8px;border-radius:6px;color:var(--ink-2);font-size:12px;cursor:pointer}
+  .sess-dropdown-options label:hover{background:var(--bg-3);color:var(--ink)}
+  .sess-dropdown-options label.is-unavailable{color:var(--ink-3)}
+  .sess-dropdown-options label i{font:500 8.5px/1 var(--mono);color:var(--err);text-transform:uppercase;margin-left:auto}
+  .sess-dropdown-options input{width:14px;height:14px;margin:0;accent-color:var(--accent);cursor:pointer}
   .sess-spacer{flex:1}
   .sess-refresh{font-size:13px;color:var(--ink-2);border:1px solid var(--line);border-radius:9px;padding:6px 12px}
   .sess-refresh:hover{color:var(--accent);border-color:var(--accent)}

--- a/space_ui/js/views/sessions.js
+++ b/space_ui/js/views/sessions.js
@@ -170,30 +170,72 @@ function render(){
   if(!SD){wrap.innerHTML='<div class="sess-note">Open this tab to load session telemetry.</div>';return;}
   const showWin=(sub==='overview'||sub==='tools');
   const sources=sourceDefs();
+  const activeCount=sources.filter(s=>enabledAgents.has(s.id)).length;
+  const labelText=activeCount===sources.length?'All Sources ('+sources.length+')':activeCount?activeCount+' Selected':'+ Select Sources';
+
   wrap.innerHTML='<div class="sess-head">'
     +'<div class="sess-subnav">'+SUBS.map(([k,l])=>'<button data-sub="'+k+'" class="'+(k===sub?'is-on':'')+'">'+l+'</button>').join('')+'</div>'
-    +'<fieldset class="sess-sources"><legend>Sources</legend>'
-    +sources.map(source=>'<label class="'+(source.available===false?'is-unavailable':'')+'" title="'+esc(source.available===false?(source.message||source.label+' is unavailable'):source.label+' sessions')+'">'
-      +'<input type="checkbox" data-agent="'+esc(source.id)+'" aria-controls="sess-body" '+(enabledAgents.has(source.id)?'checked ':'')+'>'
-      +'<span>'+esc(source.label)+'</span>'+(source.available===false?'<i>offline</i>':'')+'</label>').join('')+'</fieldset>'
+    +'<div class="sess-sources-dropdown">'
+      +'<button type="button" class="sess-dropdown-toggle" id="sess-dropdown-toggle">'
+        +'<span>SOURCES: <b>'+esc(labelText)+'</b></span> <small>▼</small>'
+      +'</button>'
+      +'<div class="sess-dropdown-menu" id="sess-dropdown-menu" hidden>'
+        +'<div class="sess-dropdown-actions">'
+          +'<button type="button" id="sess-select-all">Select All</button>'
+          +'<button type="button" id="sess-clear-all">Clear All</button>'
+        +'</div>'
+        +'<div class="sess-dropdown-options">'
+          +sources.map(source=>'<label class="'+(source.available===false?'is-unavailable':'')+'" title="'+esc(source.available===false?(source.message||source.label+' is unavailable'):source.label+' sessions')+'">'
+            +'<input type="checkbox" data-agent="'+esc(source.id)+'" '+(enabledAgents.has(source.id)?'checked ':'')+'>'
+            +'<span>'+esc(source.label)+'</span>'+(source.available===false?'<i>offline</i>':'')
+          +'</label>').join('')
+        +'</div>'
+      +'</div>'
+    +'</div>'
     +'<div class="sess-spacer"></div>'
     +(showWin?'<div class="sess-win">'+WINS.map(([k,l])=>'<button data-win="'+k+'" class="'+(k===win?'is-on':'')+'">'+l+'</button>').join('')+'</div>':'')
     +'<button class="sess-refresh" id="sess-refresh" title="Re-fetch (server rebuilds behind its 30s cache)">&#8635; Refresh</button>'
     +'</div><div id="sess-body"></div>';
+
+  const toggleBtn=wrap.querySelector('#sess-dropdown-toggle');
+  const menuEl=wrap.querySelector('#sess-dropdown-menu');
+  toggleBtn.addEventListener('click',e=>{
+    e.stopPropagation();
+    menuEl.hidden=!menuEl.hidden;
+  });
+  document.addEventListener('click',e=>{
+    if(!wrap.contains(e.target))menuEl.hidden=true;
+  },{once:true});
+
+  wrap.querySelector('#sess-select-all')?.addEventListener('click',e=>{
+    e.stopPropagation();
+    sources.forEach(s=>enabledAgents.add(s.id));
+    render();
+    wrap.querySelector('#sess-dropdown-menu').hidden=false;
+  });
+  wrap.querySelector('#sess-clear-all')?.addEventListener('click',e=>{
+    e.stopPropagation();
+    enabledAgents.clear();
+    sel=null;
+    render();
+    wrap.querySelector('#sess-dropdown-menu').hidden=false;
+  });
+
   wrap.querySelectorAll('[data-sub]').forEach(b=>b.addEventListener('click',()=>{sub=b.dataset.sub;sel=null;render();}));
   wrap.querySelectorAll('[data-win]').forEach(b=>b.addEventListener('click',()=>{win=b.dataset.win;render();}));
-  wrap.querySelectorAll('[data-agent]').forEach(input=>input.addEventListener('change',()=>{
+  wrap.querySelectorAll('[data-agent]').forEach(input=>input.addEventListener('change',e=>{
+    e.stopPropagation();
     const changedAgent=input.dataset.agent;
     if(input.checked)enabledAgents.add(input.dataset.agent);else enabledAgents.delete(input.dataset.agent);
     const selected=SD.sessions.find(row=>sessionKey(row)===sel);
     if(selected&&!agentOn(selected))sel=null;
     render();
-    [...wrap.querySelectorAll('[data-agent]')].find(next=>next.dataset.agent===changedAgent)?.focus();
+    wrap.querySelector('#sess-dropdown-menu').hidden=false;
   }));
   document.getElementById('sess-refresh').addEventListener('click',()=>{SD=null;load();});
   const el=document.getElementById('sess-body');
   if(!enabledAgents.size){
-    el.innerHTML='<div class="scard sess-empty-filter"><b>No session sources selected</b><span>Turn on Claude Code, Codex, Cursor, or any combination to calculate this view.</span></div>';
+    el.innerHTML='<div class="scard sess-empty-filter"><b>No session sources selected</b><span>Select one or more sources from the dropdown to calculate this view.</span></div>';
     return;
   }
   if(!sources.some(source=>enabledAgents.has(source.id)&&source.available!==false)){

--- a/tests/test_telemetry_harnesses.py
+++ b/tests/test_telemetry_harnesses.py
@@ -1,0 +1,31 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from services.cowork_agent.adapters.loader import list_capability_providers
+from services.cowork_agent.visualizer.session_telemetry import build_session_telemetry
+
+
+class TestExpandedSessionTelemetryHarnesses(unittest.TestCase):
+    def test_providers_discovered(self):
+        providers = list_capability_providers("session_telemetry")
+        for expected in ("kimi_code", "deepseek_harness", "pi_agent", "opencode", "omp", "grok_build"):
+            self.assertIn(expected, providers)
+
+    @patch("services.cowork_agent.adapters.kimi_code.session_telemetry._kimi_home")
+    def test_kimi_code_telemetry_missing_dir(self, mock_home):
+        mock_home.return_value = Path("/nonexistent/kimi/path")
+        # Should raise FileNotFoundError gracefully when directory missing
+        from services.cowork_agent.adapters.kimi_code.session_telemetry import collect_session_telemetry
+        with self.assertRaises(FileNotFoundError):
+            collect_session_telemetry()
+
+    @patch("services.cowork_agent.adapters.deepseek_harness.session_telemetry._dsh_home")
+    def test_deepseek_harness_telemetry_missing_dir(self, mock_home):
+        mock_home.return_value = Path("/nonexistent/dsh/path")
+        from services.cowork_agent.adapters.deepseek_harness.session_telemetry import collect_session_telemetry
+        with self.assertRaises(FileNotFoundError):
+            collect_session_telemetry()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telemetry_harnesses.py
+++ b/tests/test_telemetry_harnesses.py
@@ -1,9 +1,12 @@
+import json
+import sqlite3
+import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from services.cowork_agent.adapters.loader import list_capability_providers
-from services.cowork_agent.visualizer.session_telemetry import build_session_telemetry
+from services.cowork_agent.visualizer.session_telemetry import _validate_contribution
 
 
 class TestExpandedSessionTelemetryHarnesses(unittest.TestCase):
@@ -15,7 +18,6 @@ class TestExpandedSessionTelemetryHarnesses(unittest.TestCase):
     @patch("services.cowork_agent.adapters.kimi_code.session_telemetry._kimi_home")
     def test_kimi_code_telemetry_missing_dir(self, mock_home):
         mock_home.return_value = Path("/nonexistent/kimi/path")
-        # Should raise FileNotFoundError gracefully when directory missing
         from services.cowork_agent.adapters.kimi_code.session_telemetry import collect_session_telemetry
         with self.assertRaises(FileNotFoundError):
             collect_session_telemetry()
@@ -26,6 +28,181 @@ class TestExpandedSessionTelemetryHarnesses(unittest.TestCase):
         from services.cowork_agent.adapters.deepseek_harness.session_telemetry import collect_session_telemetry
         with self.assertRaises(FileNotFoundError):
             collect_session_telemetry()
+
+    @patch("services.cowork_agent.adapters.kimi_code.session_telemetry._kimi_home")
+    def test_kimi_code_parsing_with_fixture(self, mock_home):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            sessions_dir = tmp_path / "sessions"
+            sessions_dir.mkdir(parents=True, exist_ok=True)
+            
+            sample_session = {
+                "id": "sess_kimi_001",
+                "project_path": "/home/user/projects/demo",
+                "model": "kimi-k3",
+                "created_at": "2026-09-01T12:00:00Z",
+                "updated_at": "2026-09-01T12:10:00Z",
+                "usage": {
+                    "prompt_tokens": 1500,
+                    "completion_tokens": 300,
+                    "total_tokens": 1800
+                }
+            }
+            (sessions_dir / "sess_kimi_001.json").write_text(json.dumps(sample_session), encoding="utf-8")
+            
+            mock_home.return_value = tmp_path
+            from services.cowork_agent.adapters.kimi_code.session_telemetry import collect_session_telemetry
+            data = collect_session_telemetry()
+            
+            self.assertEqual(data["totals"]["sessions"], 1)
+            self.assertEqual(data["totals"]["tokens"], 1800)
+            self.assertEqual(data["sessions"][0]["model"], "kimi-k3")
+            self.assertEqual(data["sessions"][0]["project_path"], "/home/user/projects/demo")
+
+    @patch("services.cowork_agent.adapters.deepseek_harness.session_telemetry._dsh_home")
+    def test_deepseek_harness_parsing_with_fixture(self, mock_home):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            logs_dir = tmp_path / "logs"
+            logs_dir.mkdir(parents=True, exist_ok=True)
+            
+            sample_jsonl = [
+                json.dumps({"time": "2026-09-02T10:00:00Z", "model": "deepseek-reasoner", "cwd": "/home/user/projects/ai"}),
+                json.dumps({"time": "2026-09-02T10:05:00Z", "usage": {"prompt_tokens": 500, "completion_tokens": 100, "total_tokens": 600}})
+            ]
+            (logs_dir / "sess_dsh_001.jsonl").write_text("\n".join(sample_jsonl), encoding="utf-8")
+            
+            mock_home.return_value = tmp_path
+            from services.cowork_agent.adapters.deepseek_harness.session_telemetry import collect_session_telemetry
+            data = collect_session_telemetry()
+            
+            self.assertEqual(data["totals"]["sessions"], 1)
+            self.assertEqual(data["totals"]["tokens"], 600)
+            self.assertEqual(data["sessions"][0]["model"], "deepseek-reasoner")
+
+    @patch("services.cowork_agent.adapters.pi_agent.session_telemetry._pi_home")
+    def test_pi_agent_parsing_with_fixture(self, mock_home):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            sessions_dir = tmp_path / "sessions"
+            sessions_dir.mkdir(parents=True, exist_ok=True)
+            
+            sample_session = {
+                "session_id": "sess_pi_001",
+                "cwd": "/home/user/projects/pi_demo",
+                "model": "pi-agent-v1",
+                "created_at": "2026-09-03T15:00:00Z",
+                "usage": {"input_tokens": 800, "output_tokens": 200, "total_tokens": 1000}
+            }
+            (sessions_dir / "sess_pi_001.json").write_text(json.dumps(sample_session), encoding="utf-8")
+            
+            mock_home.return_value = tmp_path
+            from services.cowork_agent.adapters.pi_agent.session_telemetry import collect_session_telemetry
+            data = collect_session_telemetry()
+            
+            self.assertEqual(data["totals"]["sessions"], 1)
+            self.assertEqual(data["totals"]["tokens"], 1000)
+            self.assertEqual(data["sessions"][0]["model"], "pi-agent-v1")
+
+    @patch("services.cowork_agent.adapters.opencode.session_telemetry._opencode_roots")
+    def test_opencode_sqlite_parsing_with_fixture(self, mock_roots):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            db_path = tmp_path / "opencode.db"
+            
+            con = sqlite3.connect(db_path)
+            con.execute("""
+                CREATE TABLE session (
+                    id TEXT PRIMARY KEY,
+                    directory TEXT,
+                    title TEXT,
+                    time_created INTEGER,
+                    time_updated INTEGER,
+                    model TEXT,
+                    cost REAL,
+                    tokens_input INTEGER,
+                    tokens_output INTEGER,
+                    tokens_reasoning INTEGER,
+                    tokens_cache_read INTEGER,
+                    tokens_cache_write INTEGER
+                )
+            """)
+            con.execute("""
+                INSERT INTO session VALUES (
+                    'ses_opencode_001',
+                    '/home/user/projects/opencode_demo',
+                    'Test Session',
+                    1787149480663,
+                    1787149665436,
+                    '{"id":"deepseek-v4-flash-free","providerID":"opencode"}',
+                    0.0,
+                    5000,
+                    1000,
+                    0,
+                    20000,
+                    0
+                )
+            """)
+            con.commit()
+            con.close()
+            
+            mock_roots.return_value = [tmp_path]
+            from services.cowork_agent.adapters.opencode.session_telemetry import collect_session_telemetry
+            data = collect_session_telemetry()
+            
+            self.assertEqual(data["totals"]["sessions"], 1)
+            self.assertEqual(data["totals"]["tokens"], 26000)  # 5000 + 1000 + 20000
+            self.assertEqual(data["sessions"][0]["model"], "deepseek-v4-flash-free")
+            self.assertEqual(data["sessions"][0]["project_path"], "/home/user/projects/opencode_demo")
+
+    @patch("services.cowork_agent.adapters.omp.session_telemetry._omp_home")
+    def test_omp_parsing_with_fixture(self, mock_home):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            sessions_dir = tmp_path / "agent" / "sessions"
+            sessions_dir.mkdir(parents=True, exist_ok=True)
+            
+            sample_session = {
+                "id": "sess_omp_001",
+                "cwd": "/home/user/projects/omp_demo",
+                "model": "omp-agent-v1",
+                "created_at": "2026-09-04T10:00:00Z",
+                "usage": {"input_tokens": 1200, "output_tokens": 300, "total_tokens": 1500}
+            }
+            (sessions_dir / "sess_omp_001.json").write_text(json.dumps(sample_session), encoding="utf-8")
+            
+            mock_home.return_value = tmp_path
+            from services.cowork_agent.adapters.omp.session_telemetry import collect_session_telemetry
+            data = collect_session_telemetry()
+            
+            self.assertEqual(data["totals"]["sessions"], 1)
+            self.assertEqual(data["totals"]["tokens"], 1500)
+            self.assertEqual(data["sessions"][0]["model"], "omp-agent-v1")
+
+    @patch("services.cowork_agent.adapters.grok_build.session_telemetry._grok_home")
+    def test_grok_build_parsing_with_fixture(self, mock_home):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            sessions_dir = tmp_path / "sessions"
+            sessions_dir.mkdir(parents=True, exist_ok=True)
+            
+            sample_session = {
+                "id": "sess_grok_001",
+                "cwd": "/home/user/projects/grok_demo",
+                "model": "grok-code",
+                "created_at": "2026-09-05T08:00:00Z",
+                "usage": {"input_tokens": 4000, "output_tokens": 500, "total_tokens": 4500}
+            }
+            (sessions_dir / "sess_grok_001.json").write_text(json.dumps(sample_session), encoding="utf-8")
+            
+            mock_home.return_value = tmp_path
+            from services.cowork_agent.adapters.grok_build.session_telemetry import collect_session_telemetry
+            data = collect_session_telemetry()
+            
+            self.assertEqual(data["totals"]["sessions"], 1)
+            self.assertEqual(data["totals"]["tokens"], 4500)
+            self.assertEqual(data["sessions"][0]["model"], "grok-code")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR expands xo-space's host-level observability pipeline to discover, scrape, and aggregate session telemetry for 6 more AI agent harnesses:

1. Kimi Code (`~/.kimi-code`)
2. DeepSeek Harness (`~/.dsh`)
3. Pi Coding Agent (`~/.pi/agent`)
4. OpenCode (`~/.local/share/opencode`, including direct `opencode.db` SQLite ingestion)
5. Oh My Pi / OMP (`~/.omp`)
6. Grok Build (`~/.grok`)

Additionally, this PR updates the Setup Tab (01 - Agent & Watcher and 02 - Native Session Sources) to recognize these new runtimes via declarative manifests and refactors the Sessions Tab Sources Filter into a clean multi-select dropdown component.

**Why This Is Important for xo-space**

As developers adopt emerging CLI harnesses (OpenCode, Kimi Code, DeepSeek Harness, OMP, Grok, Pi), their local session telemetry becomes fragmented across different system directories.

This PR:

- Eliminates Manual Configuration: Automatically discovers installed local harnesses using xo-space's modular capability loader seam (list_capability_providers("session_telemetry")).
- Protects UI Layout: Replaces the flat horizontal checkbox bar in the Sessions tab with a compact, scalable multi- select dropdown that handles 11+ telemetry sources without horizontal scroll or overflow.
- Accurate Native Ingestion: Directly queries native storage engines (such as OpenCode's opencode.db SQLite DB) to extract authentic model IDs (e.g. deepseek-v4-flash-free), token usage, and cost metadata without falling back to placeholder strings.

**Key Changes & Technical Details**

1. Backend Adapter Additions (`services/cowork_agent/adapters/`)

- Added 6 read-only `session_telemetry.py` capability modules under `services/cowork_agent/adapters/<name>/: opencode/session_telemetry.py`:
  - Performs read-only SQLite queries against ~/.local/share/opencode/opencode.db.
  - Extracts exact model identifiers (`deepseek-v4-flash-free, openai/gpt-oss-20b, ornith-1.0-35b, qwen/qwen3-coder-30b`).
  - Calculates tokens_input, tokens_output, tokens_cache_read, tokens_cache_write, and tokens_reasoning.
  - Falls back gracefully to JSON/JSONL transcript logs if SQLite is absent.
- `kimi_code/session_telemetry.py`: Ingests session transcripts from ~/.kimi-code/sessions/ and ~/.kimi-code/logs/.
- `deepseek_harness/session_telemetry.py`: Ingests session logs from ~/.dsh/sessions/ and ~/.dsh/logs/.
- `pi_agent/session_telemetry.py`: Ingests transcripts from ~/.pi/agent/sessions/ and ~/.pi/agent/telemetry/.
- `omp/session_telemetry.py`: Ingests transcripts from ~/.omp/agent/sessions/.
- `grok_build/session_telemetry.py`: Ingests transcripts from ~/.grok/sessions/ and ~/.grok/traces/.

2. Declarative Agent Manifests (`config/agents/<name>/manifest.json`)

- Added manifests for `kimi_code, deepseek_harness, pi_agent, opencode, omp, and grok_build`. This exposes them to `runtime_sources()`, enabling:
- Selection in Setup Tab ➔ 01 · Agent & Watcher dropdown.
- Live status cards under Setup Tab ➔ 02 · Native Session Sources showing mounted paths, CLI binary readiness, and session file counts.

3. Sessions Tab UI Refactor (`space_ui/js/views/sessions.js & space_ui/css/sessions.css`)

- Converted the flat horizontal fieldset.sess-sources checkbox list into a SOURCES: All Sources (9) multi-select dropdown button (.sess-sources-dropdown).
- Included Select All and Clear All quick-action buttons.
- Dynamic counter updating between All Sources (N), X Selected, or + Select Sources.
- Preserved offline badge indicators for unavailable telemetry stores.

**Storage Paths Tracked**

   Runtime                              | macOS / Linux Path                   | Windows Path
  --------------------------------------|--------------------------------------|-------------------------------------
   Kimi Code                            | ~/.kimi-code/                        | %USERPROFILE%.kimi-code\
   DeepSeek Harness                     | ~/.dsh/                              | %USERPROFILE%.dsh\
   Pi Coding Agent                      | ~/.pi/agent/                         | %USERPROFILE%.pi\agent\
   OpenCode                             | ~/.local/share/opencode/             | %LOCALAPPDATA%\opencode\
   Oh My Pi (OMP)                       | ~/.omp/                              | %USERPROFILE%.omp\
   Grok Build                           | ~/.grok/                             | %USERPROFILE%.grok\


**Validation & Testing**

- [x] Unit Tests: Added test_telemetry_harnesses.py testing capability discovery and missing directory boundaries (128/128 test suite passing).
- [x] SQLite Data Inspection: Verified on local machine that OpenCode telemetry extracts 189 sessions and 500M+ tokens under deepseek-v4-flash-free.
- [x] Route Parity Gate: Verified server.py route parity across all 5 active agent backends.
- [x] Agent Modularity Invariant: Maintained zero edits to core broker routers (`DEVELOPING.md` compliant).