### PR TITLE
fix(github): make CLI device-flow polling idempotent, stop logging gh out on start

### DIFF
--- a/routers/cowork_agent/connectors/github_cli.py
+++ b/routers/cowork_agent/connectors/github_cli.py
@@ -54,7 +54,13 @@ async def cli_login_poll(body: CliSessionBody) -> JSONResponse:
 
     On completion, the token is validated against /user, persisted to
     token.json with `auth_method="cli"`, and the user profile is returned
-    in the same shape as the PAT flow.
+    in the same shape as the PAT flow. Polling is idempotent: a finished
+    session answers the same way on every poll until it expires.
+
+    Every outcome of a *known* session is a 200 — including ``failed``. The
+    failure is the poll's answer, not a transport error; a 5xx here makes the
+    frontend's HTTP client retry, and that retry is what used to surface as
+    "expired". 404 is reserved for a session this process doesn't know.
     """
     result = await github_cli_auth.connect(body.session_id)
 
@@ -78,7 +84,6 @@ async def cli_login_poll(body: CliSessionBody) -> JSONResponse:
 
     return JSONResponse(
         {"status": "failed", "error": result.get("error", "CLI login failed.")},
-        status_code=502,
     )
 
 

--- a/services/cowork_agent/connectors/github/cli_auth.py
+++ b/services/cowork_agent/connectors/github/cli_auth.py
@@ -9,6 +9,11 @@ github.com. Once `gh` exits successfully, the resulting token is read with
 This sits alongside the PAT flow (github_pat.py) — the two methods share the
 same storage and validation (common.py); only the *acquisition* differs.
 
+Polling is idempotent: a session keeps its final answer (connected / failed)
+until it expires or is cancelled, so a client that retries a poll — because
+a response was lost, a proxy timed out, or a background tab was throttled —
+sees the same answer instead of "unknown session".
+
 Caveats (intentional, per Option B):
   - In-memory session state. A FastAPI worker restart drops in-progress logins.
   - Output parsing depends on `gh` CLI version 2.x stdout format.
@@ -67,11 +72,19 @@ class _Session:
     process: asyncio.subprocess.Process
     user_code: str
     started_at: float = field(default_factory=time.time)
-    status: str = "pending"  # pending | completed | failed | cancelled
+    # pending   — `gh` is still waiting for the user to authorize
+    # completed — `gh` exited 0 and handed us a token (not yet validated/stored)
+    # connected — token validated and saved; `payload` holds the response body
+    # failed    — `gh` exited non-zero, or the token failed validation
+    status: str = "pending"
     error: str | None = None
     token: str | None = None
+    payload: dict[str, Any] | None = None
     # Keeps the background reader alive for the lifetime of the subprocess.
     drain_task: asyncio.Task | None = None
+    # Serialises completed → connected so two overlapping polls of the same
+    # session validate and store the token once, not twice.
+    finalize_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 _active: dict[str, _Session] = {}
@@ -230,24 +243,17 @@ async def start_login() -> dict[str, Any]:
         # Prevent gh from trying to launch a browser on the server.
         env["BROWSER"] = "true"
 
-        # Clear any prior `gh` session for github.com — `gh auth login` refuses
-        # to start a fresh device flow when an account is already logged in.
-        # Errors here are non-fatal (e.g. "not logged in" exits non-zero).
-        try:
-            logout = await asyncio.create_subprocess_exec(
-                GH_BIN, "auth", "logout", "--hostname", GITHUB_HOSTNAME,
-                env=env,
-                stdin=asyncio.subprocess.DEVNULL,
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            await asyncio.wait_for(logout.wait(), timeout=5)
-        except (asyncio.TimeoutError, FileNotFoundError, OSError):
-            pass
+        # Do NOT `gh auth logout` first. Non-interactive `gh auth login` happily
+        # re-authenticates an already-logged-in account (it only prompts when
+        # interactive), and the existing session is what git's credential
+        # helper (`gh auth git-credential`, wired by `gh auth setup-git`) runs
+        # on. Logging out here meant an abandoned or failed retry left every
+        # private-repo clone broken while token.json still said "connected".
 
         # `--insecure-storage` writes the token to a plain file under
-        # ~/.config/gh — fine here because we immediately export it into
-        # token.json and never depend on gh's local store after that.
+        # ~/.config/gh. The workspace has no keyring, and git's credential
+        # helper reads this same store, so the file is the source of truth for
+        # git while token.json is the source of truth for the API.
         proc = await asyncio.create_subprocess_exec(
             GH_BIN, "auth", "login",
             "--web",
@@ -286,42 +292,55 @@ async def start_login() -> dict[str, Any]:
     }
 
 
-async def poll_login(session_id: str) -> dict[str, Any]:
-    """
-    Check the status of an in-progress login. Returns one of:
-      - {"status": "pending",   "user_code": ..., "verification_uri": ...}
-      - {"status": "completed", "token": ...}              (consume once)
-      - {"status": "failed",    "error": ...}
-      - {"status": "not_found"}                            (unknown session_id)
-    """
+async def _lookup(session_id: str) -> _Session | None:
+    """Fetch a live session, evicting expired ones first."""
     async with _lock:
         _evict_stale_locked()
-        session = _active.get(session_id)
-        if not session:
-            return {"status": "not_found"}
+        return _active.get(session_id)
 
-        if session.status == "pending":
-            return {
-                "status": "pending",
-                "user_code": session.user_code,
-                "verification_uri": VERIFICATION_URI,
-            }
 
-        # Terminal state — pop so subsequent polls return not_found.
-        _active.pop(session_id, None)
+async def _finalize_connection(session: _Session) -> None:
+    """
+    Turn a ``completed`` session (gh handed us a token) into ``connected``
+    (token validated, stored, git wired up) or ``failed``.
 
