### PR TITLE
fix(env): stop blank exports from shadowing .env values

### DIFF
--- a/server.py
+++ b/server.py
@@ -27,9 +27,37 @@ from config.models.codex import CodexCodeClient
 from utils.local_port import LocalPortsUnavailableError, resolve_server_port
 from utils.commands import run, run_sync, spawn_detached
 
+
+def _prune_blank_env_shadows(dotenv_path: Path) -> None:
+    """Drop variables exported blank that the checkout's ``.env`` can fill.
+
+    A var exported *empty* — a launcher that always exports ``XO_SPACE_ID``,
+    say, whether or not it has one — is still present in ``os.environ``, and
+    python-dotenv skips a key on membership, not truthiness. Plain
+    ``load_dotenv()`` would therefore leave the blank in place and the ``.env``
+    value would never land: exporting empty ends up worse than not exporting
+    at all. The symptom is a configured value reading as unset (sharing parks
+    on an empty ``XO_SPACE_ID`` despite ``.env`` naming the workspace).
+
+    Only keys ``.env`` has a non-empty value for are dropped, so a variable
+    that legitimately uses ``""`` as an off switch keeps its blank, and a
+    non-empty export still outranks the file. Runs before ``_shell_env_keys``
+    is snapshotted so roots.env precedence stays consistent with it.
+    """
+    try:
+        values = dotenv_values(dotenv_path)
+    except OSError:
+        return
+    for key, value in (values or {}).items():
+        if (value or "").strip() and not os.environ.get(key, "").strip():
+            os.environ.pop(key, None)
+
+
 # Load environment variables. Keys already exported by the shell (or by
 # docker -e / compose) are recorded first: they outrank every file below,
-# exactly as install.sh orders them.
+# exactly as install.sh orders them — but only when they actually carry a
+# value, which is what the prune above guarantees.
+_prune_blank_env_shadows(Path(__file__).resolve().parent / ".env")
 _shell_env_keys = frozenset(os.environ)
 load_dotenv()
 

