### PR TITLE
feat(setup): surface usage-reporting status, dedupe telemetry warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Nothing, by default. A self-hosted install binds to loopback, needs no account, 
 
 If you set `XO_API_KEY` (or sign in from the app) to link the install to your XO account, a **daily usage summary** is sent: token counts, estimated cost, and message/session/tool-call counts per model. It never includes prompts, responses, file contents or paths. Leave the key unset to stay signed out.
 
+To see what your install decided: the status is the first thing on the Setup tab's **Agent and watcher** card (`/space/#/secrets`), and every decision the server makes is in the log — `grep usage_sync ~/.quirq/quirq.log`. The installer prints both pointers on every run.
+
 Everything else on the network happens because you asked for it: `git fetch` when Setup checks for updates, GitHub when you back a project up, connectors you connect, and whatever the agent runtimes themselves do.
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -275,8 +275,11 @@ print_reporting_notice() {
 └─────────────────────────────────────────────────────────────────────────┘
 NOTICE
     # The server logs every decision it makes about reporting; this is the
-    # one-liner that shows them, since the terminal itself stays quiet.
+    # one-liner that shows them, since the terminal itself stays quiet. The
+    # same decision is the first thing on the Setup tab's "Agent and
+    # watcher" card, for people who never open the log.
     printf '  See what it decided:  grep usage_sync %s\n' "$log_file"
+    printf '  Live status:          Setup tab → Agent and watcher (top of the card)\n'
 }
 
 # ==============================================================

--- a/services/cowork_agent/visualizer/session_telemetry.py
+++ b/services/cowork_agent/visualizer/session_telemetry.py
@@ -26,6 +26,30 @@ class SessionTelemetryUnavailable(RuntimeError):
     """Raised only when no discovered telemetry provider can be read."""
 
 
+# Last logged reason per unavailable provider. The watcher rebuilds this view
+# every few seconds, and a runtime that is simply not installed (no Codex
+# state DB, no Cursor home) would otherwise repeat the identical warning for
+# the life of the process. Log a reason once; a changed reason or a recovery
+# is news and logs again. Setup → Native session sources shows the live
+# state of every source, so the log does not need to.
+_unavailable_reasons: dict[str, str] = {}
+
+
+def _note_provider_unavailable(provider: str, reason: str) -> None:
+    if _unavailable_reasons.get(provider) == reason:
+        return
+    _unavailable_reasons[provider] = reason
+    print(
+        f"⚠️ session telemetry provider {provider} unavailable ({reason}) "
+        "— logged once until it changes; see Setup → Native session sources"
+    )
+
+
+def _note_provider_available(provider: str) -> None:
+    if _unavailable_reasons.pop(provider, None) is not None:
+        print(f"✅ session telemetry provider {provider} available again")
+
+
 def _number(value: Any) -> float:
     return float(value) if isinstance(value, (int, float)) else 0.0
 
@@ -249,8 +273,9 @@ def build_session_telemetry() -> dict:
             contribution["source"] = source
             contributions.append(contribution)
             source_status.append(source)
+            _note_provider_available(provider)
         except Exception as exc:
