### PR TITLE
fix(space): stop wiki steps collapsing into a 38px column

### DIFF
--- a/space_ui/css/wiki.css
+++ b/space_ui/css/wiki.css
@@ -34,9 +34,13 @@
 .wiki-flow span{display:block;font-size:11.5px;line-height:1.55;color:var(--ink-3)}
 .wiki-flow>i{align-self:center;font-style:normal;color:var(--accent)}
 .wiki-steps{list-style:none;counter-reset:watcher-step;display:flex;flex-direction:column}
-.wiki-steps li{counter-increment:watcher-step;display:grid;grid-template-columns:38px 205px 1fr;gap:14px;padding:18px 0;border-top:1px solid var(--line-soft)}
-.wiki-steps li::before{content:counter(watcher-step,decimal-leading-zero);font:600 10px var(--mono);letter-spacing:.1em;color:var(--accent);padding-top:3px}
-.wiki-steps b{font-size:13px;color:var(--ink)}
+.wiki-steps li{counter-increment:watcher-step;display:grid;grid-template-columns:38px 205px minmax(0,1fr);gap:14px;padding:18px 0;border-top:1px solid var(--line-soft)}
+.wiki-steps li::before{content:counter(watcher-step,decimal-leading-zero);grid-column:1;grid-row:1;font:600 10px var(--mono);letter-spacing:.1em;color:var(--accent);padding-top:3px}
+.wiki-steps b{grid-column:2;grid-row:1;font-size:13px;color:var(--ink)}
+/* A <code> command or second <p> must stay in the body track. Auto-placement
+   drops the extra child into the 38px counter column and the install page
+   renders as a single vertical strip of letters on any viewport over 900px. */
+.wiki-steps li>:not(b){grid-column:3}
 .wiki-steps p{font-size:13px;line-height:1.65;color:var(--ink-2)}
 .wiki-article code{font:500 .9em var(--mono);color:#c8e79a;background:rgba(168,217,79,.07);border:1px solid rgba(168,217,79,.12);border-radius:4px;padding:1px 4px;overflow-wrap:anywhere}
 .wiki-table-wrap{overflow-x:auto;border:1px solid var(--line);border-radius:12px}
@@ -104,8 +108,8 @@
   .wiki-page-link{min-width:210px}
   .wiki-flow{grid-template-columns:1fr}
   .wiki-flow>i{rotate:90deg;justify-self:center}
-  .wiki-steps li{grid-template-columns:32px 1fr}
-  .wiki-steps p{grid-column:2}
+  .wiki-steps li{grid-template-columns:32px minmax(0,1fr)}
+  .wiki-steps b,.wiki-steps li>:not(b){grid-column:2;grid-row:auto}
   .wiki-layer-grid{grid-template-columns:1fr}
   .wiki-recipe{grid-template-columns:1fr}
   .wiki-recipe>i{rotate:90deg;justify-self:center}

--- a/space_ui/index.html
+++ b/space_ui/index.html
@@ -10,7 +10,7 @@
 <link rel="stylesheet" href="css/timeline.css?v=20260825-timeline1">
 <link rel="stylesheet" href="css/chrome.css?v=20260813-timeline2">
 <link rel="stylesheet" href="css/projects.css?v=20260824-treecam1">
-<link rel="stylesheet" href="css/wiki.css?v=20260827-firstrun1">
+<link rel="stylesheet" href="css/wiki.css?v=20260906-steps1">
 <link rel="stylesheet" href="css/quirq.css?v=20260816-navswap1">
 <link rel="stylesheet" href="css/secrets.css?v=20260825-installlink1">
 <link rel="stylesheet" href="css/preview.css?v=20260827-htmlfix1">

--- a/tests/test_space_wiki.py
+++ b/tests/test_space_wiki.py
@@ -602,6 +602,30 @@ class SpaceWikiTests(unittest.TestCase):
         css = (ROOT / "space_ui" / "css" / "wiki.css").read_text(encoding="utf-8")
         self.assertIn(".wiki-link{", css)
 
+    def test_wiki_steps_keep_extra_children_out_of_the_counter_column(self) -> None:
+        """Install-page steps put a <code> between the title and the body.
+
+        The wide layout is a 3-track grid (counter | title | body). Grid
+        auto-placement then drops the paragraph into the 38px counter
+        column, which on a QHD viewport reads as a single vertical strip
+        of letters. Pin the explicit columns so a command or a second
+        paragraph stays in the body track on every width.
+        """
+        css = (ROOT / "space_ui" / "css" / "wiki.css").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "grid-template-columns:38px 205px minmax(0,1fr)",
+            css,
+        )
+        self.assertIn(".wiki-steps li>:not(b){grid-column:3}", css)
+        # The 900px stack must move title AND body into column 2. Pinning
+        # only p leaves a sibling <code> in the counter track.
+        self.assertIn(
+            ".wiki-steps b,.wiki-steps li>:not(b){grid-column:2;grid-row:auto}",
+            css,
+        )
+
     def test_contributing_guide_matches_how_the_repo_actually_works(self) -> None:
         """CONTRIBUTING.md is the front door for outside contributors. The
         facts most likely to rot are pinned: the branch model, the four


### PR DESCRIPTION
## Summary
- Wiki *Install & run locally* steps put a `<code>` command between the title and the body. The 3-track grid then auto-placed that paragraph into the 38px counter column, so on any viewport over 900px (including QHD 2560×1440) the text rendered as a single vertical strip of letters.
- Pin the counter, title, and body tracks explicitly, and keep extra children in the body track on the stacked 900px layout too.
- Fixes https://github.com/quirq-ai/xo-space/issues/64

## Test plan
- [x] `venv/bin/python -m unittest tests.test_space_wiki`
- [x] Measured `.wiki-steps` at 2560×1440: command and paragraphs sit in the 549px body track, not the 38px counter
- [x] Measured at 800px: title, command, and paragraphs all stack in the 563px content track
- [ ] Open Wiki → *Install & run locally* on a wide display and confirm steps 02/03 read as normal paragraphs
- [ ] Confirm the same page still stacks cleanly below 900px


Made with [Cursor](https://cursor.com)