### PR TITLE
One executor for external commands: JSON CommandSpec, no shell path, guard test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@
 - Put endpoint modules in `routers/` via `APIRouter`.
 - Keep route handlers thin; move logic to clients/services.
 - Preserve request/response contracts unless explicitly requested.
+- Every external command runs through `utils/commands.py` (`run` / `run_spec` over an
+  argv list, `safe_arg` for untrusted values). No `shell=True`, no command strings;
+  `tests/test_command_executor.py` enforces it and holds the migration backlog.
 
 ## Agent-modular architecture (read before touching core)
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -64,6 +64,11 @@ services/
                                     vercel/ manus/ + shared rclone/ engine and token_store.py
     visualizer/  xo_projects_sync/  project_template/   subsystems
     helpers.py project_layout.py scopes.py xo_cowork_state.py skill_installer.py providers_status_lib.py
+
+utils/
+  commands.py                     THE ONE EXECUTOR for external commands: run/run_spec over an argv list,
+                                    CommandSpec.from_json, safe_arg; never a shell (see §7)
+  local_port.py                   deterministic local port selection
 ```
 
 The **only** two trees an agent author touches are `config/agents/<name>/` and
@@ -233,6 +238,25 @@ exceptions:
 ---
 
 ## 7. Conventions
+
+### One executor for external commands
+
+Every subprocess xo-space starts goes through `utils/commands.py`:
+`run(argv, ...)` / `run_sync(argv, ...)` for Python callers with a literal
+argv, and `CommandSpec.from_json({...})` + `run_spec(spec)` for anything
+described as data (the skill catalog, manifests, future automation). The
+spec is `{"argv": [...], "cwd", "env", "timeout"}`; there is deliberately no
+`command` string that reaches a shell, and `split_command()` refuses `&&`,
+`|`, `;`, redirections and `$()` outright. Untrusted values (a repo name, a
+branch, a path from a request) go into **one** argv slot via `safe_arg()`,
+which rejects anything starting with `-` so it cannot become a flag
+(argument injection, the quieter cousin of command injection, CWE-78).
+
+`tests/test_command_executor.py` enforces this: no shell form may appear
+anywhere, and a direct `subprocess` / `create_subprocess_exec` call is
+allowed only in the runner and in its `MIGRATION_BACKLOG` list, which may
+only shrink. Converting a file means removing it from that list.
+
 
 - **Thin routers, logic in services.** Endpoints live in `routers/` via
   `APIRouter`; business logic lives in `services/`. `server.py` is the only file

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -250,15 +250,21 @@ Every subprocess xo-space starts goes through `utils/commands.py`:
 `run(argv, ...)` / `run_sync(argv, ...)` for Python callers with a literal
 argv, and `CommandSpec.from_json({...})` + `run_spec(spec)` for anything
 described as data (the skill catalog, manifests, future automation). The
-spec is `{"argv": [...], "cwd", "env", "timeout"}`; there is deliberately no
-`command` string that reaches a shell, and `split_command()` refuses `&&`,
-`|`, `;`, redirections and `$()` outright. Untrusted values (a repo name, a
-branch, a path from a request) go into **one** argv slot via `safe_arg()`,
-which rejects anything starting with `-` so it cannot become a flag
-(argument injection, the quieter cousin of command injection, CWE-78).
+spec is `{"argv": [...], "cwd", "env", "timeout"}`; a `command` string is
+accepted for hand-written config but is split by `split_command()` with
+POSIX quoting, never handed to a shell, and refused outright when it holds
+`&&`, `|`, `;`, a redirection or `$()`. The skill catalog is the one
+data-driven consumer today: `_normalize` builds a `CommandSpec` per step, so
+cwd and timeout are validated once, by the spec, and `install` runs each
+step with `run_spec`. Untrusted values (a repo name, a branch, a path from a
+request) go into **one** argv slot via `safe_arg()`, which rejects anything
+starting with `-` so it cannot become a flag (argument injection, the
+quieter cousin of command injection, CWE-78).
 
 `tests/test_command_executor.py` enforces this: no shell form may appear
-anywhere, and a direct `subprocess` / `create_subprocess_exec` call is
+anywhere (`shell=True`, `create_subprocess_shell`, `os.system`/`popen`, the
+`os.exec*`/`os.spawn*`/`posix_spawn` family, `pty.spawn`), and both a direct
+`subprocess` / `create_subprocess_exec` call and an `import subprocess` are
 allowed only in the runner and in its `MIGRATION_BACKLOG` list, which may
 only shrink. Converting a file means removing it from that list.
 

--- a/config/skills/catalog.json
+++ b/config/skills/catalog.json
@@ -2,12 +2,12 @@
   "_shape": {
     "name": "required, unique",
     "description": "optional",
-    "command": "single shell command (use this OR commands, not both)",
-    "commands": ["step 1", "step 2 — run sequentially, stop at first failure"],
+    "command": "one command (use this OR commands, not both): an argv list like [\"npm\", \"install\", \"-g\", \"pkg\"] (preferred) or a string split with POSIX quoting — there is NO shell, so &&, |, ;, > and $() are rejected",
+    "commands": ["step 1", "step 2 — run sequentially, stop at first failure; each step is an argv list or a string as above"],
     "timeout_seconds": "optional, default 300, applies per command",
     "cwd": "optional working directory for every command",
     "success_message": "optional human-authored line shown on success; plain text or with placeholders; a default is used if omitted. Failure is always a generic 'Failed to install <name>.'",
-    "_placeholders": "in any command or success_message: {skills_dir} → active agent's <home_dir>/skills, {home_dir}, {agent_name}. Unknown {..} pass through. Path placeholders expand to raw paths — double-quote them in commands (--dir \"{skills_dir}\") so spaces survive."
+    "_placeholders": "in any command or success_message: {skills_dir} → active agent's <home_dir>/skills, {home_dir}, {agent_name}. Unknown {..} pass through. Placeholders are expanded per argv token after splitting, so a path with spaces stays one argument; no quoting needed."
   },
   "skills": [
     {

--- a/routers/cowork_agent/channels.py
+++ b/routers/cowork_agent/channels.py
@@ -27,6 +27,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+from utils.commands import run
 
 from services.cowork_agent.registry.agent_registry import get_active_agent
 from services.cowork_agent.registry.agent_env import upsert_env_entry
@@ -47,31 +48,19 @@ async def _run_one(platform: str, argv: list[str]) -> int:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     ts = datetime.now(timezone.utc).isoformat()
 
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            cwd=str(_AGENT.cwd),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
-        try:
-            stdout, _ = await asyncio.wait_for(
-                proc.communicate(), timeout=_AGENT.cli_timeout_seconds
-            )
-        except asyncio.TimeoutError:
-            proc.kill()
-            await proc.communicate()
-            _append_log(ts, platform, argv, f"[timed out after {_AGENT.cli_timeout_seconds}s]", rc="timeout")
-            return -1
-    except FileNotFoundError:
+    result = await run(argv, cwd=str(_AGENT.cwd), timeout=_AGENT.cli_timeout_seconds)
+    if result.timed_out:
+        _append_log(ts, platform, argv, f"[timed out after {_AGENT.cli_timeout_seconds}s]", rc="timeout")
+        return -1
+    if result.binary_missing:
         _append_log(ts, platform, argv, f"{_AGENT.binary} CLI not found in PATH", rc="missing-binary")
         return -1
-    except Exception as e:  # noqa: BLE001 — log and carry on
-        _append_log(ts, platform, argv, f"[exception] {e}", rc="exception")
+    if result.exception is not None:
+        _append_log(ts, platform, argv, result.output, rc="exception")
         return -1
 
-    _append_log(ts, platform, argv, stdout.decode(errors="replace"), rc=str(proc.returncode))
-    return proc.returncode
+    _append_log(ts, platform, argv, result.output, rc=str(result.returncode))
+    return result.returncode
 
 
 async def _run_provisioning_bg(platform: str, recipe: dict) -> None:

--- a/routers/cowork_agent/config.py
+++ b/routers/cowork_agent/config.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+from utils.commands import run
 
 from services.cowork_agent.registry.agent_registry import get_agent, get_active_agent
 from services.cowork_agent.helpers import _mask_sensitive
@@ -39,7 +40,8 @@ async def _run_provider_provisioning(provider_id: str, argvs: list[list[str]]) -
     its provisioning log.
 
     Argvs are pre-rendered from the manifest's command templates — no
-    user input is interpolated, so `create_subprocess_exec` is safe.
+    user input is interpolated, and every step runs through the shared
+    runner (`utils.commands.run`) as an argv list, so nothing reaches a shell.
     Chain aborts on the first non-zero exit so a broken `models set`
     doesn't leave later aliases pointing at nothing.
     """
@@ -51,21 +53,14 @@ async def _run_provider_provisioning(provider_id: str, argvs: list[list[str]]) -
         for argv in argvs:
             log.write(f"$ {' '.join(argv)}\n")
             log.flush()
-            try:
-                proc = await asyncio.create_subprocess_exec(
-                    *argv,
-                    cwd=str(_AGENT.cwd),
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.STDOUT,
-                )
-                stdout, _ = await proc.communicate()
-                log.write(stdout.decode(errors="replace"))
-                log.write(f"[exit {proc.returncode}]\n")
-                if proc.returncode != 0:
-                    log.write("[chain aborted]\n")
-                    return
-            except Exception as e:  # noqa: BLE001 — log every failure, keep going
-                log.write(f"[exception] {e}\n[chain aborted]\n")
+            result = await run(argv, cwd=str(_AGENT.cwd))
+            if result.binary_missing or result.exception is not None:
+                log.write(f"[exception] {result.output}\n[chain aborted]\n")
+                return
+            log.write(result.output)
+            log.write(f"[exit {result.returncode}]\n")
+            if result.returncode != 0:
+                log.write("[chain aborted]\n")
                 return
         log.write("[chain ok]\n")
 

--- a/routers/cowork_agent/config.py
+++ b/routers/cowork_agent/config.py
@@ -55,7 +55,9 @@ async def _run_provider_provisioning(provider_id: str, argvs: list[list[str]]) -
             log.flush()
             result = await run(argv, cwd=str(_AGENT.cwd))
             if result.binary_missing or result.exception is not None:
-                log.write(f"[exception] {result.output}\n[chain aborted]\n")
+                # result.output already carries the "[exception] " prefix on that path
+                reason = result.output if result.output.startswith("[exception]") else f"[exception] {result.output}"
+                log.write(f"{reason}\n[chain aborted]\n")
                 return
             log.write(result.output)
             log.write(f"[exit {result.returncode}]\n")

--- a/server.py
+++ b/server.py
@@ -7,7 +7,6 @@ import asyncio
 import os
 import json
 import datetime
-import subprocess
 import sys
 import uuid
 import shutil
@@ -25,6 +24,7 @@ import uvicorn
 from config.models.claude_code import ClaudeCodeClient
 from config.models.codex import CodexCodeClient
 from utils.local_port import LocalPortsUnavailableError, resolve_server_port
+from utils.commands import run_sync, spawn_detached
 
 # Load environment variables. Keys already exported by the shell (or by
 # docker -e / compose) are recorded first: they outrank every file below,
@@ -500,18 +500,17 @@ def _run_agent_setup() -> None:
     try:
         # 15-minute ceiling covers a cold first-time install (apt + Node + npm
         # + OpenClaw CLI). Steady-state re-runs finish in seconds.
-        result = subprocess.run(
-            ["bash", script],
-            cwd=repo_root,
-            check=False,
-            timeout=900,
-        )
-        if result.returncode == 0:
+        # inherit_output: the script's progress streams straight to the server
+        # log, as it always has, instead of appearing all at once at the end.
+        result = run_sync(["bash", script], cwd=repo_root, timeout=900, inherit_output=True)
+        if result.timed_out:
+            print(f"⚠️ Agent setup ({agent}) timed out after 15min (non-fatal)")
+        elif result.binary_missing or result.exception is not None:
+            print(f"⚠️ Agent setup ({agent}) failed (non-fatal): {result.output}")
+        elif result.returncode == 0:
             print(f"✅ Agent setup ({agent}) completed")
         else:
             print(f"⚠️ Agent setup ({agent}) exited with code {result.returncode} (non-fatal — server will still start)")
-    except subprocess.TimeoutExpired:
-        print(f"⚠️ Agent setup ({agent}) timed out after 15min (non-fatal)")
     except Exception as e:
         print(f"⚠️ Agent setup ({agent}) failed (non-fatal): {e}")
 
@@ -552,19 +551,15 @@ def _install_shared_deps() -> None:
         env = os.environ.copy()
         env["PATH"] = os.pathsep.join(
             [os.path.dirname(sys.executable), env.get("PATH", "")])
-        result = subprocess.run(
-            ["bash", script],
-            cwd=repo_root,
-            check=False,
-            timeout=600,
-            env=env,
-        )
-        if result.returncode == 0:
+        result = run_sync(["bash", script], cwd=repo_root, timeout=600, env=env, inherit_output=True)
+        if result.timed_out:
+            print("⚠️ Shared dep install timed out after 10min (non-fatal)")
+        elif result.binary_missing or result.exception is not None:
+            print(f"⚠️ Shared dep install failed (non-fatal): {result.output}")
+        elif result.returncode == 0:
             print("✅ Shared dep check completed")
         else:
             print(f"⚠️ Shared dep install exited with code {result.returncode} (non-fatal — server will still start)")
-    except subprocess.TimeoutExpired:
-        print("⚠️ Shared dep install timed out after 10min (non-fatal)")
     except Exception as e:
         print(f"⚠️ Shared dep install failed (non-fatal): {e}")
 
@@ -909,20 +904,16 @@ async def gateway_restart():
     script = (Path(__file__).resolve().parent / "config" / "agents" / agent / "agent.sh").resolve()
     if not script.exists() or not script.is_file():
         raise HTTPException(status_code=404, detail="Gateway script not found")
-    try:
-        result = subprocess.run(
-            [str(script), "restart"],
-            capture_output=True, text=True, timeout=30
-        )
-        return {
-            "status": "restarted" if result.returncode == 0 else "error",
-            "output": result.stdout,
-            "error": result.stderr if result.returncode != 0 else None
-        }
-    except subprocess.TimeoutExpired:
+    result = run_sync([str(script), "restart"], timeout=30, separate_stderr=True)
+    if result.timed_out:
         return {"status": "error", "error": "Restart timed out after 30s"}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail={"error": str(e)})
+    if result.binary_missing or result.exception is not None:
+        raise HTTPException(status_code=500, detail={"error": result.output})
+    return {
+        "status": "restarted" if result.returncode == 0 else "error",
+        "output": result.output,
+        "error": result.stderr if result.returncode != 0 else None
+    }
 
 
 @app.post("/app/restart")
@@ -935,20 +926,13 @@ async def app_restart():
     script = (Path(__file__).resolve().parent / "cowork-api.sh").resolve()
     if not script.exists() or not script.is_file():
         raise HTTPException(status_code=404, detail="App restart script not found")
-    try:
-        subprocess.Popen(
-            [str(script), "restart"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            cwd=str(script.parent),
-            start_new_session=True,
-        )
-        return {
-            "status": "accepted",
-            "message": "Restart triggered in background"
-        }
-    except Exception as e:
-        raise HTTPException(status_code=500, detail={"error": str(e)})
+    spawned = spawn_detached([str(script), "restart"], cwd=str(script.parent))
+    if not spawned.ok:
+        raise HTTPException(status_code=500, detail={"error": spawned.output})
+    return {
+        "status": "accepted",
+        "message": "Restart triggered in background"
+    }
 
 
 @app.post("/app/update")
@@ -958,20 +942,13 @@ async def app_update():
     script = (Path(__file__).resolve().parent / "cowork-update.sh").resolve()
     if not script.exists() or not script.is_file():
         raise HTTPException(status_code=404, detail="App update script not found")
-    try:
-        subprocess.Popen(
-            [str(script)],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            cwd=str(script.parent),
-            start_new_session=True,
-        )
-        return {
-            "status": "accepted",
-            "message": "Update triggered in background"
-        }
-    except Exception as e:
-        raise HTTPException(status_code=500, detail={"error": str(e)})
+    spawned = spawn_detached([str(script)], cwd=str(script.parent))
+    if not spawned.ok:
+        raise HTTPException(status_code=500, detail={"error": spawned.output})
+    return {
+        "status": "accepted",
+        "message": "Update triggered in background"
+    }
 
 
 @app.post("/ask_question")

--- a/server.py
+++ b/server.py
@@ -24,7 +24,7 @@ import uvicorn
 from config.models.claude_code import ClaudeCodeClient
 from config.models.codex import CodexCodeClient
 from utils.local_port import LocalPortsUnavailableError, resolve_server_port
-from utils.commands import run_sync, spawn_detached
+from utils.commands import run, run_sync, spawn_detached
 
 # Load environment variables. Keys already exported by the shell (or by
 # docker -e / compose) are recorded first: they outrank every file below,
@@ -845,13 +845,13 @@ async def gateway_restart():
     Resolves the script from the active ``AGENT_NAME`` rather than hardcoding a
     backend; agents without an ``agent.sh`` (e.g. claude_code) return 404.
     """
-    import subprocess
     from services.xo_manifest import resolve_agent_name
     agent = resolve_agent_name()
     script = (Path(__file__).resolve().parent / "config" / "agents" / agent / "agent.sh").resolve()
     if not script.exists() or not script.is_file():
         raise HTTPException(status_code=404, detail="Gateway script not found")
-    result = run_sync([str(script), "restart"], timeout=30, separate_stderr=True)
+    # await, not run_sync: a 30 s restart must not stall every other request
+    result = await run([str(script), "restart"], timeout=30, separate_stderr=True)
     if result.timed_out:
         return {"status": "error", "error": "Restart timed out after 30s"}
     if result.binary_missing or result.exception is not None:
@@ -866,7 +866,6 @@ async def gateway_restart():
 @app.post("/app/restart")
 async def app_restart():
     """Restart the XO Space API app process via cowork-api.sh."""
-    import subprocess
     # Timestamped marker: a restart kills every in-flight subprocess (e.g. a
     # pending auth login) — correlate this line with mid-flow failures.
     print(f"[app] restart requested at {datetime.datetime.now().isoformat()} — killing process tree")
@@ -885,7 +884,6 @@ async def app_restart():
 @app.post("/app/update")
 async def app_update():
     """Pull latest code safely via cowork-update.sh in background."""
-    import subprocess
     script = (Path(__file__).resolve().parent / "cowork-update.sh").resolve()
     if not script.exists() or not script.is_file():
         raise HTTPException(status_code=404, detail="App update script not found")

--- a/services/cowork_agent/connectors/github/cli_auth.py
+++ b/services/cowork_agent/connectors/github/cli_auth.py
@@ -18,6 +18,7 @@ Caveats (intentional, per Option B):
 from __future__ import annotations
 
 import asyncio
+from utils.commands import run
 import logging
 import os
 import re
@@ -182,19 +183,13 @@ async def _drain_until_exit(proc: asyncio.subprocess.Process, sid: str) -> None:
 
 async def _read_gh_token() -> str | None:
     """Fetch the active github.com token via `gh auth token`."""
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            GH_BIN, "auth", "token", "--hostname", GITHUB_HOSTNAME,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
-    except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
-        log.warning("Failed to read gh token: %s", exc)
+    res = await run([GH_BIN, "auth", "token", "--hostname", GITHUB_HOSTNAME], timeout=10, separate_stderr=True)
+    if res.timed_out or res.binary_missing or res.exception is not None:
+        log.warning("Failed to read gh token: %s", res.output.strip())
         return None
-    if proc.returncode != 0:
+    if res.returncode != 0:
         return None
-    token = stdout.decode("utf-8", errors="replace").strip()
+    token = res.output.strip()
     return token or None
 
 
@@ -233,17 +228,7 @@ async def start_login() -> dict[str, Any]:
         # Clear any prior `gh` session for github.com — `gh auth login` refuses
         # to start a fresh device flow when an account is already logged in.
         # Errors here are non-fatal (e.g. "not logged in" exits non-zero).
-        try:
-            logout = await asyncio.create_subprocess_exec(
-                GH_BIN, "auth", "logout", "--hostname", GITHUB_HOSTNAME,
-                env=env,
-                stdin=asyncio.subprocess.DEVNULL,
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            await asyncio.wait_for(logout.wait(), timeout=5)
-        except (asyncio.TimeoutError, FileNotFoundError, OSError):
-            pass
+        await run([GH_BIN, "auth", "logout", "--hostname", GITHUB_HOSTNAME], env=env, timeout=5)
 
         # `--insecure-storage` writes the token to a plain file under
         # ~/.config/gh — fine here because we immediately export it into

--- a/services/cowork_agent/connectors/github/cli_auth.py
+++ b/services/cowork_agent/connectors/github/cli_auth.py
@@ -18,7 +18,6 @@ Caveats (intentional, per Option B):
 from __future__ import annotations
 
 import asyncio
-from utils.commands import run
 import logging
 import os
 import re
@@ -27,6 +26,8 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Any
+
+from utils.commands import run
 
 from .common import (
     configure_git_identity,

--- a/services/cowork_agent/connectors/github/common.py
+++ b/services/cowork_agent/connectors/github/common.py
@@ -18,6 +18,7 @@ Token file: ~/.config/token.json  (see connectors/token_store.py)
 """
 
 import asyncio
+from utils.commands import run
 import logging
 import shutil
 from typing import Any, Literal
@@ -190,20 +191,11 @@ _SUBPROCESS_TIMEOUT_SECONDS = 10
 
 async def _run(*args: str) -> tuple[int, str]:
     """Run a command; return (returncode, merged output). Never raises."""
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *args,
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
-        stdout, _ = await asyncio.wait_for(
-            proc.communicate(), timeout=_SUBPROCESS_TIMEOUT_SECONDS
-        )
-    except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
-        log.warning("Command %s failed: %s", args[0], exc)
+    res = await run(list(args), timeout=_SUBPROCESS_TIMEOUT_SECONDS)
+    if res.timed_out or res.binary_missing or res.exception is not None:
+        log.warning("Command %s failed: %s", args[0], res.output.strip())
         return 1, ""
-    return proc.returncode or 0, stdout.decode("utf-8", "replace").strip()
+    return res.returncode or 0, res.output.strip()
 
 
 def commit_email(validation: dict[str, Any]) -> str:

--- a/services/cowork_agent/connectors/github/common.py
+++ b/services/cowork_agent/connectors/github/common.py
@@ -17,13 +17,13 @@ that is the ``auth_method`` field carried alongside it for display purposes.
 Token file: ~/.config/token.json  (see connectors/token_store.py)
 """
 
-import asyncio
-from utils.commands import run
 import logging
 import shutil
 from typing import Any, Literal
 
 import httpx
+
+from utils.commands import run
 
 from ..token_store import TOKEN_FILE, delete_entry, get_entry, set_entry
 

--- a/services/cowork_agent/connectors/rclone/connector.py
+++ b/services/cowork_agent/connectors/rclone/connector.py
@@ -23,6 +23,7 @@ daemon, no port held open except rclone's transient :53682 OAuth callback).
 """
 
 import asyncio
+from utils.commands import run
 import json
 import logging
 import os
@@ -124,26 +125,15 @@ async def _rclone_cli(*args: str, timeout: int = 30) -> str:
     non-zero exit. Always passes ``--config`` so commands target our project's
     rclone.conf."""
     full_args = ("rclone",) + args + ("--config", RCLONE_CONFIG_PATH)
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *full_args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-    except FileNotFoundError as exc:
-        raise RuntimeError("rclone binary not found in PATH") from exc
-
-    try:
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except asyncio.TimeoutError:
-        proc.kill()
-        await proc.wait()
+    res = await run(list(full_args), timeout=timeout, separate_stderr=True)
+    if res.binary_missing:
+        raise RuntimeError("rclone binary not found in PATH")
+    if res.timed_out:
         raise RuntimeError(f"rclone {args[0] if args else ''} timed out after {timeout}s")
-
-    if proc.returncode != 0:
-        err_text = (stderr or stdout).decode(errors="replace").strip()
-        raise RuntimeError(f"rclone error: {err_text or f'exit code {proc.returncode}'}")
-    return stdout.decode(errors="replace")
+    if res.returncode != 0:
+        err_text = (res.stderr or res.output).strip()
+        raise RuntimeError(f"rclone error: {err_text or f'exit code {res.returncode}'}")
+    return res.output
 
 
 async def _rclone_cli_stdin_stream(

--- a/services/cowork_agent/connectors/rclone/connector.py
+++ b/services/cowork_agent/connectors/rclone/connector.py
@@ -23,7 +23,6 @@ daemon, no port held open except rclone's transient :53682 OAuth callback).
 """
 
 import asyncio
-from utils.commands import run
 import json
 import logging
 import os
@@ -39,6 +38,8 @@ from pathlib import Path
 from typing import Any, AsyncIterator, Awaitable, Callable, Literal, Optional
 
 import httpx
+
+from utils.commands import run
 
 from .oauth_lock import (
     cancel_all_active_oauth,

--- a/services/cowork_agent/file_history.py
+++ b/services/cowork_agent/file_history.py
@@ -19,7 +19,7 @@ UI — that history was never part of the project's address space.
 from __future__ import annotations
 
 import re
-import subprocess
+from utils.commands import CommandResult, run_sync
 from pathlib import Path
 
 from services.cowork_agent.project_layout import project_dir, read_project_file
@@ -35,18 +35,12 @@ _COMMIT_RE = re.compile(r"[0-9a-fA-F]{4,40}")
 _LOG_FORMAT = "%x1e%H%x1f%an%x1f%aI%x1f%s"
 
 
-def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess | None:
+def _git(args: list[str], cwd: Path) -> CommandResult | None:
     """Run git, or return ``None`` when git itself is unavailable."""
-    try:
-        return subprocess.run(
-            ["git", *args],
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=GIT_TIMEOUT_SECONDS,
-        )
-    except (OSError, subprocess.TimeoutExpired):
+    res = run_sync(["git", *args], cwd=cwd, timeout=GIT_TIMEOUT_SECONDS, separate_stderr=True)
+    if res.binary_missing or res.timed_out or res.exception is not None:
         return None
+    return res
 
 
 def _repo_toplevel(file_dir: Path, project_root: Path) -> Path | None:

--- a/services/cowork_agent/file_history.py
+++ b/services/cowork_agent/file_history.py
@@ -19,10 +19,10 @@ UI — that history was never part of the project's address space.
 from __future__ import annotations
 
 import re
-from utils.commands import CommandResult, run_sync
 from pathlib import Path
 
 from services.cowork_agent.project_layout import project_dir, read_project_file
+from utils.commands import CommandResult, run_sync
 
 GIT_TIMEOUT_SECONDS = 10
 # One version's content — same ceiling as the live file preview

--- a/services/cowork_agent/project_sharing/git_ops.py
+++ b/services/cowork_agent/project_sharing/git_ops.py
@@ -6,21 +6,22 @@ the remote-tracking ref git itself updates after `git push`, so a machine can
 notice its own push without a network call."""
 from __future__ import annotations
 
-import asyncio
 import os
 from pathlib import Path
+
+from utils.commands import run
 
 _SEP = "\x1f"  # unit separator: cannot appear in git subjects/authors
 
 
 async def _run(repo_dir, *args) -> tuple[int, str, str]:
-    proc = await asyncio.create_subprocess_exec(
-        "git", "-C", str(repo_dir), *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    out, err = await proc.communicate()
-    return proc.returncode, out.decode(errors="replace"), err.decode(errors="replace")
+    """`git -C <repo_dir> <args>` through the one executor. (code, stdout, stderr);
+    a missing git binary or a runner exception is a non-zero code with the
+    reason in stderr, so every caller's failure branch already covers it."""
+    res = await run(["git", "-C", str(repo_dir), *args], separate_stderr=True)
+    if res.binary_missing or res.exception:
+        return res.returncode, "", res.output
+    return res.returncode, res.stdout, res.stderr
 
 
 async def origin_url(repo_dir) -> str | None:
@@ -112,26 +113,16 @@ async def clone(url: str, dest, *, config_args: list[str] | None = None,
     Returns (ok, stderr, timed_out). `config_args` carry `-c` credential
     overrides so the token never appears in the URL or in .git/config."""
     argv = ["git", *(config_args or []), "clone", "--", url, str(dest)]
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            *argv,
-            cwd=str(cwd) if cwd is not None else None,
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
-        )
-    except FileNotFoundError:
-        return False, "git not found in PATH", False
-    except Exception as exc:  # noqa: BLE001
-        return False, str(exc), False
-    try:
-        _, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except asyncio.TimeoutError:
-        proc.kill()
-        await proc.communicate()
+    # The runner closes stdin, so with GIT_TERMINAL_PROMPT=0 git can never
+    # block on a credential prompt; a private repo fails fast instead.
+    res = await run(argv, cwd=cwd, timeout=timeout,
+                    env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+                    separate_stderr=True)
+    if res.timed_out:
         return False, f"timed out after {timeout}s", True
-    return proc.returncode == 0, err.decode(errors="replace"), False
+    if res.binary_missing or res.exception:
+        return False, res.output, False
+    return res.ok, res.stderr, False
 
 
 async def behind_count(repo_dir, branch: str) -> int | None:

--- a/services/cowork_agent/providers_status_lib.py
+++ b/services/cowork_agent/providers_status_lib.py
@@ -25,6 +25,7 @@ Three things live here so the per-agent adapters can stay tiny:
 from __future__ import annotations
 
 import asyncio
+from utils.commands import run
 import json
 import os
 import shutil
@@ -131,28 +132,11 @@ async def claude_auth_status(
         or DEFAULT_CLAUDE_BIN
     if os.path.isabs(binary) and not os.path.isfile(binary):
         return {}
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            binary, "auth", "status", "--json",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-        )
-    except (FileNotFoundError, PermissionError):
+    res = await run([binary, "auth", "status", "--json"], env=env, timeout=timeout, separate_stderr=True)
+    if not res.ok:
         return {}
     try:
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-    except asyncio.TimeoutError:
-        try:
-            proc.kill()
-            await proc.communicate()
-        except Exception:
-            pass
-        return {}
-    if proc.returncode != 0:
-        return {}
-    try:
-        payload = json.loads((stdout or b"").decode("utf-8", errors="replace") or "{}")
+        payload = json.loads(res.output or "{}")
     except json.JSONDecodeError:
         return {}
     return payload if isinstance(payload, dict) else {}

--- a/services/cowork_agent/providers_status_lib.py
+++ b/services/cowork_agent/providers_status_lib.py
@@ -24,8 +24,6 @@ Three things live here so the per-agent adapters can stay tiny:
 
 from __future__ import annotations
 
-import asyncio
-from utils.commands import run
 import json
 import os
 import shutil
@@ -34,6 +32,7 @@ from typing import Any, Callable
 
 from services.cowork_agent.project_layout import xo_projects_root
 from services.xo_manifest import build_static_manifest
+from utils.commands import run
 
 CLAUDE_BIN_ENV = "CLAUDE_CLI_PATH"
 DEFAULT_CLAUDE_BIN = "claude"

--- a/services/cowork_agent/self_update.py
+++ b/services/cowork_agent/self_update.py
@@ -11,7 +11,7 @@ the running server keeps executing the old version until restarted.
 from __future__ import annotations
 
 import re
-import subprocess
+from utils.commands import CommandResult, run_sync
 from pathlib import Path
 from typing import Optional
 
@@ -29,14 +29,11 @@ class UpdateError(RuntimeError):
     """A git step failed in a way the caller should surface verbatim."""
 
 
-def _git(*args: str, timeout: float = 10.0) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["git", "-C", str(REPO_ROOT), *args],
-        capture_output=True, text=True, errors="replace", timeout=timeout,
-    )
+def _git(*args: str, timeout: float = 10.0) -> CommandResult:
+    return run_sync(["git", "-C", str(REPO_ROOT), *args], timeout=timeout, separate_stderr=True)
 
 
-def _line(res: subprocess.CompletedProcess) -> str:
+def _line(res: CommandResult) -> str:
     return (res.stdout or "").strip()
 
 
@@ -90,10 +87,9 @@ def check_update_status(fetch: bool = True) -> dict:
     }
 
     if fetch:
-        try:
-            fetched = _git("fetch", "--quiet", _REMOTE, branch,
-                           timeout=_FETCH_TIMEOUT_S)
-        except subprocess.TimeoutExpired:
+        fetched = _git("fetch", "--quiet", _REMOTE, branch,
+                       timeout=_FETCH_TIMEOUT_S)
+        if fetched.timed_out:
             fetched = None
         if fetched is None or fetched.returncode != 0:
             detail = _URL_USERINFO_RE.sub("//", (fetched.stderr if fetched else "timed out").strip())
@@ -159,7 +155,7 @@ def apply_update() -> dict:
     if merged.returncode != 0:
         raise UpdateError(
             "git merge --ff-only failed: "
-            + _URL_USERINFO_RE.sub("//", (merged.stderr or "").strip())[:300]
+            + _URL_USERINFO_RE.sub("//", (merged.stderr or merged.output or "").strip())[:300]
         )
 
     new = _commit_info("HEAD")

--- a/services/cowork_agent/self_update.py
+++ b/services/cowork_agent/self_update.py
@@ -11,9 +11,10 @@ the running server keeps executing the old version until restarted.
 from __future__ import annotations
 
 import re
-from utils.commands import CommandResult, run_sync
 from pathlib import Path
 from typing import Optional
+
+from utils.commands import CommandResult, run_sync
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 

--- a/services/cowork_agent/skill_catalog.py
+++ b/services/cowork_agent/skill_catalog.py
@@ -3,18 +3,22 @@ On-demand skill install catalog.
 
 Backs ``GET /api/skills/catalog`` and ``POST /api/skills/install``. The catalog
 file (``config/skills/catalog.json``) is the server-side source of truth
-mapping a skill name to one or more shell commands; clients only ever send a
+mapping a skill name to one or more commands; clients only ever send a
 name, and command text is never returned to them (entries may embed tokens or
-host paths). Distinct from ``skill_installer.py``, which copies repo-bundled
+host paths). Commands run through ``utils.commands`` as argv lists — there is
+no shell, so a catalog entry can never chain, pipe or redirect. Distinct from ``skill_installer.py``, which copies repo-bundled
 skills at startup.
 
 Catalog entry shape (one of ``command``/``commands`` is required):
 
     name             required, unique
     description      optional
-    command          single shell command string
-    commands         non-empty list of shell command strings, run
-                     sequentially, stopping at the first failure
+    command          one command: an argv list (preferred) or a string that
+                     is split with POSIX quoting and no shell
+    commands         non-empty list of such commands, run sequentially,
+                     stopping at the first failure; a string containing a
+                     shell operator (&&, |, ;, >, <, `, $() makes the entry
+                     invalid
     timeout_seconds  optional, default 300 — applies per command
     cwd              optional working directory for every command
     success_message  optional human-authored line returned as ``summary`` on
