### PR TITLE
fix(tests): throttle test fails on freshly-booted machines (first catch of #69's CI)

### DIFF
--- a/tests/test_workspace_document.py
+++ b/tests/test_workspace_document.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -173,7 +174,11 @@ class WorkspaceViewFileTests(unittest.TestCase):
                 },
                 clear=False,
             ):
-                views._last_build = 0.0
+                # Relative to now, not 0.0: time.monotonic() is seconds since
+                # boot on Linux/macOS, so on a freshly booted machine (a CI
+                # runner) "now - 0.0" can be INSIDE the pinned window and the
+                # first apply() gets throttled before it ever builds.
+                views._last_build = time.monotonic() - 7200.0
                 self.assertTrue(views.apply())     # first tick builds
                 self.assertFalse(views.apply())    # second is not due
 


### PR DESCRIPTION
The very first run of the CI workflow in #69 caught a real environment bug — in my own #47, fittingly. `views._last_build = 0.0` assumes `time.monotonic()` is large, but monotonic is seconds since boot on Linux/macOS: on a freshly booted CI runner, `now - 0.0` ≈ uptime ≈ minutes, which is *inside* the pinned 3600 s window — so the **first** `apply()` is throttled before it ever builds and `assertTrue(views.apply())` fails. Any machine with more than an hour of uptime (every dev box #47 was verified on, macOS and Windows both) never sees it.

Fix: anchor the watermark relative to now (`time.monotonic() - 7200`) so the first call is always due and the second always throttled, whatever the uptime.

## How verified

macOS (Darwin 25.6) / Python 3.14.6: `tests.test_workspace_document` OK on current `development`. The failing environment (fresh-boot runner) can't be reproduced locally — it's exercised by #69's re-run once this lands, which is rather the point of having the CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)