-            print(f"⚠️ session telemetry provider {provider} unavailable ({exc})")
+            _note_provider_unavailable(provider, str(exc))
             source = _source_shell(provider, module)
             source.update({
                 "status": "unavailable",

--- a/space_ui/css/secrets.css
+++ b/space_ui/css/secrets.css
@@ -61,6 +61,22 @@
 .setup-root-apply p{margin-top:3px;color:var(--ink-3);font-size:10px;line-height:1.45}
 .setup-root-apply pre{overflow:auto;padding:9px 11px;border:1px solid var(--line-soft);border-radius:7px;background:var(--bg);font:400 9px/1.45 var(--mono);color:var(--ink-2);white-space:pre-wrap;word-break:break-word}
 .setup-runtime form,.setup-credentials form{display:flex;flex-direction:column;padding:21px}
+/* Usage-reporting status: the first thing in the runtime card, sized like
+   the watcher toggle row rather than as footnote text, with a state dot so
+   "on" vs "off" is readable at a glance. Sits between the head and the
+   form; when hidden (older server) the form is unchanged. */
+.setup-usage-reporting{display:grid;grid-template-columns:auto 1fr;align-items:start;gap:12px;margin:21px 21px 0;padding:14px 15px;border:1px solid var(--line-soft);border-radius:10px;background:rgba(255,255,255,.012)}
+.setup-usage-reporting[hidden]{display:none}
+.setup-usage-reporting>span{width:9px;height:9px;margin-top:4px;border-radius:50%;background:var(--ink-4);box-shadow:0 0 0 3px rgba(255,255,255,.04)}
+.setup-usage-reporting b{display:block;font-size:12.5px;color:var(--ink)}
+.setup-usage-reporting p{margin-top:4px;color:var(--ink-2);font-size:11.5px;line-height:1.5}
+.setup-usage-reporting a{color:var(--ink);text-decoration:underline;text-underline-offset:2px}
+.setup-usage-reporting.is-on{border-color:rgba(168,217,79,.23);background:rgba(168,217,79,.05)}
+.setup-usage-reporting.is-on>span{background:var(--accent);box-shadow:0 0 0 3px rgba(168,217,79,.16)}
+.setup-usage-reporting.is-pending{border-color:rgba(226,174,91,.28);background:rgba(226,174,91,.055)}
+.setup-usage-reporting.is-pending>span{background:#e2ae5b;box-shadow:0 0 0 3px rgba(226,174,91,.18)}
+.setup-usage-reporting.is-blocked{border-color:rgba(200,103,76,.35);background:rgba(200,103,76,.07)}
+.setup-usage-reporting.is-blocked>span{background:#e1937d;box-shadow:0 0 0 3px rgba(200,103,76,.2)}
 .setup-runtime label,.setup-credentials label{font:600 9.5px var(--mono);letter-spacing:.1em;text-transform:uppercase;color:var(--ink-2);margin-bottom:7px}
 .setup-runtime label:not(:first-child),.setup-credentials label:not(:first-child){margin-top:18px}
 .setup-runtime select,.setup-runtime input[type=number],.setup-credentials input{

--- a/space_ui/js/views/secrets.js
+++ b/space_ui/js/views/secrets.js
@@ -88,6 +88,11 @@ function renderShell(){
       +'<div class="setup-grid">'
         +'<section class="setup-card setup-runtime">'
           +'<div class="setup-card-head"><div><span>01 · Process</span><h2>Agent and watcher</h2></div><i id="setup-applied-badge">Checking</i></div>'
+          /* one fact, not a control: whether anything is reported to
+             xo-swarm-api — the same decision usage_sync logs, surfaced
+             first in the card so it cannot be missed. Outside the form so
+             the form's first label keeps its first-child spacing. */
+          +'<div class="setup-usage-reporting" id="usage-reporting" hidden></div>'
           +'<form id="runtime-form" novalidate>'
             +'<label for="runtime-agent">Active agent backend</label>'
             +'<select id="runtime-agent" name="agent_name" required><option>Loading…</option></select>'
@@ -110,10 +115,6 @@ function renderShell(){
               +'<button class="setup-primary" id="runtime-save" type="submit">Save runtime</button>'
               +'<button class="setup-restart" id="runtime-restart" type="button" hidden>Apply &amp; restart</button>'
             +'</div>'
-            /* one fact, not a control: whether anything is reported to
-               xo-swarm-api — the same decision usage_sync logs, surfaced
-               where people actually look */
-            +'<small class="setup-usage-reporting" id="usage-reporting" hidden></small>'
           +'</form>'
         +'</section>'
         +'<section class="setup-card setup-sources-card">'
@@ -377,18 +378,20 @@ function renderUsageReporting(){
   if(!ur){el.hidden=true;return;}
   const link=' <a href="https://github.com/quirq-ai/xo-space#what-leaves-your-machine" '
     +'target="_blank" rel="noopener noreferrer">What leaves your machine &#8599;</a>';
-  let text;
-  if(ur.status==='on'){
-    text='<b>Usage reporting: on</b> — key accepted by xo-swarm-api'
-      +(ur.last_synced_date?'; last report '+esc(ur.last_synced_date):'')+'.';
-  }else if(ur.status==='blocked'){
-    text='<b>Usage reporting: blocked</b> — xo-swarm-api rejected the key; nothing is sent. Fix or remove XO_API_KEY.';
-  }else if(ur.status==='pending'){
-    text='<b>Usage reporting: pending</b> — a key is set but not verified yet; nothing is sent until a sync accepts it.';
-  }else{
-    text='<b>Usage reporting: off</b> — no XO_API_KEY set. Nothing is sent.';
-  }
-  el.innerHTML=text+link;
+  const states={
+    on:['on','Key accepted by xo-swarm-api'
+      +(ur.last_synced_date?'; last report '+esc(ur.last_synced_date):'')
+      +'. A daily summary of token counts, cost and session/tool counts goes out — never prompts, responses or files.'],
+    blocked:['blocked','xo-swarm-api rejected the key; nothing is sent. Fix or remove XO_API_KEY.'],
+    pending:['pending','A key is set but not verified yet; nothing is sent until a sync accepts it.'],
+    off:['off','No XO_API_KEY set. Nothing is sent.']
+  };
+  const [state,detail]=states[ur.status]||states.off;
+  el.className='setup-usage-reporting is-'+state;
+  el.innerHTML='<span aria-hidden="true"></span><div>'
+    +'<b>Usage reporting: '+state+'</b>'
+    +'<p>'+detail+link+'</p>'
+    +'</div>';
   el.hidden=false;
 }
 

--- a/space_ui/js/views/wiki.js
+++ b/space_ui/js/views/wiki.js
@@ -446,7 +446,7 @@ const TAB_GUIDES={
       ['CLI unavailable','A manifest may support bootstrap, but required credentials must be present first. When a runtime or its CLI is missing, the card links to that runtime’s own install docs.'],
       ['Sessions missing','Confirm the native runtime directory is mounted and watcher coverage includes it.'],
       ['Secret value hidden','That is intentional; replace the value or remove the variable.'],
-      ['Usage reporting: blocked','xo-swarm-api rejected XO_API_KEY (HTTP 401/403), so nothing is sent. Fix the key in credentials (or remove it) and the next sync re-probes; details in the README section “What leaves your machine”.']
+      ['Usage reporting: blocked','The status strip at the top of Agent and watcher shows xo-swarm-api rejected XO_API_KEY (HTTP 401/403), so nothing is sent. Fix the key in credentials (or remove it) and the next sync re-probes; details in the README section “What leaves your machine”.']
     ],
     note:'XO root changes select a project collection and never move project files. An empty new .quirq root receives a safe state copy; a non-empty root is never merged.'
   }

--- a/tests/test_space_sessions.py
+++ b/tests/test_space_sessions.py
@@ -222,6 +222,56 @@ class CombinedSessionsTests(unittest.TestCase):
         }
         self.assertEqual(statuses, {"bad": "unavailable", "good": "available"})
 
+    def test_unavailable_provider_is_logged_once_until_it_changes(self) -> None:
+        # The watcher rebuilds this view every tick; a runtime that is simply
+        # not installed must not repeat the same warning on every rebuild.
+        good = SimpleNamespace(
+            SOURCE_ID="good",
+            SOURCE_LABEL="Good",
+            COST_STATUS="estimated",
+            collect_session_telemetry=self._good_payload,
+        )
+        flaky = SimpleNamespace(
+            SOURCE_ID="flaky",
+            SOURCE_LABEL="Flaky",
+            COST_STATUS="unavailable",
+            collect_session_telemetry=mock.Mock(
+                side_effect=[
+                    RuntimeError("state DB not found"),
+                    RuntimeError("state DB not found"),
+                    RuntimeError("permission denied"),
+                    self._good_payload(),
+                ]
+            ),
+        )
+
+        def load(_capability: str, *, agent: str):
+            return {"flaky": flaky, "good": good}[agent]
+
+        session_telemetry._unavailable_reasons.clear()
+        self.addCleanup(session_telemetry._unavailable_reasons.clear)
+        with mock.patch.object(
+            session_telemetry,
+            "list_capability_providers",
+            return_value=["flaky", "good"],
+        ), mock.patch.object(
+            session_telemetry,
+            "try_load_capability",
+            side_effect=load,
+        ), mock.patch("builtins.print") as fake_print:
+            for _ in range(4):
+                session_telemetry.build_session_telemetry()
+
+        lines = [str(call.args[0]) for call in fake_print.call_args_list]
+        self.assertEqual(
+            [line.split(" — ")[0] for line in lines],
+            [
+                "⚠️ session telemetry provider flaky unavailable (state DB not found)",
+                "⚠️ session telemetry provider flaky unavailable (permission denied)",
+                "✅ session telemetry provider flaky available again",
+            ],
+        )
+
 
 class SessionPromptTests(unittest.IsolatedAsyncioTestCase):
     def test_claude_prompts_are_lazy_clean_and_grouped_by_exchange(self) -> None:


### PR DESCRIPTION
## Summary

- **Usage-reporting status is now the first thing on the Agent and watcher card.** It was a 10.5px footnote at the bottom of the form with no styling of its own. It is now a status strip at the top with a coloured state dot (green on, amber pending, red blocked, muted off), a readable label, the reason, and the "What leaves your machine" link. Hidden on older servers that do not return the field.
- **install.sh prints one more pointer** under `See what it decided: grep usage_sync …`, naming the Setup tab location. README's "What leaves your machine" section says the same.
- **Telemetry "provider unavailable" warnings are logged once, not every tick.** The watcher rebuilds the sessions view every tick, so a Codex or Cursor that is simply not installed repeated the identical line for the life of the process. The reason is now logged once per provider, again only if the reason changes, plus a `✅ … available again` line on recovery. The message points at Setup → Native session sources, which already shows live per-source state.

## Why dedupe rather than remove

The first warning is useful: it says why a source is missing and which env var changes it. Every repeat after that is noise. Logs are for events; the Setup tab is for standing state.

## Test plan

- [x] New unit test: warning prints once, again on a changed reason, then a recovery line (`tests/test_space_sessions.py`)
- [x] `tests/install_sh_harness.sh`: 22 passed, 0 failed
- [x] `bash -n install.sh`, `node --check` on edited JS
- [x] Import gate under WSL: `AGENT_NAME=claude_code` and `AGENT_NAME=openclaw` both import `server`
- [x] `tests.test_space_wiki`, `tests.test_usage_reporting_status` pass
- [ ] Visual check of the Setup tab after starting the server (layout verified by reading CSS only)

Pre-existing, unrelated on Windows only: `test_docker_mount_discovery_marks_telemetry_homes_optional` fails on path separators on the untouched `development` checkout too.