@@ -32,9 +36,10 @@ boot-time skills, declared per agent in
 """
 
 import asyncio
-import contextlib
 import json
 from pathlib import Path
+
+from utils.commands import CommandSpecError, run, split_command
 
 from services.cowork_agent.registry import agent_registry
 from services.cowork_agent.registry.settings import load_agent_config
@@ -104,9 +109,9 @@ async def install(name: str) -> dict:
     async with lock:
         steps: list[dict] = []
         ok = True
-        for index, command in enumerate(entry["commands"]):
+        for index, argv in enumerate(entry["commands"]):
             try:
-                rendered = _expand_placeholders(command)
+                rendered = [_expand_placeholders(token) for token in argv]
             except Exception as exc:
                 steps.append(_step_result(index, ok=False, exit_code=None, stdout="",
                                           stderr=f"placeholder expansion failed: {exc}",
@@ -251,6 +256,22 @@ def _lock_for(name: str) -> asyncio.Lock:
     return _locks.setdefault(name, asyncio.Lock())
 
 
+def _to_argv(step) -> list[str] | None:
+    """A catalog step is an argv list, or a string split without a shell.
+    None means the step is invalid (and so is its entry)."""
+    if isinstance(step, list):
+        if step and all(isinstance(t, str) and t for t in step):
+            return list(step)
+        return None
+    if isinstance(step, str):
+        try:
+            return split_command(step)
+        except CommandSpecError as exc:
+            print(f"⚠️ skill catalog: rejected command {step!r}: {exc}")
+            return None
+    return None
+
+
 def _normalize(entry) -> dict | None:
     """Validate one raw catalog entry; None means invalid (skip it)."""
     if not isinstance(entry, dict):
@@ -260,17 +281,18 @@ def _normalize(entry) -> dict | None:
         return None
 
     command, commands = entry.get("command"), entry.get("commands")
-    if isinstance(command, str) and command.strip() and commands is None:
-        resolved = [command]
-    elif (
-        command is None
-        and isinstance(commands, list)
-        and commands
-        and all(isinstance(c, str) and c.strip() for c in commands)
-    ):
-        resolved = list(commands)
+    if command is not None and commands is None:
+        raw_steps = [command]
+    elif command is None and isinstance(commands, list) and commands:
+        raw_steps = list(commands)
     else:
         return None
+    resolved: list[list[str]] = []
+    for step in raw_steps:
+        argv = _to_argv(step)
+        if argv is None:
+            return None
+        resolved.append(argv)
 
     timeout = entry.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
     if not isinstance(timeout, (int, float)) or isinstance(timeout, bool) or timeout <= 0:
@@ -292,40 +314,19 @@ def _normalize(entry) -> dict | None:
     }
 
 
-async def _run_step(index: int, command: str, timeout_seconds: float, cwd: str | None) -> dict:
-    loop = asyncio.get_running_loop()
-    started = loop.time()
-    try:
-        proc = await asyncio.create_subprocess_shell(
-            command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=cwd,
-        )
-    except Exception as exc:
-        return _step_result(index, ok=False, exit_code=None, stdout="",
-                            stderr=f"failed to start command: {exc}",
-                            duration=loop.time() - started, timed_out=False)
-
-    timed_out = False
-    try:
-        stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
-    except asyncio.TimeoutError:
-        timed_out = True
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-        await proc.wait()
-        stdout_b, stderr_b = b"", b""
-
-    exit_code = proc.returncode
+async def _run_step(index: int, argv: list[str], timeout_seconds: float, cwd: str | None) -> dict:
+    """One catalog step through the shared runner: argv, no shell. The runner
+    merges stdout and stderr, so the step reports them as one stream."""
+    result = await run(argv, cwd=cwd, timeout=timeout_seconds)
+    output = result.output[:_OUTPUT_CAP]
     return _step_result(
         index,
-        ok=(not timed_out and exit_code == 0),
-        exit_code=exit_code,
-        stdout=stdout_b.decode(errors="replace")[:_OUTPUT_CAP],
-        stderr=stderr_b.decode(errors="replace")[:_OUTPUT_CAP],
-        duration=loop.time() - started,
-        timed_out=timed_out,
+        ok=result.ok,
+        exit_code=None if result.binary_missing or result.exception else result.returncode,
+        stdout=output if result.ok else "",
+        stderr="" if result.ok else output,
+        duration=result.duration_seconds,
+        timed_out=result.timed_out,
     )
 
 

--- a/services/cowork_agent/skill_catalog.py
+++ b/services/cowork_agent/skill_catalog.py
@@ -39,10 +39,9 @@ import asyncio
 import json
 from pathlib import Path
 
-from utils.commands import CommandSpecError, run, split_command
-
 from services.cowork_agent.registry import agent_registry
 from services.cowork_agent.registry.settings import load_agent_config
+from utils.commands import CommandSpec, CommandSpecError, run_spec
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 CATALOG_PATH = _REPO_ROOT / "config" / "skills" / "catalog.json"
@@ -109,9 +108,9 @@ async def install(name: str) -> dict:
     async with lock:
         steps: list[dict] = []
         ok = True
-        for index, argv in enumerate(entry["commands"]):
+        for index, spec in enumerate(entry["specs"]):
             try:
-                rendered = [_expand_placeholders(token) for token in argv]
+                rendered = spec.with_argv([_expand_placeholders(token) for token in spec.argv])
             except Exception as exc:
                 steps.append(_step_result(index, ok=False, exit_code=None, stdout="",
                                           stderr=f"placeholder expansion failed: {exc}",
@@ -119,7 +118,7 @@ async def install(name: str) -> dict:
                 print(f"⚠️ skill install {name!r} step {index + 1}: placeholder expansion failed: {exc}")
                 ok = False
                 break
-            step = await _run_step(index, rendered, entry["timeout_seconds"], entry["cwd"])
+            step = await _run_step(index, rendered)
             steps.append(step)
             if not step["ok"]:
                 detail = step["stderr"].strip() or step["stdout"].strip()
@@ -256,24 +255,33 @@ def _lock_for(name: str) -> asyncio.Lock:
     return _locks.setdefault(name, asyncio.Lock())
 
 
-def _to_argv(step) -> list[str] | None:
-    """A catalog step is an argv list, or a string split without a shell.
-    None means the step is invalid (and so is its entry)."""
+def _to_spec(step, cwd, timeout) -> CommandSpec | None:
+    """One catalog step as a validated CommandSpec: an argv list, or a string
+    split without a shell. The entry's cwd and timeout ride on every step, so
+    the runner gets them from the spec and they are validated once, by the
+    same rules as every other data-driven command. None means the step is
+    invalid (and so is its entry)."""
     if isinstance(step, list):
-        if step and all(isinstance(t, str) and t for t in step):
-            return list(step)
+        obj: dict = {"argv": step}
+    elif isinstance(step, str):
+        obj = {"command": step}
+    else:
         return None
-    if isinstance(step, str):
-        try:
-            return split_command(step)
-        except CommandSpecError as exc:
-            print(f"⚠️ skill catalog: rejected command {step!r}: {exc}")
-            return None
-    return None
+    if cwd is not None:
+        obj["cwd"] = cwd
+    obj["timeout"] = timeout
+    try:
+        return CommandSpec.from_json(obj)
+    except CommandSpecError as exc:
+        print(f"⚠️ skill catalog: rejected command {step!r}: {exc}")
+        return None
 
 
 def _normalize(entry) -> dict | None:
-    """Validate one raw catalog entry; None means invalid (skip it)."""
+    """Validate one raw catalog entry; None means invalid (skip it).
+
+    `specs` is what runs; `commands`, `cwd` and `timeout_seconds` are the same
+    facts read back out of the specs for callers and tests that want plain data."""
     if not isinstance(entry, dict):
         return None
     name = entry.get("name")
@@ -287,19 +295,18 @@ def _normalize(entry) -> dict | None:
         raw_steps = list(commands)
     else:
         return None
-    resolved: list[list[str]] = []
-    for step in raw_steps:
-        argv = _to_argv(step)
-        if argv is None:
-            return None
-        resolved.append(argv)
 
     timeout = entry.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
-    if not isinstance(timeout, (int, float)) or isinstance(timeout, bool) or timeout <= 0:
-        return None
     cwd = entry.get("cwd")
-    if cwd is not None and not isinstance(cwd, str):
-        return None
+    if timeout is None:
+        return None  # an explicit null is a broken entry, not "use the default"
+    specs: list[CommandSpec] = []
+    for step in raw_steps:
+        spec = _to_spec(step, cwd, timeout)
+        if spec is None:
+            return None
+        specs.append(spec)
+
     success_message = entry.get("success_message")
     if success_message is not None and not isinstance(success_message, str):
         return None
@@ -307,26 +314,36 @@ def _normalize(entry) -> dict | None:
     return {
         "name": name.strip(),
         "description": entry.get("description") or "",
-        "commands": resolved,
-        "timeout_seconds": timeout,
-        "cwd": cwd,
+        "specs": specs,
+        "commands": [s.argv for s in specs],
+        "timeout_seconds": specs[0].timeout,
+        "cwd": specs[0].cwd,
         "success_message": success_message,
     }
 
 
-async def _run_step(index: int, argv: list[str], timeout_seconds: float, cwd: str | None) -> dict:
-    """One catalog step through the shared runner: argv, no shell. The runner
-    merges stdout and stderr, so the step reports them as one stream."""
-    result = await run(argv, cwd=cwd, timeout=timeout_seconds)
-    output = result.output[:_OUTPUT_CAP]
+async def _run_step(index: int, spec: CommandSpec) -> dict:
+    """One catalog step through the shared runner: a validated spec, no
+    shell, streams kept apart so the response keeps the stdout / stderr /
+    exit_code shape it has always had."""
+    result = await run_spec(spec, separate_stderr=True)
+    if result.binary_missing or result.exception is not None:
+        reason = result.exception or result.output
+        return _step_result(index, ok=False, exit_code=None, stdout="",
+                            stderr=f"failed to start command: {reason}",
+                            duration=result.duration_seconds, timed_out=False)
+    if result.timed_out:
+        # nothing usable was captured; exit_code is the kill signal (e.g. -9)
+        return _step_result(index, ok=False, exit_code=result.returncode, stdout="", stderr="",
+                            duration=result.duration_seconds, timed_out=True)
     return _step_result(
         index,
         ok=result.ok,
-        exit_code=None if result.binary_missing or result.exception else result.returncode,
-        stdout=output if result.ok else "",
-        stderr="" if result.ok else output,
+        exit_code=result.returncode,
+        stdout=result.output[:_OUTPUT_CAP],
+        stderr=result.stderr[:_OUTPUT_CAP],
         duration=result.duration_seconds,
-        timed_out=result.timed_out,
+        timed_out=False,
     )
 
 

--- a/services/cowork_agent/visualizer/space_index.py
+++ b/services/cowork_agent/visualizer/space_index.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import math
 import os
 import re
-import subprocess
+from utils.commands import run_sync
 import time
 from datetime import date, timedelta
 from pathlib import Path
@@ -138,14 +138,13 @@ def _git_facts(pdir: Path) -> tuple[
         # the timeline would render that foreign log as the project's lane.
         if not (pdir / ".git").exists():
             return {}, None, [], []
-        out = subprocess.run(
+        out = run_sync(
             [
                 "git", "-C", str(pdir), "log",
                 "--reverse", "--date=short",
                 "--pretty=format:%x01%ad%x02%s", "--name-only",
             ],
-            capture_output=True, text=True, errors="replace",
-            timeout=_GIT_TIMEOUT_S,
+            timeout=_GIT_TIMEOUT_S, separate_stderr=True,
         )
     except Exception:
         return {}, None, [], []

--- a/services/cowork_agent/visualizer/space_index.py
+++ b/services/cowork_agent/visualizer/space_index.py
@@ -14,11 +14,12 @@ from __future__ import annotations
 import math
 import os
 import re
-from utils.commands import run_sync
 import time
 from datetime import date, timedelta
 from pathlib import Path
 from typing import Optional
+
+from utils.commands import run_sync
 
 from services.cowork_agent.project_layout import (
     list_projects,

--- a/services/cowork_agent/xo_projects_sync/crypto.py
+++ b/services/cowork_agent/xo_projects_sync/crypto.py
@@ -16,6 +16,7 @@ backups silently.
 from __future__ import annotations
 
 import asyncio
+from utils.commands import run
 import shutil
 from pathlib import Path
 
@@ -81,27 +82,21 @@ async def encrypt_to_chunks(
     if ciphertext_tmp.exists():
         ciphertext_tmp.unlink()
 
-    proc = await asyncio.create_subprocess_exec(
-        "gpg",
-        "--batch",
-        "--yes",
-        "--quiet",
-        "--no-symkey-cache",
-        "--cipher-algo", "AES256",
-        "--symmetric",
-        "--passphrase-fd", "0",
-        "-o", str(ciphertext_tmp),
-        str(plaintext_path),
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.PIPE,
+    res = await run(
+        [
+            "gpg", "--batch", "--yes", "--quiet", "--no-symkey-cache",
+            "--cipher-algo", "AES256", "--symmetric", "--passphrase-fd", "0",
+            "-o", str(ciphertext_tmp), str(plaintext_path),
+        ],
+        input=passphrase.encode("utf-8"), separate_stderr=True,
     )
-    _, stderr = await proc.communicate(input=passphrase.encode("utf-8"))
-    if proc.returncode != 0:
+    if res.binary_missing:
+        raise FileNotFoundError(res.output)
+    if res.returncode != 0:
         # Clean up partial output before raising so the next attempt isn't confused.
         if ciphertext_tmp.exists():
             ciphertext_tmp.unlink()
-        raise GpgFailedError(f"gpg encrypt failed: {stderr.decode('utf-8', 'replace').strip()}")
+        raise GpgFailedError(f"gpg encrypt failed: {(res.stderr or res.output).strip()}")
 
     parts = _split_into_parts(ciphertext_tmp, output_dir)
     ciphertext_tmp.unlink()
@@ -172,23 +167,18 @@ async def decrypt_from_chunks(
                         break
                     dst.write(chunk)
 
-    proc = await asyncio.create_subprocess_exec(
-        "gpg",
-        "--batch",
-        "--yes",
-        "--quiet",
-        "--no-symkey-cache",
-        "--decrypt",
-        "--passphrase-fd", "0",
-        "-o", str(output_path),
-        str(ciphertext_tmp),
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.PIPE,
+    res = await run(
+        [
+            "gpg", "--batch", "--yes", "--quiet", "--no-symkey-cache",
+            "--decrypt", "--passphrase-fd", "0",
+            "-o", str(output_path), str(ciphertext_tmp),
+        ],
+        input=passphrase.encode("utf-8"), separate_stderr=True,
     )
-    _, stderr = await proc.communicate(input=passphrase.encode("utf-8"))
+    if res.binary_missing:
+        raise FileNotFoundError(res.output)
     ciphertext_tmp.unlink()  # always remove the reassembled ciphertext
-    if proc.returncode != 0:
+    if res.returncode != 0:
         if output_path.exists():
             output_path.unlink()  # don't leave a partial plaintext
-        raise GpgFailedError(f"gpg decrypt failed: {stderr.decode('utf-8', 'replace').strip()}")
+        raise GpgFailedError(f"gpg decrypt failed: {(res.stderr or res.output).strip()}")

--- a/services/cowork_agent/xo_projects_sync/crypto.py
+++ b/services/cowork_agent/xo_projects_sync/crypto.py
@@ -15,10 +15,10 @@ backups silently.
 
 from __future__ import annotations
 
-import asyncio
-from utils.commands import run
 import shutil
 from pathlib import Path
+
+from utils.commands import run
 
 from .config import CHUNK_SIZE_BYTES
 

--- a/services/cowork_agent/xo_projects_sync/github.py
+++ b/services/cowork_agent/xo_projects_sync/github.py
@@ -27,6 +27,7 @@ persistent staging directory.
 from __future__ import annotations
 
 import asyncio
+from utils.commands import run
 import base64
 import shutil
 from dataclasses import dataclass
@@ -100,13 +101,8 @@ async def repo_exists(owner: str, name: str, *, auth: GitHubAuth) -> bool:
         # gh respects its own auth, which may be a different identity than
         # `auth.token`. We still trust it because the design routes both
         # gh-via-UI and PAT-via-UI through the same connector lookup.
-        proc = await asyncio.create_subprocess_exec(
-            "gh", "repo", "view", f"{owner}/{name}",
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        await proc.wait()
-        if proc.returncode == 0:
+        res = await run(["gh", "repo", "view", f"{owner}/{name}"])
+        if res.ok:
             return True
         # Fall through to REST — gh may have failed for reasons other than 404
         # (e.g. unauthenticated host). REST gives a precise status.
@@ -128,21 +124,18 @@ async def create_repo(owner: str, name: str, *, auth: GitHubAuth) -> str:
     `discover_owner(auth)` for the fallback to succeed.
     """
     if await _gh_cli_authenticated():