-        if session.status == "completed" and session.token:
-            return {"status": "completed", "token": session.token}
+    Runs at most once per session: the caller holds ``session.finalize_lock``
+    and we re-check the status under it, so a second poll that arrives while
+    the first is still validating simply waits and then reads the result.
+    """
+    if session.status != "completed":
+        return
 
-        return {
-            "status": session.status,
-            "error": session.error or "Login failed.",
-        }
+    token = session.token or ""
+    validation = await validate_token(token)
+    if not validation.get("valid"):
+        session.status = "failed"
+        session.error = validation.get(
+            "error",
+            "GitHub CLI login completed but the token failed validation.",
+        )
+        session.token = None
+        return
+
+    save_github_token(token, auth_method=AUTH_METHOD)
+    # This flow leaves a live `gh` session behind, so git can borrow it for
+    # HTTPS auth as well as take its identity from it.
+    await configure_git_identity(validation, setup_credential_helper=True)
+    log.info("GitHub connected as @%s (via gh CLI)", validation.get("username"))
+
+    session.payload = connection_payload(validation, AUTH_METHOD)
+    session.status = "connected"
+    # Persisted now — no reason to keep the raw token in memory.
+    session.token = None
 
 
 async def connect(session_id: str) -> dict[str, Any]:
     """
     Poll a login session and, once `gh` hands us a token, validate + store it.
+
+    Idempotent: polling a finished session returns the same answer every time
+    until the session expires (SESSION_TTL_SECONDS) or is cancelled. A client
+    that retries a poll never turns a success into "not_found".
 
     Mirrors ``github_pat.connect``, so both flows converge on the same stored
     entry and the same response body. Returns:
@@ -330,30 +349,29 @@ async def connect(session_id: str) -> dict[str, Any]:
         {"ok": False, "status": "not_found"}             unknown/expired session
         {"ok": False, "status": "failed", "error": ...}  login or validation failed
     """
-    result = await poll_login(session_id)
-    status = result.get("status")
+    session = await _lookup(session_id)
+    if not session:
+        return {"ok": False, "status": "not_found"}
 
-    if status != "completed":
-        return {"ok": False, **result}
+    async with session.finalize_lock:
+        await _finalize_connection(session)
 
-    token = result["token"]
-    validation = await validate_token(token)
-    if not validation.get("valid"):
+    if session.status == "pending":
         return {
             "ok": False,
-            "status": "failed",
-            "error": validation.get(
-                "error",
-                "GitHub CLI login completed but the token failed validation.",
-            ),
+            "status": "pending",
+            "user_code": session.user_code,
+            "verification_uri": VERIFICATION_URI,
         }
 
-    save_github_token(token, auth_method=AUTH_METHOD)
-    # This flow leaves a live `gh` session behind, so git can borrow it for
-    # HTTPS auth as well as take its identity from it.
-    await configure_git_identity(validation, setup_credential_helper=True)
-    log.info("GitHub connected as @%s (via gh CLI)", validation.get("username"))
-    return {"ok": True, "payload": connection_payload(validation, AUTH_METHOD)}
+    if session.status == "connected" and session.payload is not None:
+        return {"ok": True, "payload": dict(session.payload)}
+
+    return {
+        "ok": False,
+        "status": "failed",
+        "error": session.error or "Login failed.",
+    }
 
 
 async def cancel_login(session_id: str) -> dict[str, Any]:

--- a/tests/test_github_cli_auth.py
+++ b/tests/test_github_cli_auth.py
@@ -1,0 +1,201 @@
+"""
+GitHub connector — `gh auth login` device flow.
+
+Pins the behaviours a browser client relies on when it polls the login:
+
+  - Polling is idempotent. A completed or failed login answers the same way
+    on every poll until it expires or is cancelled. Consuming the result on
+    first read meant any retried poll (lost response, proxy hiccup, tab
+    throttling) got 404 "expired" while the token had in fact been saved.
+  - A failed login is a *result* of the poll, not a transport failure, so
+    the route answers 200 with ``status: failed`` — a 502 makes the client
+    retry, and the retry then found no session.
+  - Starting a login never logs the workspace out of `gh`. That logout
+    silently broke `gh auth git-credential` for every repo while the stored
+    token still reported "connected".
+
+Hermetic: no real `gh`, git, or network — subprocess spawning and the shared
+GitHub helpers are patched at the module seam.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest import mock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routers.cowork_agent.connectors import github_cli as github_cli_router
+from services.cowork_agent.connectors.github import cli_auth
+
+VALID = {
+    "valid": True,
+    "status": "connected",
+    "username": "octocat",
+    "name": "The Octocat",
+    "avatar_url": "https://example.invalid/a.png",
+    "scopes": "repo",
+    "user_id": 1,
+    "email": "",
+}
+
+
+class _FakeProc:
+    """Stand-in for an asyncio subprocess whose stdout we script."""
+
+    def __init__(self, lines: list[bytes]) -> None:
+        self.stdout = asyncio.StreamReader()
+        for line in lines:
+            self.stdout.feed_data(line)
+        self.returncode: int | None = None
+        self.killed = False
+
+    def finish(self, returncode: int) -> None:
+        self.returncode = returncode
+        self.stdout.feed_eof()
+
+    async def wait(self) -> int:
+        while self.returncode is None:
+            await asyncio.sleep(0)
+        return self.returncode
+
+    def kill(self) -> None:
+        self.killed = True
+        self.finish(-9)
+
+
+class _CliAuthTestCase(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self._active = mock.patch.object(cli_auth, "_active", {})
+        self._active.start()
+        # A fresh lock per test: asyncio.Lock binds to the first loop it waits on.
+        self._lock = mock.patch.object(cli_auth, "_lock", asyncio.Lock())
+        self._lock.start()
+
+    async def asyncTearDown(self) -> None:
+        self._lock.stop()
+        self._active.stop()
+
+    def _seed(self, status: str, *, token: str | None = None, error: str | None = None) -> str:
+        proc = _FakeProc([])
+        proc.finish(0 if status == "completed" else 1)
+        session = cli_auth._Session(
+            session_id="sid-1", process=proc, user_code="ABCD-1234"
+        )
+        session.status = status
+        session.token = token
+        session.error = error
+        cli_auth._active[session.session_id] = session
+        return session.session_id
+
+    def _patch_finalizers(self):
+        validate = mock.patch.object(
+            cli_auth, "validate_token", mock.AsyncMock(return_value=dict(VALID))
+        )
+        save = mock.patch.object(cli_auth, "save_github_token")
+        identity = mock.patch.object(
+            cli_auth, "configure_git_identity", mock.AsyncMock()
+        )
+        return validate, save, identity
+
+
+class ConnectIdempotencyTests(_CliAuthTestCase):
+    async def test_connect_answers_connected_on_every_poll_after_success(self) -> None:
+        sid = self._seed("completed", token="gho_abc")
+        validate, save, identity = self._patch_finalizers()
+        with validate, save as save_mock, identity:
+            first = await cli_auth.connect(sid)
+            second = await cli_auth.connect(sid)
+
+        self.assertTrue(first["ok"])
+        self.assertEqual(first["payload"]["status"], "connected")
+        self.assertEqual(first["payload"]["username"], "octocat")
+        self.assertEqual(second, first, "a retried poll must see the same answer")
+        save_mock.assert_called_once_with("gho_abc", auth_method="cli")
+
+    async def test_connect_reports_failure_on_every_poll(self) -> None:
+        sid = self._seed("failed", error="`gh auth login` exited with status 1.")
+        first = await cli_auth.connect(sid)
+        second = await cli_auth.connect(sid)
+
+        self.assertEqual(first["status"], "failed")
+        self.assertIn("exited with status 1", first["error"])
+        self.assertEqual(second, first, "a retried poll must not turn into not_found")
+
+    async def test_concurrent_polls_finalize_once(self) -> None:
+        sid = self._seed("completed", token="gho_abc")
+        validate, save, identity = self._patch_finalizers()
+        with validate as validate_mock, save as save_mock, identity:
+            results = await asyncio.gather(cli_auth.connect(sid), cli_auth.connect(sid))
+
+        self.assertTrue(all(r["ok"] for r in results))
+        validate_mock.assert_awaited_once()
+        save_mock.assert_called_once()
+
+    async def test_unknown_session_is_not_found(self) -> None:
+        result = await cli_auth.connect("nope")
+        self.assertEqual(result, {"ok": False, "status": "not_found"})
+
+    async def test_pending_session_stays_pending(self) -> None:
+        sid = self._seed("pending")
+        result = await cli_auth.connect(sid)
+        self.assertEqual(result["status"], "pending")
+        self.assertEqual(result["user_code"], "ABCD-1234")
+
+
+class StartLoginTests(_CliAuthTestCase):
+    async def test_start_login_does_not_log_out_the_existing_gh_session(self) -> None:
+        spawned: list[tuple[str, ...]] = []
+        proc = _FakeProc([
+            b"! First copy your one-time code: 7B79-D4F8\n",
+            b"Open this URL to continue in your web browser: https://github.com/login/device\n",
+        ])
+
+        async def fake_exec(*argv, **_kwargs):
+            spawned.append(tuple(argv))
+            return proc
+
+        with mock.patch.object(cli_auth.shutil, "which", return_value="/usr/bin/gh"), \
+             mock.patch.object(cli_auth.asyncio, "create_subprocess_exec", fake_exec):
+            info = await cli_auth.start_login()
+            proc.finish(1)
+            await cli_auth._active[info["session_id"]].drain_task
+
+        self.assertEqual(info["user_code"], "7B79-D4F8")
+        self.assertEqual([a[:3] for a in spawned], [("gh", "auth", "login")])
+
+
+class PollRouteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        app = FastAPI()
+        app.include_router(github_cli_router.router)
+        self.client = TestClient(app)
+
+    def _poll(self, result: dict):
+        with mock.patch.object(
+            github_cli_router.github_cli_auth, "connect", mock.AsyncMock(return_value=result)
+        ):
+            return self.client.post(
+                "/api/connectors/github/cli/poll", json={"session_id": "sid-1"}
+            )
+
+    def test_failed_login_is_a_200_result_not_a_gateway_error(self) -> None:
+        resp = self._poll({"ok": False, "status": "failed", "error": "boom"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "failed", "error": "boom"})
+
+    def test_unknown_session_is_404(self) -> None:
+        resp = self._poll({"ok": False, "status": "not_found"})
+        self.assertEqual(resp.status_code, 404)
+
+    def test_connected_returns_the_payload(self) -> None:
+        payload = {"status": "connected", "auth_method": "cli", "username": "octocat"}
+        resp = self._poll({"ok": True, "payload": payload})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #75

## What

The GitHub CLI device-flow connector showed "Unknown or expired CLI login session" after a successful authorization, then reported connected anyway, and could leave the workspace's `gh` session logged out so private-repo clones failed. See the issue for the full analysis.

## Changes

**`services/cowork_agent/connectors/github/cli_auth.py`**
- Polling is idempotent. A finished session keeps its answer (`connected` with the cached payload, or `failed` with the error) until the 15-minute TTL or a cancel, instead of being popped on first read.
- Finalisation (validate token, save to `token.json`, `gh auth setup-git`) runs at most once per session, guarded by a per-session `asyncio.Lock`, so two overlapping polls do not double-save.
- The pre-login `gh auth logout` is removed. Non-interactive `gh auth login --web` re-authenticates an already-logged-in account without prompting (verified against gh v2.92.0, the version pinned in the workspace image). The logout was wiping the session that `gh auth git-credential` reads.

**`routers/cowork_agent/connectors/github_cli.py`**
- `POST /api/connectors/github/cli/poll` answers a failed login with `200 {"status": "failed", "error": ...}` instead of `502`. The frontend client retries 5xx, and that retry is what produced the 404. `404` remains for unknown/expired sessions.

**`tests/test_github_cli_auth.py`** (new)
- Idempotent connect after success, failure reported on every poll, concurrent polls finalise once, pending/not-found passthrough, no `gh auth logout` on start, and the route's 200/404 status codes.

## Contract note

The only response-shape change is `/cli/poll` on a failed login: `502` → `200` with the same JSON body. The frontend's `GitHubCliPollResponse` type already models `status: "failed"` on a 2xx; that branch was unreachable before.

## Verification

- `tests.test_github_cli_auth`: 9 tests, 5 failed before the fix, all pass after.
- Full `unittest discover`: no new failures (the 6 remaining are Windows-only, pre-existing: `fcntl`, `os.fchmod`, POSIX paths).
- `AGENT_NAME=openclaw python -c "import server"` passes; no routes added or removed.

## Not covered

The PAT method never configures git credentials, so a PAT-connected workspace also cannot clone private repos over HTTPS. Separate issue.