--- a/tests/test_env_blank_shadow.py
+++ b/tests/test_env_blank_shadow.py
@@ -1,0 +1,84 @@
+"""Blank exports must not shadow real ``.env`` values.
+
+A variable exported as an empty string is still *present* in ``os.environ``,
+and python-dotenv skips a key on membership rather than truthiness — so
+``load_dotenv()`` alone leaves the blank in place and the file value never
+lands. ``server._prune_blank_env_shadows`` closes that gap without disturbing
+the documented precedence (shell > .env).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Imported at module scope on purpose: importing server runs its dotenv
+# prologue, which is the code under test.
+import server
+
+
+class PruneBlankEnvShadowsTests(unittest.TestCase):
+    def test_blank_export_is_dropped_when_file_has_a_value(self):
+        """The reported bug: sharing parked on a blank XO_SPACE_ID."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / ".env"
+            path.write_text("XO_SPACE_ID=ws-from-file\n")
+            with patch.dict(os.environ, {"XO_SPACE_ID": ""}):
+                server._prune_blank_env_shadows(path)
+                self.assertNotIn("XO_SPACE_ID", os.environ)
+
+    def test_whitespace_only_export_counts_as_blank(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / ".env"
+            path.write_text("XO_SPACE_ID=ws-from-file\n")
+            with patch.dict(os.environ, {"XO_SPACE_ID": "   "}):
+                server._prune_blank_env_shadows(path)
+                self.assertNotIn("XO_SPACE_ID", os.environ)
+
+    def test_non_empty_export_still_outranks_the_file(self):
+        """Precedence is unchanged: an explicit export wins, as install.sh documents."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / ".env"
+            path.write_text("XO_SPACE_ID=ws-from-file\n")
+            with patch.dict(os.environ, {"XO_SPACE_ID": "ws-from-shell"}):
+                server._prune_blank_env_shadows(path)
+                self.assertEqual(os.environ.get("XO_SPACE_ID"), "ws-from-shell")
+
+    def test_blank_stays_when_the_file_has_nothing_to_offer(self):
+        """A var using "" as an off switch keeps its blank."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / ".env"
+            path.write_text("ANTHROPIC_API_KEY=\nOTHER=value\n")
+            with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}):
+                server._prune_blank_env_shadows(path)
+                self.assertIn("ANTHROPIC_API_KEY", os.environ)
+                self.assertEqual(os.environ["ANTHROPIC_API_KEY"], "")
+
+    def test_unset_key_is_left_unset(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / ".env"
+            path.write_text("XO_SPACE_ID=ws-from-file\n")
+            with patch.dict(os.environ):
+                os.environ.pop("XO_SPACE_ID", None)
+                server._prune_blank_env_shadows(path)
+                self.assertNotIn("XO_SPACE_ID", os.environ)
+
+    def test_missing_env_file_is_not_an_error(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.dict(os.environ, {"XO_SPACE_ID": ""}):
+                server._prune_blank_env_shadows(Path(temp_dir) / "absent.env")
+                self.assertEqual(os.environ.get("XO_SPACE_ID"), "")
+
+    def test_unreadable_env_file_is_not_an_error(self):
+        """dotenv_values raising OSError must not stop the server booting."""
+        with patch.object(server, "dotenv_values", side_effect=OSError("boom")):
+            with patch.dict(os.environ, {"XO_SPACE_ID": ""}):
+                server._prune_blank_env_shadows(Path("/nonexistent/.env"))
+                self.assertEqual(os.environ.get("XO_SPACE_ID"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #101.

## The bug

A variable exported as an empty string is still *present* in `os.environ`, and python-dotenv skips a key on **membership, not truthiness**. So the plain `load_dotenv()` at `server.py` left the blank in place and the `.env` value never landed — exporting empty ends up worse than not exporting at all.

Observed as Space UI reporting no workspace id in environments where the Coder template exported `XO_SPACE_ID` without a value, even though `.env` named the workspace:

```
space_ui/js/views/sharing_data.js:103
  no_workspace_id: "no workspace id — set XO_SPACE_ID in .env and restart"
```

`services/cowork_agent/project_sharing/config.py:19` reads `os.getenv("XO_SPACE_ID", "").strip() or None`, so `""` becomes `None` and the relay parks.

```
env -u XO_SPACE_ID  ...  -> resolves from .env   (True)
XO_SPACE_ID=        ...  -> None                 (False)
```

Not specific to that key: a current cloud workspace also inherits blank `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` from the pod, and both appear in `.env`. They are empty in `.env` today so nothing is broken — but any real value placed there would be silently discarded. `install.sh` already warns humans about blanks on the `.env` side; nothing defended against one arriving from the environment side, which is where it actually comes from.

## The fix

`_prune_blank_env_shadows()` runs before the `_shell_env_keys` snapshot and drops keys that are present-but-blank in the environment **and** have a non-empty value in `.env`.

Deliberately narrow:
- a variable that legitimately uses `""` as an off switch keeps its blank;
- a non-empty export still outranks the file, so the documented precedence (`install.sh:421-430`, `DEVELOPING.md:349`) is unchanged;
- an unreadable `.env` cannot stop the server booting.

Shaped as a named helper rather than inline code to match the existing `_load_storage_roots()` idiom in the same file, and so the logic is directly testable.

### Rejected alternatives

| Alternative | Why not |
| --- | --- |
| `load_dotenv(override=True)` | Inverts the documented precedence; breaks `PORT=8080 ./install.sh` and `docker -e` injection. |
| Read `.env` inside `project_sharing/config.py` | Fixes one key, and gives that module a second env source — its docstring is "the relay's only reader of environment and auth". |
| Strip every empty var | Shorter, but silently deletes vars where `""` is meaningful. |

## Tests

`tests/test_env_blank_shadow.py` — 7 cases: blank export dropped, whitespace-only treated as blank, non-empty export still wins, `""`-as-off-switch preserved, unset stays unset, missing file and `OSError` both non-fatal.

## Verification

| Check | Result |
| --- | --- |
| `venv/bin/python scripts/check_route_parity.py` | OK — 200 core + each agent's own routes, nothing leaked |
| `venv/bin/python -m unittest discover -s tests` | OK — 560 tests (was 553) |
| Blank `XO_SPACE_ID=` export + real `.env` value | resolves (was `None`) |
| Non-empty export | still wins over `.env` |

`unittest discover` is the gate named in `pytest.ini`; pytest is not installed in the venv and I did not add it.

## Follow-up, not in this PR

`xo-coder-templates` should stop exporting `XO_SPACE_ID` when it has no value — `DEVELOPING.md:353` still marks the cloud value as "set by the template (pending)". This PR makes the server resilient to that export regardless, and to the same mistake in any other deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)