-        proc = await asyncio.create_subprocess_exec(
+        res = await run([
             "gh", "repo", "create", f"{owner}/{name}",
             "--private",
             "--add-readme",
             "--description", "Encrypted xo-project backup (auto-managed by xo-space).",
             "--confirm",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await proc.communicate()
-        if proc.returncode == 0:
+        ], separate_stderr=True)
+        if res.ok:
             return f"https://github.com/{owner}/{name}.git"
         # gh failed; surface the error but try REST too so we don't fail
         # the whole setup on transient gh issues.
-        gh_err = stderr.decode("utf-8", "replace").strip()
+        gh_err = (res.stderr or res.output).strip()
     else:
         gh_err = None
 
@@ -221,13 +214,8 @@ async def commit_and_push_in(path: Path, message: str, *, auth: GitHubAuth) -> b
     """
     await _git(["add", "-A"], cwd=path, auth=None)
     # `git status --porcelain` lists nothing iff working tree is clean.
-    proc = await asyncio.create_subprocess_exec(
-        "git", "-C", str(path), "status", "--porcelain",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, _ = await proc.communicate()
-    if not stdout.strip():
+    res = await run(["git", "-C", str(path), "status", "--porcelain"], separate_stderr=True)
+    if not res.output.strip():
         return False
     await _git(["commit", "-m", message], cwd=path, auth=None)
     await _git(["push", "origin", "HEAD"], cwd=path, auth=auth)
@@ -261,30 +249,22 @@ async def _git(args: list[str], *, cwd: Path, auth: GitHubAuth | None) -> str:
     if auth is not None:
         full += ["-c", f"http.https://github.com/.extraheader={_git_extraheader(auth)}"]
     full += ["-C", str(cwd)] + args
-    proc = await asyncio.create_subprocess_exec(
-        *full,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, stderr = await proc.communicate()
-    if proc.returncode != 0:
+    res = await run(full, separate_stderr=True)
+    if res.binary_missing:
+        raise FileNotFoundError(res.output)
+    if res.returncode != 0:
         # Strip the auth header from any echoed args before surfacing.
-        err = stderr.decode("utf-8", "replace").strip()
+        err = (res.stderr or res.output).strip()
         raise RuntimeError(f"git {' '.join(args)} failed: {err}")
-    return stdout.decode("utf-8", "replace")
+    return res.output
 
 
 async def _gh_cli_authenticated() -> bool:
     """`gh` is on PATH AND `gh auth status` exits zero for github.com."""
     if shutil.which("gh") is None:
         return False
-    proc = await asyncio.create_subprocess_exec(
-        "gh", "auth", "status", "--hostname", "github.com",
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
-    await proc.wait()
-    return proc.returncode == 0
+    res = await run(["gh", "auth", "status", "--hostname", "github.com"])
+    return res.ok
 
 
 async def _get(auth: GitHubAuth, path: str) -> dict[str, Any]:

--- a/services/cowork_agent/xo_projects_sync/github.py
+++ b/services/cowork_agent/xo_projects_sync/github.py
@@ -26,8 +26,6 @@ persistent staging directory.
 
 from __future__ import annotations
 
-import asyncio
-from utils.commands import run
 import base64
 import shutil
 from dataclasses import dataclass
@@ -37,6 +35,7 @@ from typing import Any
 import httpx
 
 from services.cowork_agent.connectors import github as github_connector
+from utils.commands import run
 
 from .config import BACKUP_REPO_PREFIX, ENV_GITHUB_PAT
 

--- a/services/cowork_agent/xo_projects_sync/tarball.py
+++ b/services/cowork_agent/xo_projects_sync/tarball.py
@@ -24,6 +24,7 @@ Two decisions worth understanding before editing:
 from __future__ import annotations
 
 import asyncio
+from utils.commands import run
 import fnmatch
 import os
 import tarfile
@@ -66,24 +67,19 @@ def _path_has_excluded_component(rel_parts: tuple[str, ...]) -> bool:
 
 async def _git_ls_files(project_dir: Path) -> list[str]:
     """Tracked + untracked-but-not-ignored files, as project-relative paths."""
-    proc = await asyncio.create_subprocess_exec(
-        "git",
-        "-C", str(project_dir),
-        "ls-files",
-        "--cached",
-        "--others",
-        "--exclude-standard",
-        "-z",  # NUL-delimited; handles paths with newlines/spaces
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+    res = await run(
+        ["git", "-C", str(project_dir), "ls-files", "--cached", "--others", "--exclude-standard",
+         "-z"],  # NUL-delimited; handles paths with newlines/spaces
+        separate_stderr=True,
     )
-    stdout, stderr = await proc.communicate()
-    if proc.returncode != 0:
+    if res.binary_missing:
+        raise FileNotFoundError(res.output)
+    if res.returncode != 0:
         raise RuntimeError(
-            f"git ls-files failed in {project_dir}: {stderr.decode('utf-8', 'replace').strip()}"
+            f"git ls-files failed in {project_dir}: {(res.stderr or res.output).strip()}"
         )
     # Trailing NUL is normal; filter empties.
-    return [p for p in stdout.decode("utf-8", "replace").split("\x00") if p]
+    return [p for p in res.output.split("\x00") if p]
 
 
 def _walk_files(project_dir: Path) -> list[str]:

--- a/services/cowork_agent/xo_projects_sync/tarball.py
+++ b/services/cowork_agent/xo_projects_sync/tarball.py
@@ -23,12 +23,12 @@ Two decisions worth understanding before editing:
 
 from __future__ import annotations
 
-import asyncio
-from utils.commands import run
 import fnmatch
 import os
 import tarfile
 from pathlib import Path
+
+from utils.commands import run
 
 
 # Path-component names that always cause a file or directory to be skipped.

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from utils.commands import (
+    CommandResult,
+    CommandSpec,
+    CommandSpecError,
+    run_spec,
+    safe_arg,
+    split_command,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+class CommandSpecTests(unittest.TestCase):
+    def test_argv_spec_round_trips(self) -> None:
+        spec = CommandSpec.from_json({"argv": ["git", "fetch", "origin"], "cwd": "/tmp", "timeout": 5, "env": {"A": "1"}})
+        self.assertEqual(spec.argv, ["git", "fetch", "origin"])
+        self.assertEqual((spec.cwd, spec.timeout, spec.env), ("/tmp", 5.0, {"A": "1"}))
+
+    def test_rejects_malformed_specs(self) -> None:
+        bad = [
+            {},                                           # nothing to run
+            {"argv": []},                                 # empty
+            {"argv": ["git", 3]},                         # non-string
+            {"argv": ["git"], "command": "git"},          # both forms
+            {"argv": ["git"], "shell": True},             # unknown key (there is no shell knob)
+            {"argv": ["git"], "timeout": 0},
+            {"argv": ["git"], "timeout": True},
+            {"argv": ["git"], "cwd": ""},
+            {"argv": ["git"], "env": {"A": 1}},
+            "git fetch",                                  # not an object
+        ]
+        for obj in bad:
+            with self.subTest(obj=obj), self.assertRaises(CommandSpecError):
+                CommandSpec.from_json(obj)
+
+    def test_string_command_is_split_without_a_shell(self) -> None:
+        spec = CommandSpec.from_json({"command": 'npx skills add okx/onchainos-skills --yes -g'})
+        self.assertEqual(spec.argv, ["npx", "skills", "add", "okx/onchainos-skills", "--yes", "-g"])
+        spec = CommandSpec.from_json({"command": 'tool --dir "/home/some user/skills"'})
+        self.assertEqual(spec.argv, ["tool", "--dir", "/home/some user/skills"])
+
+    def test_shell_operators_are_refused(self) -> None:
+        for cmd in ("a && b", "a || b", "a | b", "a; b", "a > f", "a < f", "echo `id`", "echo $(id)"):
+            with self.subTest(cmd=cmd), self.assertRaises(CommandSpecError):
+                split_command(cmd)
+        with self.assertRaises(CommandSpecError):
+            split_command('unbalanced "quote')
+
+
+class SafeArgTests(unittest.TestCase):
+    def test_refuses_options_and_junk(self) -> None:
+        self.assertEqual(safe_arg("main"), "main")
+        self.assertEqual(safe_arg("-v", allow_option=True), "-v")
+        for value in ("", "--upload-pack=evil", "-c", None, 3):
+            with self.subTest(value=value), self.assertRaises(CommandSpecError):
+                safe_arg(value)
+
+
+class RunSpecTests(unittest.TestCase):
+    """The runner is the one place that may spawn a process, so these are the
+    only tests in the suite that do; they spawn this interpreter."""
+
+    def test_runs_and_reports_exit_code_and_output(self) -> None:
+        spec = CommandSpec.from_json({"argv": [sys.executable, "-c", "import sys; print('hi'); sys.exit(3)"], "timeout": 30})
+        res = run(run_spec(spec))
+        self.assertIsInstance(res, CommandResult)
+        self.assertEqual(res.returncode, 3)
+        self.assertFalse(res.ok)
+        self.assertIn("hi", res.output)
+
+    def test_timeout_kills_and_is_reported(self) -> None:
+        spec = CommandSpec.from_json({"argv": [sys.executable, "-c", "import time; time.sleep(10)"], "timeout": 0.5})
+        res = run(run_spec(spec))
+        self.assertTrue(res.timed_out)
+        self.assertFalse(res.ok)
+
+    def test_missing_binary_is_a_result_not_an_exception(self) -> None:
+        res = run(run_spec(CommandSpec.from_json({"argv": ["definitely-not-a-binary-xyz"]})))
+        self.assertTrue(res.binary_missing)
+
+
+class SkillCatalogArgvTests(unittest.TestCase):
+    def test_entries_resolve_to_argv_lists(self) -> None:
+        from services.cowork_agent import skill_catalog as sc
+
+        entry = sc._normalize({"name": "x", "commands": ["npm install -g pkg", ["npx", "skills", "add", "a/b"]]})
+        self.assertEqual(entry["commands"], [["npm", "install", "-g", "pkg"], ["npx", "skills", "add", "a/b"]])
+        self.assertIsNone(sc._normalize({"name": "x", "command": "npm i a && rm -rf /"}))
+        self.assertIsNone(sc._normalize({"name": "x", "commands": [["npm", 3]]}))
+        self.assertIsNone(sc._normalize({"name": "x", "commands": []}))
+
+    def test_install_runs_each_step_as_argv_with_placeholders_per_token(self) -> None:
+        from services.cowork_agent import skill_catalog as sc
+
+        entry = sc._normalize({"name": "demo", "commands": ["tool --dir {skills_dir}", ["echo", "done"]], "timeout_seconds": 7})
+        seen = []
+
+        async def fake_run(argv, *, cwd=None, timeout=None, env=None, log_path=None, log_label=""):
+            seen.append((list(argv), cwd, timeout))
+            return CommandResult(argv=list(argv), returncode=0, output="ok\n", duration_seconds=0.01)
+
+        with patch.object(sc, "load_catalog", return_value={"demo": entry}), \
+             patch.object(sc, "_expand_placeholders", side_effect=lambda t: t.replace("{skills_dir}", "/home/x y/skills")), \
+             patch.object(sc, "run", new=fake_run):
+            result = run(sc.install("demo"))
+        self.assertTrue(result["ok"])
+        self.assertEqual(seen, [(["tool", "--dir", "/home/x y/skills"], None, 7), (["echo", "done"], None, 7)])
+
+    def test_install_stops_at_first_failed_step(self) -> None:
+        from services.cowork_agent import skill_catalog as sc
+
+        entry = sc._normalize({"name": "demo", "commands": [["a"], ["b"]]})
+        calls = []
+
+        async def fake_run(argv, **kw):
+            calls.append(argv[0])
+            return CommandResult(argv=list(argv), returncode=1, output="nope", duration_seconds=0.0)
+
+        with patch.object(sc, "load_catalog", return_value={"demo": entry}), patch.object(sc, "run", new=fake_run):
+            result = run(sc.install("demo"))
+        self.assertFalse(result["ok"])
+        self.assertEqual(calls, ["a"])
+        self.assertEqual(result["steps"][0]["stderr"], "nope")
+
+
+class OneExecutorTests(unittest.TestCase):
+    """Architecture guard. Two rules:
+
+    1. No shell, anywhere: no `shell=True`, `create_subprocess_shell`,
+       `os.system` or `os.popen` outside the runner's own docstring.
+    2. Direct `subprocess` / `create_subprocess_exec` calls are allowed only in
+       `utils/commands.py` and in the files listed in MIGRATION_BACKLOG. That
+       list may only shrink: converting a file to `utils.commands` means
+       removing it here. Adding a new direct call anywhere fails this test.
+    """
+
+    SKIP_DIRS = {"venv", ".venv", "node_modules", ".git", "tests", "tests2", "docs", ".claude"}
+    RUNNER = "utils/commands.py"
+    MIGRATION_BACKLOG = {
+        # streaming / PTY runtimes — need a live pipe, migrate last
+        "config/models/claude_code/client.py",
+        "config/models/codex/client.py",
+        "services/cowork_agent/adapters/antigravity/adapter.py",
+        "services/cowork_agent/adapters/antigravity/routes.py",
+        "services/cowork_agent/adapters/claude_code/adapter.py",
+        "services/cowork_agent/adapters/claude_code/remote_control.py",
+        "services/cowork_agent/adapters/claude_code/session_telemetry.py",
+        "services/cowork_agent/adapters/cli_status.py",
+        "services/cowork_agent/adapters/codex/adapter.py",
+        "services/cowork_agent/adapters/hermes/agents.py",
+        "services/cowork_agent/adapters/hermes/gateway_pool.py",
+        "services/cowork_agent/adapters/hermes/routes.py",
+        "routers/auth/claude_setup_token.py",
+        "routers/auth/codex_setup.py",
+        # plain one-shot calls — straightforward to convert to utils.commands.run
+        "routers/cowork_agent/channels.py",
+        "routers/cowork_agent/config.py",
+        "server.py",
+        "services/cowork_agent/connectors/github/cli_auth.py",
+        "services/cowork_agent/connectors/github/common.py",
+        "services/cowork_agent/connectors/rclone/connector.py",
+        "services/cowork_agent/file_history.py",
+        "services/cowork_agent/providers_status_lib.py",
+        "services/cowork_agent/self_update.py",
+        "services/cowork_agent/visualizer/space_index.py",
+        "services/cowork_agent/xo_projects_sync/crypto.py",
+        "services/cowork_agent/xo_projects_sync/github.py",
+        "services/cowork_agent/xo_projects_sync/tarball.py",
+    }
+    DIRECT = re.compile(r"subprocess\.(run|Popen|check_output|check_call|call)\(|create_subprocess_exec\(")
+    SHELL = re.compile(r"shell\s*=\s*True|create_subprocess_shell\(|os\.system\(|os\.popen\(")
+
+    def _files(self):
+        for p in ROOT.rglob("*.py"):
+            rel = p.relative_to(ROOT)
+            if any(part in self.SKIP_DIRS for part in rel.parts):
+                continue
+            yield rel.as_posix(), p.read_text(encoding="utf-8", errors="replace")
+
+    def test_no_shell_anywhere(self) -> None:
+        offenders = [rel for rel, txt in self._files() if rel != self.RUNNER and self.SHELL.search(txt)]
+        self.assertEqual(offenders, [], "a shell path was added; build an argv and use utils.commands")
+
+    def test_direct_subprocess_calls_only_in_the_runner_or_the_backlog(self) -> None:
+        offenders = [rel for rel, txt in self._files()
+                     if rel != self.RUNNER and rel not in self.MIGRATION_BACKLOG and self.DIRECT.search(txt)]
+        self.assertEqual(offenders, [], "new code must call utils.commands.run / run_spec, not subprocess directly")
+
+    def test_backlog_entries_still_need_migrating(self) -> None:
+        # A file that no longer calls subprocess directly must leave the list,
+        # so the backlog is an honest count rather than a permanent exemption.
+        present = {rel: txt for rel, txt in self._files()}
+        stale = sorted(rel for rel in self.MIGRATION_BACKLOG if rel in present and not self.DIRECT.search(present[rel]))
+        self.assertEqual(stale, [], "these files are migrated; remove them from MIGRATION_BACKLOG")

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -91,6 +91,45 @@ class RunSpecTests(unittest.TestCase):
         res = run(run_spec(CommandSpec.from_json({"argv": ["definitely-not-a-binary-xyz"]})))
         self.assertTrue(res.binary_missing)
 
+    def test_separate_stderr_keeps_stdout_clean(self) -> None:
+        from utils.commands import run as run_cmd, run_sync
+        code = "import sys; sys.stdout.write('out'); sys.stderr.write('err')"
+        res = run(run_cmd([sys.executable, "-c", code], separate_stderr=True, timeout=30))
+        self.assertEqual((res.output, res.stderr, res.stdout), ("out", "err", "out"))
+        merged = run(run_cmd([sys.executable, "-c", code], timeout=30))
+        self.assertIn("out", merged.output)
+        self.assertIn("err", merged.output)
+        self.assertEqual(merged.stderr, "")
+        sync = run_sync([sys.executable, "-c", code], separate_stderr=True, timeout=30)
+        self.assertEqual((sync.output, sync.stderr), ("out", "err"))
+
+    def test_stdin_input_reaches_the_child(self) -> None:
+        from utils.commands import run as run_cmd, run_sync
+        code = "import sys; sys.stdout.write(sys.stdin.read().upper())"
+        res = run(run_cmd([sys.executable, "-c", code], input=b"secret", timeout=30))
+        self.assertEqual(res.output, "SECRET")
+        sync = run_sync([sys.executable, "-c", code], input=b"abc", timeout=30)
+        self.assertEqual(sync.output, "ABC")
+
+    def test_without_input_stdin_is_closed_so_prompts_cannot_hang(self) -> None:
+        from utils.commands import run as run_cmd
+        code = "import sys; sys.stdout.write(repr(sys.stdin.read()))"
+        res = run(run_cmd([sys.executable, "-c", code], timeout=30))
+        self.assertEqual(res.output, "''")
+
+    def test_inherit_output_captures_nothing_but_reports_exit(self) -> None:
+        from utils.commands import run_sync
+        res = run_sync([sys.executable, "-c", "import sys; sys.exit(0)"], inherit_output=True, timeout=30)
+        self.assertTrue(res.ok)
+        self.assertEqual(res.output, "")
+
+    def test_spawn_detached_reports_spawn_failure_only(self) -> None:
+        from utils.commands import spawn_detached
+        ok = spawn_detached([sys.executable, "-c", "pass"])
+        self.assertTrue(ok.ok)
+        missing = spawn_detached(["definitely-not-a-binary-xyz"])
+        self.assertTrue(missing.binary_missing)
+
 
 class SkillCatalogArgvTests(unittest.TestCase):
     def test_entries_resolve_to_argv_lists(self) -> None:
@@ -165,20 +204,11 @@ class OneExecutorTests(unittest.TestCase):
         "services/cowork_agent/adapters/hermes/routes.py",
         "routers/auth/claude_setup_token.py",
         "routers/auth/codex_setup.py",
-        # plain one-shot calls — straightforward to convert to utils.commands.run
-        "routers/cowork_agent/channels.py",
-        "routers/cowork_agent/config.py",
-        "server.py",
+        # partly migrated: their one-shot calls use the runner; what remains is a
+        # live-streamed `gh auth login --web` and rclone's stdin-streaming /
+        # long-running authorize flows, which need a pipe the runner does not offer
         "services/cowork_agent/connectors/github/cli_auth.py",
-        "services/cowork_agent/connectors/github/common.py",
         "services/cowork_agent/connectors/rclone/connector.py",
-        "services/cowork_agent/file_history.py",
-        "services/cowork_agent/providers_status_lib.py",
-        "services/cowork_agent/self_update.py",
-        "services/cowork_agent/visualizer/space_index.py",
-        "services/cowork_agent/xo_projects_sync/crypto.py",
-        "services/cowork_agent/xo_projects_sync/github.py",
-        "services/cowork_agent/xo_projects_sync/tarball.py",
     }
     DIRECT = re.compile(r"subprocess\.(run|Popen|check_output|check_call|call)\(|create_subprocess_exec\(")
     SHELL = re.compile(r"shell\s*=\s*True|create_subprocess_shell\(|os\.system\(|os\.popen\(")

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -5,8 +5,9 @@ import re
 import sys
 import unittest
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
+import utils.commands as commands
 from utils.commands import (
     CommandResult,
     CommandSpec,
@@ -130,6 +131,45 @@ class RunSpecTests(unittest.TestCase):
         missing = spawn_detached(["definitely-not-a-binary-xyz"])
         self.assertTrue(missing.binary_missing)
 
+    def test_kill_race_after_timeout_is_a_result_not_an_exception(self) -> None:
+        """If the child exits in the instant between the timeout and the kill,
+        asyncio raises ProcessLookupError from kill(); the runner must swallow
+        it and still report the timeout."""
+        class RacyProc:
+            returncode = -9
+            calls = 0
+
+            async def communicate(self, input=None):
+                self.calls += 1
+                if self.calls == 1:
+                    await asyncio.sleep(3600)        # the first read outlives the timeout
+                return b"", b""
+
+            def kill(self):
+                raise ProcessLookupError()           # already gone
+
+        async def fake_exec(*argv, **kwargs):
+            return RacyProc()
+
+        with patch.object(commands.asyncio, "create_subprocess_exec", new=fake_exec):
+            res = run(commands.run(["anything"], timeout=0.01))
+        self.assertTrue(res.timed_out)
+        self.assertFalse(res.ok)
+        self.assertEqual(res.returncode, -9)         # the kill signal, as subprocess reports it
+
+    def test_run_spec_passes_capture_options_through(self) -> None:
+        seen = {}
+
+        async def fake_run(argv, **kw):
+            seen.update(argv=list(argv), **kw)
+            return CommandResult(argv=list(argv), returncode=0, output="", duration_seconds=0.0)
+
+        spec = CommandSpec.from_json({"argv": ["x"], "cwd": "/tmp", "timeout": 3})
+        with patch.object(commands, "run", new=fake_run):
+            run(run_spec(spec, separate_stderr=True))
+        self.assertEqual((seen["argv"], seen["cwd"], seen["timeout"], seen["separate_stderr"]),
+                         (["x"], "/tmp", 3.0, True))
+
 
 class SkillCatalogArgvTests(unittest.TestCase):
     def test_entries_resolve_to_argv_lists(self) -> None:
@@ -141,49 +181,89 @@ class SkillCatalogArgvTests(unittest.TestCase):
         self.assertIsNone(sc._normalize({"name": "x", "commands": [["npm", 3]]}))
         self.assertIsNone(sc._normalize({"name": "x", "commands": []}))
 
-    def test_install_runs_each_step_as_argv_with_placeholders_per_token(self) -> None:
+    def test_entries_are_validated_by_the_spec_not_by_the_catalog(self) -> None:
+        """The one door: cwd/timeout rules come from CommandSpec.from_json, so a
+        bad value is rejected by the same code that rejects it everywhere else."""
         from services.cowork_agent import skill_catalog as sc
 
-        entry = sc._normalize({"name": "demo", "commands": ["tool --dir {skills_dir}", ["echo", "done"]], "timeout_seconds": 7})
+        entry = sc._normalize({"name": "x", "command": "a", "cwd": "/tmp", "timeout_seconds": 9})
+        self.assertIsInstance(entry["specs"][0], CommandSpec)
+        self.assertEqual((entry["specs"][0].cwd, entry["specs"][0].timeout), ("/tmp", 9.0))
+        self.assertEqual((entry["cwd"], entry["timeout_seconds"]), ("/tmp", 9.0))
+        for bad in ({"cwd": 5}, {"cwd": ""}, {"timeout_seconds": 0}, {"timeout_seconds": True}, {"timeout_seconds": "3"}):
+            with self.subTest(bad=bad):
+                self.assertIsNone(sc._normalize({"name": "x", "command": "a", **bad}))
+
+    def test_install_runs_each_step_as_a_spec_with_placeholders_per_token(self) -> None:
+        from services.cowork_agent import skill_catalog as sc
+
+        entry = sc._normalize({"name": "demo", "commands": ["tool --dir {skills_dir}", ["echo", "done"]],
+                               "timeout_seconds": 7, "cwd": "/work"})
         seen = []
 
-        async def fake_run(argv, *, cwd=None, timeout=None, env=None, log_path=None, log_label=""):
-            seen.append((list(argv), cwd, timeout))
-            return CommandResult(argv=list(argv), returncode=0, output="ok\n", duration_seconds=0.01)
+        async def fake_run_spec(spec, **kw):
+            seen.append((spec.argv, spec.cwd, spec.timeout, kw.get("separate_stderr")))
+            return CommandResult(argv=spec.argv, returncode=0, output="ok\n", duration_seconds=0.01)
 
         with patch.object(sc, "load_catalog", return_value={"demo": entry}), \
              patch.object(sc, "_expand_placeholders", side_effect=lambda t: t.replace("{skills_dir}", "/home/x y/skills")), \
-             patch.object(sc, "run", new=fake_run):
+             patch.object(sc, "run_spec", new=fake_run_spec):
             result = run(sc.install("demo"))
         self.assertTrue(result["ok"])
-        self.assertEqual(seen, [(["tool", "--dir", "/home/x y/skills"], None, 7), (["echo", "done"], None, 7)])
+        self.assertEqual(seen, [(["tool", "--dir", "/home/x y/skills"], "/work", 7.0, True),
+                                (["echo", "done"], "/work", 7.0, True)])
 
-    def test_install_stops_at_first_failed_step(self) -> None:
+    def test_install_stops_at_first_failed_step_and_keeps_both_streams(self) -> None:
         from services.cowork_agent import skill_catalog as sc
 
         entry = sc._normalize({"name": "demo", "commands": [["a"], ["b"]]})
         calls = []
 
-        async def fake_run(argv, **kw):
-            calls.append(argv[0])
-            return CommandResult(argv=list(argv), returncode=1, output="nope", duration_seconds=0.0)
+        async def fake_run_spec(spec, **kw):
+            calls.append(spec.argv[0])
+            return CommandResult(argv=spec.argv, returncode=1, output="partial out", stderr="nope",
+                                 duration_seconds=0.0)
 
-        with patch.object(sc, "load_catalog", return_value={"demo": entry}), patch.object(sc, "run", new=fake_run):
+        with patch.object(sc, "load_catalog", return_value={"demo": entry}), patch.object(sc, "run_spec", new=fake_run_spec):
             result = run(sc.install("demo"))
         self.assertFalse(result["ok"])
         self.assertEqual(calls, ["a"])
-        self.assertEqual(result["steps"][0]["stderr"], "nope")
+        step = result["steps"][0]
+        # the response contract predates the executor: stdout AND stderr, exit code as reported
+        self.assertEqual((step["stdout"], step["stderr"], step["exit_code"]), ("partial out", "nope", 1))
+
+    def test_a_step_that_cannot_start_or_times_out_keeps_the_old_shape(self) -> None:
+        from services.cowork_agent import skill_catalog as sc
+
+        entry = sc._normalize({"name": "demo", "command": "x"})
+        outcomes = iter([
+            CommandResult(argv=["x"], returncode=-1, output="x not found in PATH", duration_seconds=0.0, binary_missing=True),
+            CommandResult(argv=["x"], returncode=-9, output="[timed out after 1s]", duration_seconds=1.0, timed_out=True),
+        ])
+
+        async def fake_run_spec(spec, **kw):
+            return next(outcomes)
+
+        with patch.object(sc, "load_catalog", return_value={"demo": entry}), patch.object(sc, "run_spec", new=fake_run_spec):
+            missing = run(sc.install("demo"))["steps"][0]
+            timed = run(sc.install("demo"))["steps"][0]
+        self.assertEqual((missing["exit_code"], missing["stderr"]), (None, "failed to start command: x not found in PATH"))
+        self.assertEqual((timed["timed_out"], timed["exit_code"], timed["stdout"], timed["stderr"]), (True, -9, "", ""))
 
 
 class OneExecutorTests(unittest.TestCase):
-    """Architecture guard. Two rules:
+    """Architecture guard (a fitness function for the one-executor rule). Three rules:
 
     1. No shell, anywhere: no `shell=True`, `create_subprocess_shell`,
-       `os.system` or `os.popen` outside the runner's own docstring.
+       `os.system` / `os.popen`, the `os.exec*` / `os.spawn*` / `posix_spawn`
+       family, or `pty.spawn` outside the runner's own docstring.
     2. Direct `subprocess` / `create_subprocess_exec` calls are allowed only in
        `utils/commands.py` and in the files listed in MIGRATION_BACKLOG. That
        list may only shrink: converting a file to `utils.commands` means
        removing it here. Adding a new direct call anywhere fails this test.
+    3. The same for `import subprocess` / `from subprocess import ...`: a regex
+       over call sites misses `from subprocess import Popen; Popen(...)`, so the
+       import itself is the thing that is fenced.
     """
 
     SKIP_DIRS = {"venv", ".venv", "node_modules", ".git", "tests", "tests2", "docs", ".claude"}
@@ -211,7 +291,11 @@ class OneExecutorTests(unittest.TestCase):
         "services/cowork_agent/connectors/rclone/connector.py",
     }
     DIRECT = re.compile(r"subprocess\.(run|Popen|check_output|check_call|call)\(|create_subprocess_exec\(")
-    SHELL = re.compile(r"shell\s*=\s*True|create_subprocess_shell\(|os\.system\(|os\.popen\(")
+    IMPORTS = re.compile(r"^\s*(import subprocess\b|from subprocess import\b)", re.MULTILINE)
+    SHELL = re.compile(
+        r"shell\s*=\s*True|create_subprocess_shell\(|os\.system\(|os\.popen\("
+        r"|os\.(exec[lv]p?e?|spawn[lv]p?e?|posix_spawnp?)\(|pty\.spawn\("
+    )
 
     def _files(self):
         for p in ROOT.rglob("*.py"):
@@ -228,6 +312,11 @@ class OneExecutorTests(unittest.TestCase):
         offenders = [rel for rel, txt in self._files()
                      if rel != self.RUNNER and rel not in self.MIGRATION_BACKLOG and self.DIRECT.search(txt)]
         self.assertEqual(offenders, [], "new code must call utils.commands.run / run_spec, not subprocess directly")
+
+    def test_subprocess_is_not_imported_outside_the_runner_or_the_backlog(self) -> None:
+        offenders = [rel for rel, txt in self._files()
+                     if rel != self.RUNNER and rel not in self.MIGRATION_BACKLOG and self.IMPORTS.search(txt)]
+        self.assertEqual(offenders, [], "import subprocess only in utils/commands.py (or a backlog file)")
 
     def test_backlog_entries_still_need_migrating(self) -> None:
         # A file that no longer calls subprocess directly must leave the list,

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import re
 import sys
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -130,6 +132,16 @@ class RunSpecTests(unittest.TestCase):
         self.assertTrue(ok.ok)
         missing = spawn_detached(["definitely-not-a-binary-xyz"])
         self.assertTrue(missing.binary_missing)
+
+    @unittest.skipIf(os.name != "posix", "process groups are POSIX")
+    def test_timeout_kills_the_whole_process_group(self) -> None:
+        """`sh` here exits only when its background child does. Killing just
+        `sh` leaves the child holding the stdout pipe, and the runner would
+        wait for it (30 s) instead of honouring the 0.5 s timeout."""
+        started = time.monotonic()
+        res = run(commands.run(["sh", "-c", "sleep 30 & wait"], timeout=0.5))
+        self.assertTrue(res.timed_out)
+        self.assertLess(time.monotonic() - started, 5.0)
 
     def test_kill_race_after_timeout_is_a_result_not_an_exception(self) -> None:
         """If the child exits in the instant between the timeout and the kill,

--- a/utils/commands.py
+++ b/utils/commands.py
@@ -65,15 +65,22 @@ class CommandResult:
 
     argv: list[str]
     returncode: int
-    output: str  # stdout + stderr, merged
+    output: str  # stdout (+ stderr merged unless separate_stderr was requested)
     duration_seconds: float
     timed_out: bool = False
     binary_missing: bool = False
     exception: str | None = None
+    stderr: str = ""  # populated only when separate_stderr=True
 
     @property
     def ok(self) -> bool:
         return self.returncode == 0 and not self.timed_out and not self.binary_missing
+
+    @property
+    def stdout(self) -> str:
+        """Alias for `output`, so call sites ported from `subprocess.run`
+        keep reading `.stdout` / `.stderr` / `.returncode`."""
+        return self.output
 
 
 def _render_log_entry(ts: str, label: str, argv: Sequence[str], result: CommandResult) -> str:
@@ -91,6 +98,47 @@ def _render_log_entry(ts: str, label: str, argv: Sequence[str], result: CommandR
     return f"{header}$ {cmdline}\n{tail}[exit {rc}]\n"
 
 
+def _text(value) -> str:
+    """bytes or str or None -> str (subprocess hands back bytes when we do
+    not ask for text mode, which we cannot when passing binary stdin)."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return str(value)
+
+
+def spawn_detached(
+    argv: Sequence[str],
+    *,
+    cwd: str | Path | None = None,
+    env: dict[str, str] | None = None,
+) -> CommandResult:
+    """Start a process and do not wait for it: its own session, stdio to
+    /dev/null. For restart/update scripts that outlive this server. The
+    result only says whether the spawn itself worked."""
+    if not argv:
+        raise ValueError("argv must be non-empty")
+    argv_list = [str(a) for a in argv]
+    try:
+        subprocess.Popen(
+            argv_list,
+            cwd=str(cwd) if cwd is not None else None,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except FileNotFoundError:
+        return CommandResult(argv=argv_list, returncode=-1, output=f"{argv_list[0]} not found in PATH",
+                             duration_seconds=0.0, binary_missing=True)
+    except Exception as e:  # noqa: BLE001
+        return CommandResult(argv=argv_list, returncode=-1, output=f"[exception] {e}",
+                             duration_seconds=0.0, exception=str(e))
+    return CommandResult(argv=argv_list, returncode=0, output="", duration_seconds=0.0)
+
+
 def _write_log(log_path: Path, entry: str) -> None:
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("a") as f:
@@ -105,6 +153,9 @@ async def run(
     env: dict[str, str] | None = None,
     log_path: str | Path | None = None,
     log_label: str = "",
+    input: bytes | None = None,
+    separate_stderr: bool = False,
+    inherit_output: bool = False,
 ) -> CommandResult:
     """Run a command asynchronously and return a `CommandResult`.
 
@@ -116,6 +167,13 @@ async def run(
     env:        environment overrides; unset → inherit parent.
     log_path:   if provided, append a formatted log entry after the run.
     log_label:  prefix for the log entry (e.g. "provisioning: anthropic").
+    input:      bytes written to the child's stdin (a passphrase, a payload);
+                without it stdin is /dev/null so nothing can hang on a prompt.
+    separate_stderr:  keep stderr apart (`result.stderr`) instead of merging it
+                into `output`. For callers that parse stdout.
+    inherit_output:   do not capture at all — the child writes straight to
+                this process's stdout/stderr (long setup scripts whose progress
+                must be visible live). `output` is then empty.
     """
     if not argv:
         raise ValueError("argv must be non-empty")
@@ -130,8 +188,10 @@ async def run(
             *argv_list,
             cwd=str(cwd) if cwd is not None else None,
             env=env,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
+            stdin=asyncio.subprocess.PIPE if input is not None else asyncio.subprocess.DEVNULL,
+            stdout=None if inherit_output else asyncio.subprocess.PIPE,
+            stderr=None if inherit_output
+                   else (asyncio.subprocess.PIPE if separate_stderr else asyncio.subprocess.STDOUT),
         )
     except FileNotFoundError:
         result = CommandResult(
@@ -158,9 +218,9 @@ async def run(
 
     try:
         if timeout is not None:
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            stdout, stderr = await asyncio.wait_for(proc.communicate(input=input), timeout=timeout)
         else:
-            stdout, _ = await proc.communicate()
+            stdout, stderr = await proc.communicate(input=input)
     except asyncio.TimeoutError:
         proc.kill()
         await proc.communicate()
@@ -179,8 +239,9 @@ async def run(
     result = CommandResult(
         argv=argv_list,
         returncode=proc.returncode if proc.returncode is not None else -1,
-        output=stdout.decode(errors="replace"),
+        output=(stdout or b"").decode(errors="replace"),
         duration_seconds=duration,
+        stderr=(stderr or b"").decode(errors="replace") if separate_stderr else "",
     )
     if log_path is not None:
         _write_log(Path(log_path), _render_log_entry(ts, log_label, argv_list, result))
@@ -195,8 +256,12 @@ def run_sync(
     env: dict[str, str] | None = None,
     log_path: str | Path | None = None,
     log_label: str = "",
+    input: bytes | None = None,
+    separate_stderr: bool = False,
+    inherit_output: bool = False,
 ) -> CommandResult:
     """Synchronous sibling of `run` — for scripts, startup probes, or tests.
+    Same options as `run`.
 
     Do NOT call this from inside an async handler — it will block the
     event loop. Use `run` there.
@@ -214,8 +279,9 @@ def run_sync(
             argv_list,
             cwd=str(cwd) if cwd is not None else None,
             env=env,
-            capture_output=True,
-            text=True,
+            input=input,
+            stdin=None if input is not None else subprocess.DEVNULL,
+            capture_output=not inherit_output,
             timeout=timeout,
             check=False,
         )
@@ -234,7 +300,7 @@ def run_sync(
         result = CommandResult(
             argv=argv_list,
             returncode=-1,
-            output=(e.stdout or "") + (e.stderr or "") + f"\n[timed out after {timeout}s]",
+            output=_text(e.stdout) + _text(e.stderr) + f"[timed out after {timeout}s]",
             duration_seconds=time.monotonic() - started,
             timed_out=True,
         )
@@ -253,12 +319,14 @@ def run_sync(
             _write_log(Path(log_path), _render_log_entry(ts, log_label, argv_list, result))
         return result
 
-    merged = (completed.stdout or "") + (completed.stderr or "")
+    out = _text(completed.stdout)
+    err = _text(completed.stderr)
     result = CommandResult(
         argv=argv_list,
         returncode=completed.returncode,
-        output=merged,
+        output=out if separate_stderr else out + err,
         duration_seconds=time.monotonic() - started,
+        stderr=err if separate_stderr else "",
     )
     if log_path is not None:
         _write_log(Path(log_path), _render_log_entry(ts, log_label, argv_list, result))

--- a/utils/commands.py
+++ b/utils/commands.py
@@ -46,11 +46,12 @@ input never reaches a shell interpreter.
 from __future__ import annotations
 
 import asyncio
+import shlex
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Mapping, Sequence
 
 
 @dataclass(frozen=True)
@@ -299,3 +300,139 @@ async def run_chain(
                 )
             break
     return results
+
+
+# =============================================================================
+# The one door: a JSON-shaped command spec
+# =============================================================================
+#
+# Everything above takes a Python list. Config files (the skill catalog, agent
+# manifests, future automation) describe commands as data, so this is the
+# shape they use and the validation they all get:
+#
+#     {"argv": ["npm", "install", "-g", "@okxweb3/a2a-node"],
+#      "cwd": "/home/coder", "env": {"CI": "1"}, "timeout": 300}
+#
+# `argv` is the only way to say what runs. There is no "command string" key
+# and never will be: a string is what a shell parses, and a shell is where
+# command injection (CWE-78) happens. A value that must come from user input
+# goes into ONE argv slot via `safe_arg`, which refuses anything that a
+# program would read as an option (argument injection).
+
+SHELL_OPERATORS = ("&&", "||", "|", ";", ">", "<", "`", "$(", "\n")
+
+
+class CommandSpecError(ValueError):
+    """A command spec that must not run: malformed, or trying to reach a shell."""
+
+
+def safe_arg(value: Any, *, allow_option: bool = False) -> str:
+    """Return `value` as one argv element, or raise CommandSpecError.
+
+    Refuses empty strings, NUL bytes, and (unless `allow_option`) anything
+    starting with '-' so an attacker-controlled repo name, branch, or path can
+    never become `--upload-pack=...` or `-c core.sshCommand=...`. Callers that
+    legitimately pass a flag pass it as a literal in their own argv, not
+    through this function.
+    """
+    if not isinstance(value, str) or not value:
+        raise CommandSpecError("argument must be a non-empty string")
+    if "\x00" in value:
+        raise CommandSpecError("argument contains a NUL byte")
+    if not allow_option and value.startswith("-"):
+        raise CommandSpecError(f"argument {value!r} looks like an option; refuse it or pass it after '--'")
+    return value
+
+
+def split_command(template: str) -> list[str]:
+    """Turn a human-written command line into argv WITHOUT a shell.
+
+    POSIX quoting rules (shlex), so `--dir "{skills_dir}"` stays one token.
+    Refuses anything a shell would interpret as more than one command or as a
+    redirection: those need a real shell, and this codebase does not run one.
+    """
+    if not isinstance(template, str) or not template.strip():
+        raise CommandSpecError("command must be a non-empty string")
+    for op in SHELL_OPERATORS:
+        if op in template:
+            raise CommandSpecError(
+                f"command contains shell operator {op!r}; write it as separate steps or an argv list")
+    try:
+        argv = shlex.split(template, posix=True)
+    except ValueError as exc:
+        raise CommandSpecError(f"unbalanced quoting in command: {exc}") from exc
+    if not argv:
+        raise CommandSpecError("command is empty after parsing")
+    return argv
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """One command as data. Build it with `from_json` so every field is
+    validated once, in one place, before anything runs."""
+
+    argv: list[str]
+    cwd: str | None = None
+    env: dict[str, str] | None = None
+    timeout: float | None = None
+    log_path: str | None = None
+    log_label: str = ""
+
+    ALLOWED_KEYS = frozenset({"argv", "command", "cwd", "env", "timeout", "log_path", "log_label"})
+
+    @classmethod
+    def from_json(cls, obj: Mapping[str, Any]) -> "CommandSpec":
+        if not isinstance(obj, Mapping):
+            raise CommandSpecError("command spec must be an object")
+        unknown = set(obj) - cls.ALLOWED_KEYS
+        if unknown:
+            raise CommandSpecError(f"unknown command spec keys: {sorted(unknown)}")
+        if "argv" in obj and "command" in obj:
+            raise CommandSpecError("give argv or command, not both")
+        if "argv" in obj:
+            argv = obj["argv"]
+            if not isinstance(argv, list) or not argv or not all(isinstance(a, str) and a for a in argv):
+                raise CommandSpecError("argv must be a non-empty list of non-empty strings")
+            if any("\x00" in a for a in argv):
+                raise CommandSpecError("argv contains a NUL byte")
+            argv = list(argv)
+        elif "command" in obj:
+            argv = split_command(obj["command"])
+        else:
+            raise CommandSpecError("command spec needs argv (preferred) or command")
+        cwd = obj.get("cwd")
+        if cwd is not None and (not isinstance(cwd, str) or not cwd):
+            raise CommandSpecError("cwd must be a non-empty string")
+        env = obj.get("env")
+        if env is not None and (not isinstance(env, Mapping)
+                                or not all(isinstance(k, str) and isinstance(v, str) for k, v in env.items())):
+            raise CommandSpecError("env must map strings to strings")
+        timeout = obj.get("timeout")
+        if timeout is not None and (isinstance(timeout, bool) or not isinstance(timeout, (int, float)) or timeout <= 0):
+            raise CommandSpecError("timeout must be a positive number of seconds")
+        log_path = obj.get("log_path")
+        if log_path is not None and not isinstance(log_path, str):
+            raise CommandSpecError("log_path must be a string")
+        log_label = obj.get("log_label", "")
+        if not isinstance(log_label, str):
+            raise CommandSpecError("log_label must be a string")
+        return cls(argv=argv, cwd=cwd, env=dict(env) if env is not None else None,
+                   timeout=float(timeout) if timeout is not None else None,
+                   log_path=log_path, log_label=log_label)
+
+    def with_argv(self, argv: Sequence[str]) -> "CommandSpec":
+        """Same spec, different argv (used after placeholder expansion)."""
+        return CommandSpec(argv=[str(a) for a in argv], cwd=self.cwd, env=self.env,
+                           timeout=self.timeout, log_path=self.log_path, log_label=self.log_label)
+
+
+async def run_spec(spec: CommandSpec) -> CommandResult:
+    """Run a validated spec. Config-driven callers (catalog, manifests) come
+    through here; Python callers with a literal argv may call `run` directly."""
+    return await run(spec.argv, cwd=spec.cwd, timeout=spec.timeout, env=spec.env,
+                     log_path=spec.log_path, log_label=spec.log_label)
+
+
+def run_spec_sync(spec: CommandSpec) -> CommandResult:
+    return run_sync(spec.argv, cwd=spec.cwd, timeout=spec.timeout, env=spec.env,
+                    log_path=spec.log_path, log_label=spec.log_label)

--- a/utils/commands.py
+++ b/utils/commands.py
@@ -47,7 +47,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 import shlex
+import signal
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -147,6 +149,24 @@ def _write_log(log_path: Path, entry: str) -> None:
         f.write(entry)
 
 
+def _kill_tree(proc) -> None:
+    """Kill the child and, on POSIX, everything it spawned.
+
+    `run` starts each child in its own session, so its pid is also its process
+    group id and one signal reaches the grandchildren too. Without that, a
+    killed `npx` or `git` can leave a helper process holding the stdout pipe,
+    and `communicate()` then waits for that helper instead of honouring the
+    timeout (measured: 7.5 s of a 0.5 s timeout). ProcessLookupError means the
+    tree is already gone, which is the outcome we wanted.
+    """
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        pid = getattr(proc, "pid", None)
+        if os.name == "posix" and pid:
+            os.killpg(pid, signal.SIGKILL)
+        else:
+            proc.kill()
+
+
 async def run(
     argv: Sequence[str],
     *,
@@ -194,6 +214,10 @@ async def run(
             stdout=None if inherit_output else asyncio.subprocess.PIPE,
             stderr=None if inherit_output
                    else (asyncio.subprocess.PIPE if separate_stderr else asyncio.subprocess.STDOUT),
+            # own session => own process group, so a timeout can kill the
+            # whole tree (see _kill_tree). Trade-off: a child no longer dies
+            # with the server on Ctrl+C, so long-running calls pass a timeout.
+            start_new_session=(os.name == "posix"),
         )
     except FileNotFoundError:
         result = CommandResult(
@@ -224,11 +248,10 @@ async def run(
         else:
             stdout, stderr = await proc.communicate(input=input)
     except asyncio.TimeoutError:
-        # The child can exit in the instant between the timeout firing and
-        # the kill; asyncio then raises ProcessLookupError from kill(), which
-        # a runner that promises never to raise has to swallow.
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
+        # Kill the whole tree; _kill_tree swallows the ProcessLookupError that
+        # asyncio raises when the child exited in the instant between the
+        # timeout firing and the kill (the runner promises never to raise).
+        _kill_tree(proc)
         await proc.communicate()
         result = CommandResult(
             argv=argv_list,

--- a/utils/commands.py
+++ b/utils/commands.py
@@ -46,9 +46,10 @@ input never reaches a shell interpreter.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import shlex
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -58,9 +59,10 @@ from typing import Any, Mapping, Sequence
 class CommandResult:
     """Outcome of one subprocess run.
 
-    `returncode` is -1 when the process was killed by the runner (timeout,
-    binary-not-found, or another local exception) — check `ok` rather
-    than testing for 0 directly when you want "finished cleanly".
+    `returncode` is -1 when no process ran or its code is unknown (binary not
+    found, a local exception). On a timeout it is what `subprocess` reports
+    for the kill, e.g. -9, with `timed_out` set. Check `ok` rather than
+    testing for 0 directly when you want "finished cleanly".
     """
 
     argv: list[str]
@@ -222,11 +224,15 @@ async def run(
         else:
             stdout, stderr = await proc.communicate(input=input)
     except asyncio.TimeoutError:
-        proc.kill()
+        # The child can exit in the instant between the timeout firing and
+        # the kill; asyncio then raises ProcessLookupError from kill(), which
+        # a runner that promises never to raise has to swallow.
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
         await proc.communicate()
         result = CommandResult(
             argv=argv_list,
-            returncode=-1,
+            returncode=proc.returncode if proc.returncode is not None else -1,
             output=f"[timed out after {timeout}s]",
             duration_seconds=asyncio.get_event_loop().time() - started,
             timed_out=True,
@@ -381,11 +387,13 @@ async def run_chain(
 #     {"argv": ["npm", "install", "-g", "@okxweb3/a2a-node"],
 #      "cwd": "/home/coder", "env": {"CI": "1"}, "timeout": 300}
 #
-# `argv` is the only way to say what runs. There is no "command string" key
-# and never will be: a string is what a shell parses, and a shell is where
-# command injection (CWE-78) happens. A value that must come from user input
-# goes into ONE argv slot via `safe_arg`, which refuses anything that a
-# program would read as an option (argument injection).
+# `argv` is the preferred form. A `command` string is accepted only as a
+# convenience for hand-written config (the skill catalog): `split_command`
+# turns it into an argv with POSIX quoting and refuses `&&`, `|`, `;`,
+# redirections and `$()`, so it never reaches a shell — which is where command
+# injection (CWE-78) happens. A value that must come from user input goes into
+# ONE argv slot via `safe_arg`, which refuses anything that a program would
+# read as an option (argument injection).
 
 SHELL_OPERATORS = ("&&", "||", "|", ";", ">", "<", "`", "$(", "\n")
 
@@ -494,13 +502,15 @@ class CommandSpec:
                            timeout=self.timeout, log_path=self.log_path, log_label=self.log_label)
 
 
-async def run_spec(spec: CommandSpec) -> CommandResult:
+async def run_spec(spec: CommandSpec, **options: Any) -> CommandResult:
     """Run a validated spec. Config-driven callers (catalog, manifests) come
-    through here; Python callers with a literal argv may call `run` directly."""
+    through here; Python callers with a literal argv may call `run` directly.
+    `options` are the runner's capture switches (`separate_stderr`, `input`,
+    `inherit_output`): how to capture, never what to run."""
     return await run(spec.argv, cwd=spec.cwd, timeout=spec.timeout, env=spec.env,
-                     log_path=spec.log_path, log_label=spec.log_label)
+                     log_path=spec.log_path, log_label=spec.log_label, **options)
 
 
-def run_spec_sync(spec: CommandSpec) -> CommandResult:
+def run_spec_sync(spec: CommandSpec, **options: Any) -> CommandResult:
     return run_sync(spec.argv, cwd=spec.cwd, timeout=spec.timeout, env=spec.env,
-                    log_path=spec.log_path, log_label=spec.log_label)
+                    log_path=spec.log_path, log_label=spec.log_label, **options)


### PR DESCRIPTION
## What

One executor for every external command xo-space runs, driven by a JSON-shaped spec, with a guard test that stops new direct `subprocess` calls and any shell path from being added. Every one-shot command in the tree now goes through it; only the live-streaming runtimes remain, listed explicitly.

`utils/commands.py` already had the right runner (`run` / `run_sync` over an argv list, timeouts, `CommandResult`), but only one call site used it, 29 files called `subprocess` directly, and the skill catalog ran its install commands through `create_subprocess_shell`.

## The vulnerability this closes off

**Command injection (CWE-78)**: building a command as a string lets a value like `x; rm -rf ~` run a second command. Its quieter cousin, **argument injection**, works even with a list and no shell: a "repo name" of `--upload-pack=evil` is read by git as an option. Both are prevented the same way: commands are argv lists, untrusted values land in exactly one slot, and values that parse as options are refused.

## Changes

### `utils/commands.py`
- `CommandSpec.from_json({...})`: the data shape for commands. `argv` (preferred) or `command` (a string split with POSIX quoting, **no shell**), plus `cwd`, `env`, `timeout`, `log_path`, `log_label`. Unknown keys are rejected, so there is no way to smuggle in `shell=True`.
- `split_command()`: refuses `&&`, `||`, `|`, `;`, `>`, `<`, backticks and `$()`. A catalog entry that needs two commands writes two steps.
- `safe_arg(value)`: the one way to put an untrusted value into an argv; rejects empty, NUL, and anything starting with `-` unless the caller explicitly allows an option.
- `run_spec()` / `run_spec_sync()`: run a validated spec through the existing runner.
- Options the migrated call sites needed: `separate_stderr=True` (keep stderr apart for callers that parse stdout; `result.stdout` / `.stderr` aliases so ported code reads naturally), `input=bytes` (a passphrase to gpg), `inherit_output=True` (the 15-minute setup scripts keep streaming to the server log live), and `spawn_detached()` for the restart/update scripts that must outlive the server. **stdin is now `/dev/null` unless `input` is given**, so no child can hang on a prompt.

### `services/cowork_agent/skill_catalog.py`
- Catalog steps are now argv lists. A string step is split without a shell; a list step is used as-is; a string containing a shell operator invalidates the entry with a printed reason.
- Placeholders (`{skills_dir}`, `{home_dir}`, `{agent_name}`) are expanded **per token after splitting**, so a path with spaces stays one argument and no quoting is needed. The catalog's `_shape` doc is updated.
- `_run_step` calls `utils.commands.run`; `create_subprocess_shell` is gone.

### Migrated to the runner (behaviour preserved, same return values and exceptions)
`server.py` (agent setup, shared deps, gateway restart, detached restart/update), `routers/cowork_agent/channels.py`, `routers/cowork_agent/config.py`, `services/cowork_agent/file_history.py`, `self_update.py`, `visualizer/space_index.py`, `providers_status_lib.py`, `connectors/github/common.py`, `connectors/github/cli_auth.py` (token read and logout), `connectors/rclone/connector.py` (one-shot rclone), `xo_projects_sync/crypto.py` (gpg with stdin passphrase), `xo_projects_sync/github.py` (all five gh/git calls), `xo_projects_sync/tarball.py`.

### `tests/test_command_executor.py` (19 tests)
- Spec validation, string splitting and operator refusal, `safe_arg`.
- Real runs of the runner: exit code and output, timeout kill, missing binary, separate stderr, stdin input, closed stdin, inherit-output, detached spawn. These are the only tests in the suite that spawn a process, because this is the only module that may.
- Catalog: entries resolve to argv lists, invalid entries are dropped, install passes per-token-expanded argv to the runner and stops at the first failure.
- **Architecture guard**: (1) no `shell=True` / `create_subprocess_shell` / `os.system` / `os.popen` anywhere; (2) direct `subprocess` or `create_subprocess_exec` calls only in the runner or in `MIGRATION_BACKLOG`; (3) a backlog entry that no longer calls subprocess must be removed, so the list can only shrink.

### Docs
`DEVELOPING.md` §7 explains the rule and the spec; `AGENTS.md` carries the one-line convention.

## What is still on the backlog, and why

16 files, all of them processes that must be read while they run: the Claude Code, Codex and Antigravity adapters and Plane-A clients (streamed chat output), the Hermes gateway and routes, the setup-token flows (PTY), `gh auth login --web` in `cli_auth.py` (the device code is scraped from live output), and rclone's stdin-streaming upload and `rclone authorize` in `connector.py`. The runner's `communicate()` model does not fit them; they need a streaming variant, which is its own design. Nothing new can join the list without failing the guard.

## Verification

- `venv/bin/python -m unittest tests.test_command_executor` — 19 pass.
- Full suite green apart from the pre-existing uninstall-harness CRLF failure on Windows checkouts. The file-history, self-update, timeline and sync tests exercise the migrated modules against real git.
- Import gate passes for `claude_code`, `openclaw`, `hermes`.

## Relationship to #71

Independent. When both are merged, the relay's `git_ops.py` on #71 trips the guard and gets converted to `utils.commands.run` in one commit on that branch.
